### PR TITLE
fix #242 increase ENDPOINT_TOLERANCE to accept fp-boundary solver solutions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,61 @@ Agent: OpenCode (claudeopus46)
 docs #15 update AGENTS.md with branching workflow
 ```
 
+### Project Status
+
+When starting work on an issue, set its project card status to **"In progress"**
+and move it to **"In review"** when the PR is opened.  Use the GitHub GraphQL
+API via `gh api graphql`.
+
+**Step 1 – look up the project item ID and Status field option IDs:**
+
+```bash
+gh api graphql -f query='
+{ repository(owner:"bluesky", name:"hklpy2") {
+    issue(number:NNN) {
+      projectItems(first:5) { nodes {
+        id
+        project { id title
+          fields(first:20) { nodes {
+            ... on ProjectV2SingleSelectField { id name options { id name } }
+          }}
+        }
+      }}
+    }
+  }
+}'
+```
+
+Note the `itemId`, `projectId`, `fieldId` (for the **Status** field), and the
+`singleSelectOptionId` for the desired status (e.g. `"In progress"`).
+
+**Step 2 – set the status:**
+
+```bash
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "<projectId>"
+    itemId:    "<itemId>"
+    fieldId:   "<fieldId>"
+    value: { singleSelectOptionId: "<optionId>" }
+  }) { projectV2Item { id } }
+}'
+```
+
+For the **hklpy2 v1.0** project the IDs are stable:
+
+| Status | `singleSelectOptionId` |
+|--------|------------------------|
+| Backlog | `f75ad846` |
+| Ready | `61e4505c` |
+| In progress | `47fc9ee4` |
+| In review | `df73e18b` |
+| Done | `98236657` |
+
+- `projectId`: `PVT_kwDOAtd7Hc4BFQ_A`
+- `fieldId` (Status): `PVTSSF_lADOAtd7Hc4BFQ_Azg2p0U4`
+
 ### Pull Requests
 
 A Pull Request (PR) describes *how* an issue has been (or will be) addressed.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -57,6 +57,9 @@ describe future plans.
     Fixes
     -----
 
+    * Fix ``LimitsConstraint.valid()`` rejecting solver solutions that land just
+      outside a limit boundary due to floating-point arithmetic; increase
+      ``ENDPOINT_TOLERANCE`` from ``1e-7`` to ``1e-4``. (:issue:`242`)
     * Fix :func:`~hklpy2.misc.creator_from_config` restoring reflections with
       wrong axis values when YAML serialises ``reals`` dict keys alphabetically
       instead of in physical axis order. (:issue:`243`)

--- a/src/hklpy2/blocks/constraints.py
+++ b/src/hklpy2/blocks/constraints.py
@@ -28,7 +28,7 @@ from ..misc import ConfigurationError
 from ..misc import ConstraintsError
 from ..misc import KeyValueMap
 
-ENDPOINT_TOLERANCE: float = 1e-7  # for comparisons, less than motion step size
+ENDPOINT_TOLERANCE: float = 1e-4  # for comparisons, less than motion step size
 UNDEFINED_LABEL: str = "undefined"
 
 

--- a/src/hklpy2/blocks/tests/test_constraints.py
+++ b/src/hklpy2/blocks/tests/test_constraints.py
@@ -5,6 +5,7 @@ import pytest
 
 from ...diffract import creator
 from ...misc import ConfigurationError
+from ..constraints import ENDPOINT_TOLERANCE
 from ..constraints import ConstraintBase
 from ..constraints import ConstraintsError
 from ..constraints import LimitsConstraint
@@ -43,6 +44,20 @@ def test_raises():
         pytest.param(20, 10, 10, True, id="reversed-at-lo"),
         pytest.param(20, 10, 15, True, id="reversed-within"),
         pytest.param(20, 10, 20, True, id="reversed-at-hi"),
+        # floating-point boundary cases (issue #242): solver may return
+        # values like 180.0000001 which must still be accepted at limit=180
+        pytest.param(
+            -180, 180, 180 + ENDPOINT_TOLERANCE * 0.5, True, id="fp-at-hi-within-tol"
+        ),
+        pytest.param(
+            -180, 180, -180 - ENDPOINT_TOLERANCE * 0.5, True, id="fp-at-lo-within-tol"
+        ),
+        pytest.param(
+            -180, 180, 180 + ENDPOINT_TOLERANCE * 2, False, id="fp-beyond-hi-tol"
+        ),
+        pytest.param(
+            -180, 180, -180 - ENDPOINT_TOLERANCE * 2, False, id="fp-beyond-lo-tol"
+        ),
     ],
 )
 def test_LimitsConstraint(lo, hi, value, result):

--- a/src/hklpy2/tests/test_user.py
+++ b/src/hklpy2/tests/test_user.py
@@ -125,6 +125,9 @@ def test_cahkl_table(fourc, capsys):
 
     # After #240, the solver preserves the lattice when UB is set,
     # so more valid solutions are found for (0,1,0).
+    # After #242, ENDPOINT_TOLERANCE is wider so chi=180 (solver fp result)
+    # is no longer rejected at limit=180; both chi=180 and chi=-180 solutions
+    # appear (they are physically identical but the solver returns both).
     expected = "\n".join(
         [
             "======= = ===== ==== ====== ===",
@@ -133,7 +136,8 @@ def test_cahkl_table(fourc, capsys):
             "(1 0 0) 1 30    0    90     60 ",
             "(1 0 0) 2 -150  0    -90    60 ",
             "(1 0 0) 3 30    180  -90    60 ",
-            "(1 0 0) 4 -150  -180 90     60 ",
+            "(1 0 0) 4 -150  180  90     60 ",
+            "(1 0 0) 5 -150  -180 90     60 ",
             "(0 1 0) 1 30    90   68.3   60 ",
             "(0 1 0) 2 30    90   -68.3  60 ",
             "(0 1 0) 3 30    90   111.7  60 ",


### PR DESCRIPTION
- closes #242

## Summary

- Raise `ENDPOINT_TOLERANCE` in `LimitsConstraint.valid()` from `1e-7` to `1e-4` so solver results that land just outside a limit boundary due to floating-point arithmetic (e.g. `chi=180.0000001` when the limit is `180.0`) are correctly accepted rather than silently discarded.
- Add four parametrised boundary test cases to `test_LimitsConstraint` (within-tolerance at high/low limit, beyond-tolerance at high/low limit).
- Update `test_cahkl_table` to include the one additional `(1 0 0)` solution that is now correctly admitted (`chi=180` at the `[-180, 180]` boundary).
- Document the GitHub GraphQL project-status workflow (`In progress` / `In review`) in `AGENTS.md` so future agents can set it without having to re-derive the IDs.

## Approach

`1e-4` is still orders of magnitude smaller than any realistic motor step size, so no physically distinct positions are collapsed; the wider window only covers the sub-millidegree floating-point noise that libhkl introduces at trigonometric singularities.

Agent: OpenCode (claudesonnet46)