### PR TITLE
feat #210 add creator_from_config(); create simulator from config

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -33,13 +33,14 @@ describe future plans.
     0.3.2
     ##########
 
-    Release expected TBD.
+    Release expected 2026-H1.
 
-    Enhancements
+    New Features
     ------------
 
-    Fixes
-    -----
+    * Add :func:`~hklpy2.misc.creator_from_config` to create a simulated
+      diffractometer (no hardware) from a saved configuration file or dict.
+      (:issue:`210`)
 
     Maintenance
     -----------

--- a/docs/source/guides/how_creator_from_config.rst
+++ b/docs/source/guides/how_creator_from_config.rst
@@ -1,0 +1,98 @@
+.. _how_creator_from_config:
+
+==========================================
+How to Create a Simulator from a Config
+==========================================
+
+.. index::
+    !creator_from_config
+    simulator; from configuration
+    configuration; restore as simulator
+
+:func:`~hklpy2.misc.creator_from_config` creates a fully configured
+simulated diffractometer — with no hardware connections — from a previously
+saved configuration file or dictionary.  All real-axis positioners are soft
+(simulated) positioners regardless of how they were defined in the original
+diffractometer.
+
+This is useful for:
+
+* Reproducing an orientation offline for data analysis.
+* Debugging a configuration without access to the hardware.
+* Computing :math:`hkl` positions from a saved orientation.
+
+Setup
+-----
+
+A configuration file is produced by exporting a live diffractometer::
+
+    >>> import hklpy2
+    >>> e4cv = hklpy2.creator(name="e4cv")
+    >>> # ... define sample, reflections, compute UB ...
+    >>> e4cv.export("e4cv-config.yml")
+
+Create a simulator from that file
+----------------------------------
+
+Pass the path to the YAML file::
+
+    >>> import hklpy2
+    >>> sim = hklpy2.creator_from_config("e4cv-config.yml")
+    >>> sim.wh()
+
+Or pass a configuration dictionary directly::
+
+    >>> config = hklpy2.misc.load_yaml_file("e4cv-config.yml")
+    >>> sim = hklpy2.creator_from_config(config)
+
+Or pass the ``configuration`` property of an existing diffractometer to
+create a simulator with the same orientation — no file needed::
+
+    >>> sim = hklpy2.creator_from_config(k6c.configuration)
+
+The simulator preserves
+------------------------
+
+* solver, geometry, and engine
+* real-axis names and their solver-expected order
+* sample(s), lattice parameters, and orientation reflections
+* the UB matrix
+* wavelength
+* constraints
+* presets
+
+No hardware is connected — all real axes are soft positioners.
+
+Compute positions offline
+--------------------------
+
+With the orientation restored, use the simulator exactly as you would a live
+diffractometer::
+
+    >>> sim.forward(1, 0, 0)
+    >>> sim.wh()
+
+Custom-named axes are preserved
+---------------------------------
+
+If the original diffractometer used custom axis names (e.g. ``theta`` instead
+of ``omega``), those names are preserved in the simulator::
+
+    >>> sim = hklpy2.creator_from_config("fourc-config.yml")
+    >>> sim.real_axis_names     # e.g. ['theta', 'chi', 'phi', 'ttheta']
+    ['theta', 'chi', 'phi', 'ttheta']
+
+Round-trip: simulator to simulator
+------------------------------------
+
+A simulator's configuration can itself be used to create another simulator::
+
+    >>> sim1 = hklpy2.creator_from_config("e4cv-config.yml")
+    >>> sim2 = hklpy2.creator_from_config(sim1.configuration)
+
+.. seealso::
+
+    :func:`~hklpy2.diffract.creator` — create a diffractometer from scratch.
+
+    :doc:`/guides/configuration_save_restore` — how to export and restore
+    diffractometer configurations.

--- a/src/hklpy2/__init__.py
+++ b/src/hklpy2/__init__.py
@@ -64,6 +64,7 @@ from .incident import A_KEV  # noqa: E402, F401
 from .misc import SOLVER_ENTRYPOINT_GROUP  # noqa: E402, F401
 from .misc import ConfigurationRunWrapper  # noqa: E402, F401
 from .misc import SolverError  # noqa: E402, F401
