### PR TITLE
docs #205 trim concepts/solvers.rst; move guide content to guides/solvers.rst

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -54,6 +54,9 @@ describe future plans.
       (:issue:`202`)
     * Trim ``concepts/diffract.rst`` to a brief concept overview; move
       guide and example content to ``guides/diffract.rst``. (:issue:`204`)
+    * Trim ``concepts/solvers.rst`` to a brief concept overview; move
+      how-to content to new ``guides/solvers.rst``; add ``entry point``
+      Glossary entry. (:issue:`205`)
     * Use US spelling throughout docs and source. (:issue:`202`)
 
     Fixes

--- a/docs/source/concepts/solvers.rst
+++ b/docs/source/concepts/solvers.rst
@@ -4,24 +4,17 @@
 Solvers
 ==================
 
-.. TODO: How much is guide or example?  This should be a concepts doc. Brief.
-
-.. TODO:
-    - Describe the responsibilities of a |solver|.
-    - Define the terms expected (add to glossary.).
-    - Note that solvers provide different features: additions and not availables
-
 .. index::
     !design; solver
     !solver
 
-A |solver| is a Python class that connects |hklpy2| with a (backend) library
-that provides diffractometer capabilities, including:
+A |solver| is a Python class that connects |hklpy2| with a backend library
+providing diffractometer capabilities, including:
 
 * definition(s) of physical diffractometer **geometries**
 
   * axes (angles and reciprocal space)
-  * operating **modes** for the axes (angles and reciprocal space)
+  * operating **modes** for the axes
 
 * calculations that convert:
 
@@ -32,91 +25,32 @@ that provides diffractometer capabilities, including:
 
   * calculate the UB matrix
   * refine the crystal lattice
-  * sample definition
-
-    * name
-    * crystal lattice parameters: :math:`a, b, c, \alpha, \beta, \gamma`
-    * list of orientation reflections
+  * sample definition (name, lattice parameters, orientation reflections)
 
 .. index:: entry point
 
-A |solver| class is written as a plugin for |hklpy2| and is connected by an `entry point
+A |solver| class is written as a plugin for |hklpy2| and is connected by an
+`entry point
 <https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins>`_
-using the ``"hklpy2.solver"`` group.  Here's an example from |hklpy2|'s
-``pyproject.toml`` file for two such |solver| classes::
+using the ``"hklpy2.solver"`` group.
 
-    [project.entry-points."hklpy2.solver"]
-    hkl_soleil = "hklpy2.backends.hkl_soleil:HklSolver"
-    th_tth = "hklpy2.backends.th_tth_q:ThTthSolver"
+Solvers provided with |hklpy2|:
 
+.. list-table::
+   :header-rows: 1
 
-.. _api.solvers.set:
+   * - Name
+     - Description
+   * - ``hkl_soleil``
+     - |libhkl| backend (Linux 64-bit only). Supports many geometry types.
+   * - ``no_op``
+     - No-op solver for testing. Provides no useful geometries.
+   * - ``th_tth``
+     - Pure-Python minimal solver: :math:`\theta, 2\theta` geometry with
+       :math:`Q` pseudo axis. Runs on any OS.
 
-How to select a Solver
-----------------------
+.. seealso::
 
-To list all available |solver| classes (by their entry point name),
-call :func:`~hklpy2.backends.base.solvers()`.
-This example shows the |solver| classes supplied with |hklpy2|::
+   :ref:`guide.solvers` for how to list, select, and instantiate solvers.
 
-    >>> from hklpy2 import solvers
-    >>> solvers()
-    {'hkl_soleil': 'hklpy2.backends.hkl_soleil:HklSolver',
-     'th_tth': 'hklpy2.backends.th_tth_q:ThTthSolver'}
-
-This is a dictionary, keyed by the solver names.  To create an instance
-of a specific |solver| class, use :func:`~hklpy2.misc.solver_factory`.
-In the next example (Linux-only), the first argument, `hkl_soleil`, picks the
-:class:`~hklpy2.backends.hkl_soleil.HklSolver`, the `geometry` keyword
-picks the Eulerian 4-circle geometry with the *hkl* engine:
-
-.. code-block: Python
-    :linenos:
-
-    >>> from hklpy2 import solver_factory
-    >>> solver = solver_factory("hkl_soleil", "E4CV")
-    >>> print(solver)
-    HklSolver(name='hkl_soleil', version='v5.0.0.3434', geometry='E4CV', engine='hkl')
-
-To select a |solver| class without creating an instance, call
-:func:`~hklpy2.misc.get_solver`. This example
-selects the |libhkl| |solver| (using its entry point name:
-``"hkl_soleil"``):
-
-.. code-block: Python
-    :linenos:
-
-    >>> from hklpy2 import get_solver
-    >>> Solver = get_solver("hkl_soleil")
-    >>> print(f"{Solver=}")
-    Solver=<class 'hklpy2.backends.hkl_soleil.HklSolver'>
-
-Solver: hkl_soleil
-~~~~~~~~~~~~~~~~~~~~~~
-
-*Hkl* (`documentation <https://people.debian.org/~picca/hkl/hkl.html>`_), from
-Synchrotron Soleil, is used as a backend library to convert between real-space
-motor coordinates and reciprocal-space crystallographic coordinates.  Here, we
-refer to this library as **hkl_soleil** to clarify and distinguish from other
-use of of the term *hkl*.  Multiple source code repositories exist. |hklpy2|
-uses the `active development repository <https://repo.or.cz/hkl.git>`_.
-
-.. caution:: At this time, it is only compiled for 64-bit Linux.  Not Windows, not Mac OS.
-
-Solver: no_op
-~~~~~~~~~~~~~~~~~~~~~~
-
-This solver was built for testing the |hklpy2| code.  It provides no useful
-geometries for diffractometer users.
-
-Solver: th_tth
-~~~~~~~~~~~~~~~~~~~~~~
-
-This solver was built as a demonstration of a minimal all Python solver.  It
-provides basic support for :math:`\theta, 2\theta` geometry with a :math:`Q`
-pseudo axis. It can be used on any OS where Python runs.
-
-How to write a Solver
-----------------------
-
-.. seealso:: :ref:`howto.solvers.write`
+   :ref:`howto.solvers.write` for how to write a new solver plugin.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -104,6 +104,15 @@ Glossary
   specific directions.
 
 ..  index::
