### PR TITLE
fix #199 standardize error messages

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -54,6 +54,15 @@ describe future plans.
     * Show a banner on dev/pre-release doc pages noting that a stable
       version is available, with a link to it. (:issue:`213`)
 
+    Fixes
+    -----
+
+    * Fix error message bugs: missing f-string prefix in ``hkl_soleil.py``,
+      typo ``"must by"`` → ``"must be"`` in ``sample.py``, trailing comma in
+      ``user.py`` ``set_wavelength()`` message; standardize
+      ``NoForwardSolutions`` message; deduplicate ``_header`` key message
+      into a constant; fix capitalization inconsistency. (:issue:`199`)
+
     Maintenance
     -----------
 

--- a/src/hklpy2/backends/hkl_soleil.py
+++ b/src/hklpy2/backends/hkl_soleil.py
@@ -427,7 +427,7 @@ class HklSolver(SolverBase):
             return solutions
 
         except GLib.GError as exc:
-            raise NoForwardSolutions("No forward solutions found.") from exc
+            raise NoForwardSolutions("No solutions.") from exc
 
     @classmethod
     def geometries(cls) -> list[str]:
@@ -634,7 +634,7 @@ class HklSolver(SolverBase):
 
         if False in [isinstance(v, (float, int)) for v in _r]:
             raise TypeError(
-                "All values must be numbers.  Received: {reals!r}",
+                f"All values must be numbers.  Received: {reals!r}",
             )
 
         self._hkl_geometry.axis_values_set(_r, LIBHKL_USER_UNITS)

--- a/src/hklpy2/blocks/sample.py
+++ b/src/hklpy2/blocks/sample.py
@@ -175,7 +175,7 @@ class Sample:
         if not np.isreal(arr).all():
             raise TypeError(f"{name} matrix must be numerical.  Received {value}")
         if arr.shape != (3, 3):
-            raise ValueError(f"{name} matrix must by 3x3. Received {value}")
+            raise ValueError(f"{name} matrix must be 3x3.  Received {value}")
         if name == "UB":
             return
         # Rows and columns of U matrix must have unit norms.

--- a/src/hklpy2/blocks/tests/test_sample.py
+++ b/src/hklpy2/blocks/tests/test_sample.py
@@ -270,10 +270,10 @@ def test_remove_reflection(rname, context, expected):
             "rows must be normalized",
         ],
         ["U", [1, 2, "3"], pytest.raises(TypeError), "must be numerical"],
-        ["U", [1, 2, 3], pytest.raises(ValueError), "must by 3x3."],
+        ["U", [1, 2, 3], pytest.raises(ValueError), "must be 3x3."],
         ["U", IDENTITY_MATRIX_3X3, does_not_raise(), None],
         ["UB", [1, 2, "3"], pytest.raises(TypeError), "must be numerical"],
-        ["UB", [1, 2, 3], pytest.raises(ValueError), "must by 3x3."],
+        ["UB", [1, 2, 3], pytest.raises(ValueError), "must be 3x3."],
         ["UB", IDENTITY_MATRIX_3X3, does_not_raise(), None],
     ],
 )

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -48,6 +48,7 @@ from .misc import AxesDict
 from .misc import BlueskyPlanType
 from .misc import DiffractometerError
 from .misc import KeyValueMap
+from .misc import MISSING_HEADER_KEY_MSG
 from .misc import load_yaml_file
 from .misc import pick_first_solution
 from .misc import roundoff
@@ -370,7 +371,7 @@ class DiffractometerBase(PseudoPositioner):
             raise TypeError(f"Unrecognized configuration: {config=}")
         header = config.get("_header")
         if header is None:
-            raise KeyError("Configuration is missing '_header' key.")
+            raise KeyError(MISSING_HEADER_KEY_MSG)
         # Note: python_class key is not testable, could be anything.
 
         bcfg = config["beam"].copy()

--- a/src/hklpy2/misc.py
+++ b/src/hklpy2/misc.py
@@ -171,6 +171,9 @@ NamedFloatDict = Mapping[str, NUMERIC]
 IDENTITY_MATRIX_3X3: Matrix3x3 = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 """Identity matrix, 2-D, 3 rows, 3 columns."""
 
+MISSING_HEADER_KEY_MSG: str = "Configuration is missing '_header' key."
+"""Error message for missing _header key in configuration dicts."""
+
 SOLVER_ENTRYPOINT_GROUP: str = "hklpy2.solver"
 """Name by which |hklpy2| |solver| classes are grouped."""
 
@@ -592,7 +595,7 @@ def compare_float_dicts(a1, a2, tol=1e-4) -> bool:
     Compare two dictionaries.  Values are all floats.
     """
     if tol <= 0:
-        raise ValueError(f"received {tol=}, should be tol >0")
+        raise ValueError(f"Received {tol=}, should be tol >0.")
 
     if sorted(a1.keys()) != sorted(a2.keys()):
         return False
@@ -1188,7 +1191,7 @@ def creator_from_config(config: Union[dict, str, pathlib.Path]):
             f"Expected a dict or path to a YAML file. Received: {type(config)!r}"
         )
     if "_header" not in config:
-        raise KeyError("Configuration is missing '_header' key.")
+        raise KeyError(MISSING_HEADER_KEY_MSG)
 
     solver_cfg = config.get("solver", {})
     solver_name = solver_cfg.get("name", "hkl_soleil")

--- a/src/hklpy2/user.py
+++ b/src/hklpy2/user.py
@@ -626,7 +626,7 @@ def set_wavelength(value: float, units=None) -> None:
     beam = _choice.diffractometer.beam
     if not beam.wavelength.write_access:
         raise TypeError(
-            f"'set_wavelength()' not supported for {beam.wavelength.name!r},"
+            f"'set_wavelength()' not supported for {beam.wavelength.name!r}."
         )
     if units is not None:
         beam.wavelength_units.put(units)


### PR DESCRIPTION
## Summary

- closes #199 (item 1: error message bug fixes)

Fixes six concrete error message bugs and inconsistencies:

- Add missing `f` prefix on `TypeError` in `hkl_soleil.py:637` — `{reals!r}` was never interpolated
- Fix typo `"must by 3x3"` → `"must be 3x3"` in `sample.py:178`
- Fix trailing comma → period in `set_wavelength()` error message in `user.py:629`
- Standardize `NoForwardSolutions` to `"No solutions."` in `hkl_soleil.py:430` (was `"No forward solutions found."`)
- Extract `MISSING_HEADER_KEY_MSG` constant in `misc.py`, import in `diffract.py` to deduplicate
- Capitalize `"received"` → `"Received"` in `compare_float_dicts` error message in `misc.py:595`

Test expectations updated to match. All 874 tests pass.

Remaining items from #199 have been split into separate issues:
- #229 — Refactor `scan_extra` into smaller methods
- #230 — Fix type annotations (`*reals` in `setor()`, `KeyValueMap` usage)
- #231 — `configuration` setter skips validation and wavelength restore
- #232 — Standardize `pytest.raises(match=)` usage across tests
- #233 — Consider `TypedDict` for reflection/sample dicts

Agent: OpenCode (claudesonnet46)