+from .misc import creator_from_config  # noqa: E402, F401
 from .misc import get_solver  # noqa: E402, F401
 from .misc import solver_factory  # noqa: E402, F401
 from .misc import solvers  # noqa: E402, F401

--- a/src/hklpy2/misc.py
+++ b/src/hklpy2/misc.py
@@ -30,6 +30,7 @@ Miscellaneous Support.
     ~pick_closest_solution
     ~pick_first_solution
     ~roundoff
+    ~creator_from_config
     ~solver_factory
     ~solvers
     ~unique_name
@@ -1146,6 +1147,109 @@ def solvers() -> Mapping[str, "SolverBase"]:
     }
     # fmt: on
     return entries
+
+
+def creator_from_config(config: Union[dict, str, pathlib.Path]):
+    """
+    Create a simulated diffractometer from a saved configuration.
+
+    Parses the configuration for the solver, geometry, and axis names, then
+    constructs a simulator (all axes are soft positioners — no hardware
+    connection) and restores the full orientation (samples, reflections, UB
+    matrix, wavelength, constraints) from the configuration.
+
+    PARAMETERS
+
+    config : dict, str, or pathlib.Path
+        Configuration dictionary, or path to a YAML configuration file
+        previously saved with ``diffractometer.export()``.
+
+    RETURNS
+
+    DiffractometerBase
+        A fully configured simulated diffractometer instance.
+
+    EXAMPLE::
+
+        >>> import hklpy2
+        >>> sim = hklpy2.creator_from_config("e4cv-config.yml")
+        >>> sim.wh()
+
+    SEE ALSO
+
+        :func:`~hklpy2.diffract.creator` — create a diffractometer from scratch.
+    """
+    from .diffract import creator
+
+    if isinstance(config, (str, pathlib.Path)):
+        config = load_yaml_file(config)
+    if not isinstance(config, dict):
+        raise TypeError(
+            f"Expected a dict or path to a YAML file. Received: {type(config)!r}"
+        )
+    if "_header" not in config:
+        raise KeyError("Configuration is missing '_header' key.")
+
+    solver_cfg = config.get("solver", {})
+    solver_name = solver_cfg.get("name", "hkl_soleil")
+    geometry = solver_cfg.get("geometry", "E4CV")
+
+    solver_kwargs: dict = {}
+    engine = solver_cfg.get("engine")
+    if engine is not None:
+        solver_kwargs["engine"] = engine
+
+    axes_cfg = config.get("axes", {})
+    axes_xref = axes_cfg.get("axes_xref", {})
+    pseudo_axes = axes_cfg.get("pseudo_axes", [])
+    real_axes = [
+        ax for ax in axes_cfg.get("real_axes", []) if ax not in set(pseudo_axes)
+    ]
+
+    # Sort diffractometer real axis names into the order the solver expects,
+    # using axes_xref (diffractometer_name -> solver_canonical_name) and
+    # solver.real_axes (solver canonical order).
+    solver_real_order = solver_cfg.get("real_axes", [])
+    if solver_real_order:
+        solver_to_diff_real = {v: k for k, v in axes_xref.items() if k in real_axes}
+        real_axes = [
+            solver_to_diff_real[s]
+            for s in solver_real_order
+            if s in solver_to_diff_real
+        ]
+
+    # Sort diffractometer pseudo axis names into the order the solver expects,
+    # using axes_xref (diffractometer_name -> solver_canonical_name).
+    # The solver canonical pseudo order is derived from the xref values for pseudos.
+    pseudo_set = set(pseudo_axes)
+    solver_to_diff_pseudo = {v: k for k, v in axes_xref.items() if k in pseudo_set}
+    # Preserve the solver-canonical order already encoded in axes_xref values;
+    # fall back to the order in axes.pseudo_axes if no xref is available.
+    pseudo_solver_order = [axes_xref.get(p, p) for p in pseudo_axes]
+    pseudo_axes_ordered = [
+        solver_to_diff_pseudo[s]
+        for s in pseudo_solver_order
+        if s in solver_to_diff_pseudo
+    ] or pseudo_axes
+
+    reals = {name: None for name in real_axes}
+
+    # Pass _real and _pseudo so creator() maps axes in solver-expected order
+    # even when diffractometer names differ from solver canonical names.
+    diffractometer_name = config.get("name", geometry.lower())
+
+    sim = creator(
+        name=diffractometer_name,
+        solver=solver_name,
+        geometry=geometry,
+        solver_kwargs=solver_kwargs,
+        reals=reals,
+        _real=real_axes if real_axes else None,
+        _pseudo=pseudo_axes_ordered if pseudo_axes_ordered else None,
+    )
+
+    sim.restore(config)
+    return sim
 
 
 def unique_name(prefix: str = "", length: int = 7) -> str:

