### PR TITLE
Note %wa TypeError as bluesky upstream bug with numpy 2.x

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -57,6 +57,9 @@ describe future plans.
     Fixes
     -----
 
+    * ``%wa`` bluesky magic raises ``TypeError`` for diffractometers under
+      numpy 2.x; this is a bluesky upstream bug triggered by numpy 2.0
+      tightening ``ndarray.__format__``. (:issue:`201`)
     * ``cahkl()`` now returns solutions at motor positions that previously
       yielded no results. (:issue:`193`)
     * ``calc_UB()`` now raises a clear ``ValueError`` with diagnostic hints


### PR DESCRIPTION
- refs #201

## Summary

- Documents in release notes that the `%wa` `TypeError` is a **bluesky upstream bug** triggered by numpy 2.0 tightening `ndarray.__format__` to reject string alignment specs.
- `bluesky._print_positioners` calls `np.round(p.position)` on any positioner, which converts a `PseudoPositioner` namedtuple to a 1-D ndarray. Under numpy 1.x, `"{: <11}".format(ndarray)` silently worked; under numpy 2.x it raises `TypeError`.
- The fix belongs in bluesky's `_print_positioners` — wrapping the `LINE_FMT.format()` call to handle non-scalar values gracefully, consistent with how `limits` and `user_offset` failures are already handled there.
- Issue kept open in hklpy2 until the upstream bluesky fix is released.

Agent: OpenCode (claudesonnet46)