### PR TITLE
docs #235 sort glossary alphabetically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,14 @@ The `Makefile` `pre` target also exports this variable automatically.
   Features, Enhancements, Fixes, Maintenance, Deprecations, New Contributors.
 - Sort entries alphabetically within each subsection.
 
+## Documentation: Glossary
+
+- Keep glossary entries in `docs/source/glossary.rst` sorted alphabetically
+  (case-insensitive).
+- Each entry consists of an `.. index::` directive followed by a `:term:`
+  definition.  When adding or moving entries, keep the index directive and
+  definition together as a unit.
+
 ## Documentation: Sphinx Index entries
 
 - Each term should have **at most one primary index entry** (`!term`) across the

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -62,6 +62,8 @@ describe future plans.
       ``user.py`` ``set_wavelength()`` message; standardize
       ``NoForwardSolutions`` message; deduplicate ``_header`` key message
       into a constant; fix capitalization inconsistency. (:issue:`199`)
+    * Sort glossary alphabetically; fix ``:real:`` → ``:virtual:`` typo in
+      glossary entry. (:issue:`235`)
 
     Maintenance
     -----------

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -104,15 +104,6 @@ Glossary
   specific directions.
 
 ..  index::
-    !definition; entry point
-    !entry point
-
-:entry point: A Python packaging mechanism that allows a package to advertise
-  a named object (such as a class or function) so other packages can discover
-  and load it without a hard-coded import.  |hklpy2| uses the
-  ``"hklpy2.solver"`` entry point group to locate installed |solver| plugins.
-
-..  index::
     !definition; engine
     !engine
 
@@ -121,6 +112,15 @@ Glossary
   such as for reflectometry or surface scattering.  The |solver| may provide
   an engine for each separate type of transformation (and related
   *pseudos*).
+
+..  index::
+    !definition; entry point
+    !entry point
+
+:entry point: A Python packaging mechanism that allows a package to advertise
+  a named object (such as a class or function) so other packages can discover
+  and load it without a hard-coded import.  |hklpy2| uses the
+  ``"hklpy2.solver"`` entry point group to locate installed |solver| plugins.
 
 ..  index::
     !definition; extra
@@ -283,10 +283,10 @@ Glossary
 
 ..  index::
     !definition; virtual
-    !real
+    !virtual
 
-:real: Virtual (computed) diffractometer **axis** (either **pseudo** or
-    **real**), computed from one or more additional **diffractometer** axes.
+:virtual: Virtual (computed) diffractometer *axis* (either *pseudo* or
+    *real*), computed from one or more additional diffractometer axes.
 
 ..  index::
     !definition; wavelength


### PR DESCRIPTION
## Summary

- closes #235

- Sort glossary entries in `docs/source/glossary.rst` alphabetically (case-insensitive)
- Fix duplicate `:real:` definition → `:virtual:` with corrected `.. index::` directive
- Swap `entry point` and `engine` entries to restore alphabetical order
- Add glossary sorting rule to `AGENTS.md`

Agent: OpenCode (claudesonnet46)