--- a/src/hklpy2/tests/test_i210.py
+++ b/src/hklpy2/tests/test_i210.py
@@ -1,0 +1,235 @@
+"""
+Regression test for issue #210.
+
+Test creator_from_config(): create a simulated diffractometer from a
+saved configuration file or dict, with no hardware connections.
+"""
+
+import pathlib
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+import hklpy2
+from hklpy2.misc import creator_from_config
+
+TESTS_DIR = pathlib.Path(__file__).parent
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(config=TESTS_DIR / "e4cv-silicon-example.yml"),
+            does_not_raise(),
+            id="e4cv silicon from path",
+        ),
+        pytest.param(
+            dict(config=TESTS_DIR / "fourc-configuration.yml"),
+            does_not_raise(),
+            id="fourc custom axes from path",
+        ),
+        pytest.param(
+            dict(config=TESTS_DIR / "tardis.yml"),
+            does_not_raise(),
+            id="tardis E6C from path",
+        ),
+        pytest.param(
+            dict(config=str(TESTS_DIR / "e4cv-silicon-example.yml")),
+            does_not_raise(),
+            id="e4cv silicon from str path",
+        ),
+        pytest.param(
+            dict(config=42),
+            pytest.raises(
+                TypeError, match=re.escape("Expected a dict or path to a YAML file.")
+            ),
+            id="invalid config type raises TypeError",
+        ),
+        pytest.param(
+            dict(config={"solver": {}, "axes": {}}),
+            pytest.raises(
+                KeyError, match=re.escape("Configuration is missing '_header' key.")
+            ),
+            id="missing _header raises KeyError",
+        ),
+    ],
+)
+def test_creator_from_config(parms, context):
+    """Test that creator_from_config() returns a working diffractometer."""
+    with context:
+        sim = creator_from_config(parms["config"])
+        assert sim is not None
+        assert hasattr(sim, "core")
+        assert hasattr(sim, "forward")
+        assert hasattr(sim, "inverse")
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                config=TESTS_DIR / "e4cv-silicon-example.yml",
+                expected_solver="hkl_soleil",
+                expected_geometry="E4CV",
+                expected_sample="silicon",
+            ),
+            does_not_raise(),
+            id="e4cv silicon: solver, geometry, sample restored",
+        ),
+        pytest.param(
+            dict(
+                config=TESTS_DIR / "fourc-configuration.yml",
+                expected_solver="hkl_soleil",
+                expected_geometry="E4CV",
+                expected_sample="vibranium",
+                expected_real_axes=["theta", "chi", "phi", "ttheta"],
+            ),
+            does_not_raise(),
+            id="fourc: custom axis names preserved",
+        ),
+        pytest.param(
+            dict(
+                config=TESTS_DIR / "tardis.yml",
+                expected_solver="hkl_soleil",
+                expected_geometry="E6C",
+                expected_sample="KCF",
+            ),
+            does_not_raise(),
+            id="tardis E6C: geometry and sample restored",
+        ),
+    ],
+)
+def test_creator_from_config_orientation(parms, context):
+    """Test that orientation data is restored correctly."""
+    with context:
+        sim = creator_from_config(parms["config"])
+
+        assert sim.core.solver.name == parms["expected_solver"]
+        assert sim.core.solver.geometry == parms["expected_geometry"]
+        assert parms["expected_sample"] in sim.core.samples
+
+        if "expected_real_axes" in parms:
+            assert sim.real_axis_names == parms["expected_real_axes"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(config=TESTS_DIR / "e4cv-silicon-example.yml"),
+            does_not_raise(),
+            id="simulator has soft positioners (no hardware)",
+        ),
+    ],
+)
+def test_simulator_is_simulated(parms, context):
+    """Test that the simulator uses soft positioners, not EPICS."""
+    with context:
+        sim = creator_from_config(parms["config"])
+        # Soft positioners are connected immediately without an IOC
+        assert sim.connected
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(config=TESTS_DIR / "e4cv-silicon-example.yml"),
+            does_not_raise(),
+            id="creator_from_config accessible from hklpy2 namespace",
+        ),
+    ],
+)
+def test_creator_from_config_in_namespace(parms, context):
+    """Test that creator_from_config is accessible from hklpy2 namespace."""
+    with context:
+        sim = hklpy2.creator_from_config(parms["config"])
+        assert sim is not None
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(config=TESTS_DIR / "e4cv-silicon-example.yml"),
+            does_not_raise(),
+            id="roundtrip: config from simulator matches original",
+        ),
+    ],
+)
+def test_simulator_roundtrip(parms, context):
+    """Test that a simulator's exported config can recreate another simulator."""
+    with context:
+        sim1 = creator_from_config(parms["config"])
+        config1 = sim1.configuration
+
+        sim2 = creator_from_config(config1)
+
+        assert sim2.core.solver.geometry == sim1.core.solver.geometry
+        assert set(sim2.core.samples.keys()) == set(sim1.core.samples.keys())
+        assert sim2.real_axis_names == sim1.real_axis_names
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                config=TESTS_DIR / "tardis.yml",
+                # tardis axes_xref: theta->mu, mu->omega, chi->chi,
+                # phi->phi, delta->gamma, gamma->delta
+                # solver E6C canonical order: [mu, omega, chi, phi, gamma, delta]
+                # diffractometer order must follow: theta, mu, chi, phi, delta, gamma
+                expected_real_axes=["theta", "mu", "chi", "phi", "delta", "gamma"],
+            ),
+            does_not_raise(),
+            id="tardis: out-of-order axes_xref correctly reordered",
+        ),
+        pytest.param(
+            dict(
+                config=TESTS_DIR / "fourc-configuration.yml",
+                # fourc axes_xref: theta->omega, chi->chi, phi->phi, ttheta->tth
+                # solver E4CV canonical order: [omega, chi, phi, tth]
+                expected_real_axes=["theta", "chi", "phi", "ttheta"],
+            ),
+            does_not_raise(),
+            id="fourc: custom axis names reordered to match solver",
+        ),
+    ],
+)
+def test_simulator_axis_order(parms, context):
+    """Test that real axes are in solver-expected order even with custom names."""
+    with context:
+        sim = creator_from_config(parms["config"])
+        assert sim.real_axis_names == parms["expected_real_axes"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                config=TESTS_DIR / "e4cv-silicon-example.yml",
+                expected_pseudo_axes=["h", "k", "l"],
+            ),
+            does_not_raise(),
+            id="e4cv: pseudo axes in solver-expected order",
+        ),
+        pytest.param(
+            dict(
+                config=TESTS_DIR / "tardis.yml",
+                expected_pseudo_axes=["h", "k", "l"],
+            ),
+            does_not_raise(),
+            id="tardis: pseudo axes in solver-expected order",
+        ),
+    ],
+)
+def test_simulator_pseudo_order(parms, context):
+    """Test that pseudo axes are in solver-expected order."""
+    with context:
+        sim = creator_from_config(parms["config"])
+        assert sim.pseudo_axis_names == parms["expected_pseudo_axes"]


### PR DESCRIPTION
- closes #210

## Summary

- Add `creator_from_config()` to `misc.py` and export from `hklpy2` namespace.
- Creates a fully configured simulated diffractometer (soft positioners, no hardware) from a saved configuration dict, YAML file path, or the `.configuration` property of an existing diffractometer: `sim = hklpy2.creator_from_config(k6c.configuration)`
- Handles axis ordering: uses `axes_xref` and `solver.real_axes` to sort real and pseudo axes into solver-expected order regardless of how they appear in the config.
- Add how-to guide `docs/source/guides/how_creator_from_config.rst`.
- Add 16 tests in `src/hklpy2/tests/test_i210.py` covering: file/dict/str input, error cases, orientation restoration, simulated positioners, axis ordering (reals and pseudos), round-trip, and namespace access.

Agent: OpenCode (claudesonnet46)