+    !definition; entry point
+    !entry point
+
+:entry point: A Python packaging mechanism that allows a package to advertise
+  a named object (such as a class or function) so other packages can discover
+  and load it without a hard-coded import.  |hklpy2| uses the
+  ``"hklpy2.solver"`` entry point group to locate installed |solver| plugins.
+
+..  index::
     !definition; engine
     !engine
 

--- a/docs/source/guides/solvers.rst
+++ b/docs/source/guides/solvers.rst
@@ -1,0 +1,88 @@
+.. _guide.solvers:
+
+=============
+Solvers Guide
+=============
+
+.. seealso:: :ref:`concepts.solvers` for a concept overview.
+
+How to list available Solvers
+=============================
+
+To list all available |solver| classes (by their entry point name),
+call :func:`~hklpy2.backends.base.solvers()`.
+This example shows the |solver| classes supplied with |hklpy2|::
+
+    >>> from hklpy2 import solvers
+    >>> solvers()
+    {'hkl_soleil': 'hklpy2.backends.hkl_soleil:HklSolver',
+     'th_tth': 'hklpy2.backends.th_tth_q:ThTthSolver'}
+
+How to select a Solver
+=======================
+
+To create an instance of a specific |solver| class, use
+:func:`~hklpy2.misc.solver_factory`.  The first argument is the entry point
+name; the ``geometry`` keyword picks the geometry.  In the next example
+(Linux-only), ``hkl_soleil`` picks the
+:class:`~hklpy2.backends.hkl_soleil.HklSolver` and ``"E4CV"`` selects the
+Eulerian 4-circle geometry with the *hkl* engine:
+
+.. code-block:: pycon
+
+    >>> from hklpy2 import solver_factory
+    >>> solver = solver_factory("hkl_soleil", "E4CV")
+    >>> print(solver)
+    HklSolver(name='hkl_soleil', version='v5.0.0.3434', geometry='E4CV', engine='hkl')
+
+To select a |solver| class without creating an instance, call
+:func:`~hklpy2.misc.get_solver`:
+
+.. code-block:: pycon
+
+    >>> from hklpy2 import get_solver
+    >>> Solver = get_solver("hkl_soleil")
+    >>> print(f"{Solver=}")
+    Solver=<class 'hklpy2.backends.hkl_soleil.HklSolver'>
+
+How to register a new Solver
+=============================
+
+A |solver| class is registered as a plugin via an `entry point
+<https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins>`_
+using the ``"hklpy2.solver"`` group.  Here is an example from |hklpy2|'s
+``pyproject.toml``::
+
+    [project.entry-points."hklpy2.solver"]
+    hkl_soleil = "hklpy2.backends.hkl_soleil:HklSolver"
+    th_tth = "hklpy2.backends.th_tth_q:ThTthSolver"
+
+.. seealso:: :ref:`howto.solvers.write`
+
+Solver descriptions
+===================
+
+Solver: hkl_soleil
+------------------
+
+*Hkl* (`documentation <https://people.debian.org/~picca/hkl/hkl.html>`_), from
+Synchrotron Soleil, is used as a backend library to convert between real-space
+motor coordinates and reciprocal-space crystallographic coordinates.  Here, we
+refer to this library as **hkl_soleil** to clarify and distinguish from other
+use of the term *hkl*.  Multiple source code repositories exist. |hklpy2|
+uses the `active development repository <https://repo.or.cz/hkl.git>`_.
+
+.. caution:: At this time, it is only compiled for 64-bit Linux.  Not Windows, not Mac OS.
+
+Solver: no_op
+-------------
+
+This solver was built for testing the |hklpy2| code.  It provides no useful
+geometries for diffractometer users.
+
+Solver: th_tth
+--------------
+
+This solver was built as a demonstration of a minimal all-Python solver.  It
+provides basic support for :math:`\theta, 2\theta` geometry with a :math:`Q`
+pseudo axis. It can be used on any OS where Python runs.


### PR DESCRIPTION
- closes #205

## Summary

- Trimmed `concepts/solvers.rst` to a brief overview: kept the intro bullet list and entry-point explanation, replaced per-solver prose with a concise summary table, removed all TODO markers, added `seealso` cross-references.
- Created `guides/solvers.rst` with moved how-to content: how to list, select, and instantiate solvers; how to register a new solver via entry point; detailed per-solver descriptions (`hkl_soleil`, `no_op`, `th_tth`).
- Added `entry point` definition to the Glossary.
- Updated `RELEASE_NOTES.rst` under 0.3.1 Enhancements.
- Clean docs build (zero warnings); pre-commit passes.

Agent: OpenCode (claudesonnet46)