### PR TITLE
test #232 add re.escape() to all pytest.raises(match=) calls

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -68,6 +68,8 @@ describe future plans.
     Maintenance
     -----------
 
+    * Add ``re.escape()`` to all ``pytest.raises(match=...)`` calls that were
+      using raw strings. (:issue:`232`)
     * Backfill workflow no longer patches ``conf.py`` from ``main``; legacy
       tag builds use their own ``conf.py`` so the displayed version is correct
       and no switcher dropdown appears in builds that predate it. (:issue:`213`)

--- a/src/hklpy2/blocks/tests/test_zone.py
+++ b/src/hklpy2/blocks/tests/test_zone.py
@@ -34,7 +34,7 @@ def sim4c2():
             {},
             None,
             True,
-            pytest.raises(ValueError, match="zone axis is undefined"),
+            pytest.raises(ValueError, match=re.escape("zone axis is undefined")),
             id="ValueError: No kwargs, zone axis is undefined",
         ),
         pytest.param(
@@ -154,7 +154,7 @@ def test_OrthonormalZone_repr(parms, result, context):
         pytest.param(
             dict(axis=(0, 0, 1)),
             1,
-            pytest.raises(ValueError, match="vector must be 1-D array-like"),
+            pytest.raises(ValueError, match=re.escape("vector must be 1-D array-like")),
             id="vector shape !=(3,)",
         ),
         pytest.param(
@@ -162,7 +162,7 @@ def test_OrthonormalZone_repr(parms, result, context):
             dict(),
             pytest.raises(
                 ValueError,
-                match="Cannot create vector from empty dictionary",
+                match=re.escape("Cannot create vector from empty dictionary"),
             ),
             id="empty dict",
         ),

--- a/src/hklpy2/tests/test_diffract.py
+++ b/src/hklpy2/tests/test_diffract.py
@@ -1,6 +1,7 @@
 """Test the hklpy2.diffract module."""
 
 import math
+import re
 from collections import deque
 from collections import namedtuple
 from contextlib import nullcontext as does_not_raise
@@ -806,7 +807,7 @@ def test_repeated_reflections(
                 pseudos=dict(h2=2, k2=-1, l2=0),
             ),
             "psi_constant",
-            pytest.raises(KeyError, match="'NO_SUCH_SCAN_AXIS' not in "),
+            pytest.raises(KeyError, match=re.escape("'NO_SUCH_SCAN_AXIS' not in ")),
             None,
             id="KeyError in diffract..scan_extra()",
         ),

--- a/src/hklpy2/tests/test_misc.py
+++ b/src/hklpy2/tests/test_misc.py
@@ -825,7 +825,7 @@ def test_istype_with_numpy_scalar_and_none():
                 order="aa bb cc dd".split(),
                 canonical="h k l".split(),
             ),
-            pytest.raises(ValueError, match="Too many axes specified"),
+            pytest.raises(ValueError, match=re.escape("Too many axes specified")),
             id="ValueError: \"Too many axes specified in order=['aa', 'bb', 'cc', 'dd']. Expected 3.\"",
         ),
         pytest.param(
@@ -834,7 +834,7 @@ def test_istype_with_numpy_scalar_and_none():
                 order="aa bb cc".split(),
                 canonical="h k l".split(),
             ),
-            pytest.raises(KeyError, match="Unknown axis_name="),
+            pytest.raises(KeyError, match=re.escape("Unknown axis_name=")),
             id="KeyError: Unknown axis_name=",
         ),
         pytest.param(
@@ -844,12 +844,12 @@ def test_istype_with_numpy_scalar_and_none():
                 order="h h l".split(),
                 canonical="h k l".split(),
             ),
-            pytest.raises(ValueError, match="Duplicates in order="),
+            pytest.raises(ValueError, match=re.escape("Duplicates in order=")),
             id="ValueError: Duplicates in order=",
         ),
         pytest.param(
             dict(space="not recognized"),
-            pytest.raises(KeyError, match="Unknown space='not recognized'"),
+            pytest.raises(KeyError, match=re.escape("Unknown space='not recognized'")),
             id="KeyError: Unknown space='not recognized'",
         ),
         pytest.param(
@@ -966,6 +966,6 @@ def test_make_dynamic_instance_raises():
     non_callable = "hklpy2.misc.DEFAULT_MOTOR_LABELS"
     with pytest.raises(
         TypeError,
-        match=f"{non_callable!r} is not callable",
+        match=re.escape(f"{non_callable!r} is not callable"),
     ):
         make_dynamic_instance(non_callable)

--- a/src/hklpy2/tests/test_ops.py
+++ b/src/hklpy2/tests/test_ops.py
@@ -1,6 +1,7 @@
 """Test the hklpy2.ops module."""
 
 import math
+import re
 import uuid
 from collections import namedtuple
 from contextlib import nullcontext as does_not_raise
@@ -171,7 +172,9 @@ def test_unknown_reflection():
             "h k l".split(),
             dict(a=1, b=2, c=3, d=4),  # cannot use number as value
             "h b c d".split(),  # duplicate name is pseudos and reals
-            pytest.raises(TypeError, match="Incorrect type 'int' for specs="),
+            pytest.raises(
+                TypeError, match=re.escape("Incorrect type 'int' for specs=")
+            ),
             "Incorrect type 'int' for specs=",
             id="Incorrect type 'int' for specs=",
         ),
@@ -179,7 +182,9 @@ def test_unknown_reflection():
             "h k l".split(),
             dict(a=None, b="m5", c=None, d=None),
             "h b c d".split(),  # same name used in both pseudos and reals
-            pytest.raises(ValueError, match="Axis name cannot be in more than list."),
+            pytest.raises(
+                ValueError, match=re.escape("Axis name cannot be in more than list.")
+            ),
             "Axis name cannot be in more than list.",
             id="Axis name cannot be in more than list.",
         ),
@@ -208,7 +213,7 @@ def test_unknown_reflection():
             "a b c d".split(),  # standard order
             pytest.raises(
                 KeyError,
-                match="Expected 'class' key, received None",
+                match=re.escape("Expected 'class' key, received None"),
             ),
             "Expected 'class' key, received None",
             id="Expected 'class' key, received None",

--- a/src/hklpy2/tests/test_user.py
+++ b/src/hklpy2/tests/test_user.py
@@ -565,7 +565,7 @@ def test_cahkl_forward_raises(parms, context):
                 extras=dict(h4=2, k4=2, l4=0),
                 fail_on_exception=True,
             ),
-            pytest.raises(KeyError, match='"Unexpected extra axis name'),
+            pytest.raises(KeyError, match=re.escape("Unexpected extra axis name")),
             id="no hkl_4 extras",
         ),
     ],


### PR DESCRIPTION
## Summary

- #232 (partial — re.escape fixes only; assert_context_result migration deferred)

Adds `re.escape()` to all 13 `pytest.raises(match=...)` calls that were using raw strings:

- `test_diffract.py` (1 site)
- `test_user.py` (1 site)
- `test_ops.py` (3 sites)
- `test_misc.py` (5 sites)
- `test_zone.py` (3 sites)

Added `import re` to `test_diffract.py` and `test_ops.py` where it was missing.

All 874 tests pass. The `assert_context_result` migration (117 call sites) is left for a follow-up effort.

Agent: OpenCode (claudesonnet46)