### PR TITLE
docs #224 how to choose the default forward() solution

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -42,6 +42,13 @@ describe future plans.
       diffractometer (no hardware) from a saved configuration file or dict.
       (:issue:`210`)
 
+    Enhancements
+    ------------
+
+    * Add how-to guide for choosing the default ``forward()`` solution picker
+      (``pick_first_solution``, ``pick_closest_solution``, or custom).
+      (:issue:`224`)
+
     Maintenance
     -----------
 

--- a/docs/source/concepts/planning/_checklist_v2.md
+++ b/docs/source/concepts/planning/_checklist_v2.md
@@ -54,7 +54,7 @@ It could be re-organized.
   * [x] [TwoC unknown](https://github.com/bluesky/hklpy/issues/165)
   * [ ] [xrayutilities](https://github.com/bluesky/hklpy/issues/162) (:issue:`95`)
 * [ ] Documentation
-  * [ ] Choosing the default `forward()` solution. (:issue:`71`, :issue:`224`)
+  * [x] Choosing the default `forward()` solution. (:issue:`71`, :issue:`224`)
   * [x] documentation from hklpy.
   * [x] How to calculate UB from 2 reflections.
   * [x] How to hold axes fixed during `forward()` transformation.

--- a/docs/source/guides/how_forward_solution.rst
+++ b/docs/source/guides/how_forward_solution.rst
@@ -1,0 +1,132 @@
+.. _how_forward_solution:
+
+=============================================
+How to Choose the Default forward() Solution
+=============================================
+
+.. index::
+    !forward() solution
+    pick_first_solution
+    pick_closest_solution
+    _forward_solution
+
+The :meth:`~hklpy2.diffract.DiffractometerBase.forward` method may return
+multiple valid real-axis positions for a given set of pseudo-axis coordinates.
+A *solution picker* function selects one solution from that list.
+
+This guide explains the built-in pickers, how to switch between them, and how
+to write a custom one.
+
+Built-in solution pickers
+--------------------------
+
+Two pickers are provided:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Function
+     - Behavior
+   * - :func:`~hklpy2.misc.pick_first_solution` *(default)*
+     - Returns the first solution in the list as supplied by the solver.
+   * - :func:`~hklpy2.misc.pick_closest_solution`
+     - Returns the solution whose real-axis values are closest (RMS distance)
+       to the current motor positions.
+
+The default is :func:`~hklpy2.misc.pick_first_solution`.
+
+Check the current picker
+-------------------------
+
+::
+
+    >>> e4cv._forward_solution
+    <function pick_first_solution at 0x...>
+
+Switch to pick_closest_solution at runtime
+-------------------------------------------
+
+Assign directly to :attr:`~hklpy2.diffract.DiffractometerBase._forward_solution`::
+
+    >>> from hklpy2.misc import pick_closest_solution
+    >>> e4cv._forward_solution = pick_closest_solution
+
+Switch back::
+
+    >>> from hklpy2.misc import pick_first_solution
+    >>> e4cv._forward_solution = pick_first_solution
+
+Set the picker at creation time
+---------------------------------
+
+Pass ``forward_solution_function`` as a dotted name string to
+:func:`~hklpy2.diffract.creator`::
+
+    >>> import hklpy2
+    >>> e4cv = hklpy2.creator(
+    ...     name="e4cv",
+    ...     forward_solution_function="hklpy2.misc.pick_closest_solution",
+    ... )
+
+Or pass a callable directly to
+:class:`~hklpy2.diffract.DiffractometerBase.__init__` when subclassing::
+
+    >>> from hklpy2.misc import pick_closest_solution
+    >>> e4cv = MyDiffractometerClass(
+    ...     "",
+    ...     name="e4cv",
+    ...     forward_solution_function=pick_closest_solution,
+    ... )
+
+Write a custom picker
+----------------------
+
+A picker function must accept two arguments and return one solution:
+
+.. code-block:: python
+
+    from typing import NamedTuple
+
+    def my_picker(position: NamedTuple, solutions: list[NamedTuple]) -> NamedTuple:
+        """Return the solution with the smallest omega value."""
+        from hklpy2.misc import NoForwardSolutions
+        if not solutions:
+            raise NoForwardSolutions("No solutions.")
+        return min(solutions, key=lambda s: abs(s.omega))
+
+Assign it at runtime or at creation::
+
+    >>> e4cv._forward_solution = my_picker
+
+    >>> e4cv = hklpy2.creator(
+    ...     name="e4cv",
+    ...     forward_solution_function="mymodule.my_picker",
+    ... )
+
+The picker interface
+---------------------
+
+All pickers must follow this interface:
+
+``position`` : named tuple
+    The current real-axis position of the diffractometer (e.g.
+    ``RealPosition(omega=..., chi=..., phi=..., tth=...)``).
+
+``solutions`` : list of named tuples
+    All valid solutions returned by :meth:`~hklpy2.ops.Core.forward`.
+    Each element is a named tuple with the same fields as ``position``.
+
+**Returns:** one named tuple from ``solutions``.
+
+**Raises:** :exc:`~hklpy2.misc.NoForwardSolutions` if ``solutions`` is empty.
+
+.. seealso::
+
+    :func:`~hklpy2.misc.pick_first_solution`,
+    :func:`~hklpy2.misc.pick_closest_solution` — built-in pickers.
+
+    :attr:`~hklpy2.diffract.DiffractometerBase._forward_solution` — the
+    attribute that holds the active picker.
+
+    :meth:`~hklpy2.ops.Core.forward` — returns all solutions before the
+    picker is applied.


### PR DESCRIPTION
- closes #224
- related: #71

## Summary

- Add `guides/how_forward_solution.rst` covering:
  - Built-in pickers: `pick_first_solution` (default) and `pick_closest_solution`
  - Switching the picker at runtime via `diffractometer._forward_solution`
  - Setting the picker at creation time via `creator(forward_solution_function=...)`
  - Writing a custom picker function with the required interface
- Check off the *Choosing the default forward() solution* item in the v2 checklist.
- Add entry to 0.3.2 Enhancements in `RELEASE_NOTES.rst`.
- Docs build clean; pre-commit passes.

Agent: OpenCode (claudesonnet46)