### PR TITLE
fix #231 configuration setter delegates to restore()

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -45,6 +45,10 @@ describe future plans.
     Enhancements
     ------------
 
+    * Export :func:`~hklpy2.misc.get_run_orientation` and
+      :func:`~hklpy2.misc.list_orientation_runs` at the top-level ``hklpy2``
+      namespace, consistent with :class:`~hklpy2.misc.ConfigurationRunWrapper`.
+      (:issue:`231`)
     * Add how-to guide for choosing the default ``forward()`` solution picker
       (``pick_first_solution``, ``pick_closest_solution``, or custom).
       (:issue:`224`)
@@ -56,6 +60,11 @@ describe future plans.
 
     Fixes
     -----
+
+    * Fix ``diffractometer.configuration = config`` setter to delegate to
+      :meth:`~hklpy2.diffract.DiffractometerBase.restore`, applying geometry
+      validation, beam/wavelength restoration, and state clearing consistently
+      with calling ``restore()`` directly. (:issue:`231`)
 
     * Fix ``LimitsConstraint.valid()`` rejecting solver solutions that land just
       outside a limit boundary due to floating-point arithmetic; increase

--- a/src/hklpy2/__init__.py
+++ b/src/hklpy2/__init__.py
@@ -63,6 +63,8 @@ from .diffract import diffractometer_class_factory  # noqa: E402, F401, F403
 from .incident import A_KEV  # noqa: E402, F401
 from .misc import SOLVER_ENTRYPOINT_GROUP  # noqa: E402, F401
 from .misc import ConfigurationRunWrapper  # noqa: E402, F401
+from .misc import get_run_orientation  # noqa: E402, F401
+from .misc import list_orientation_runs  # noqa: E402, F401
 from .misc import SolverError  # noqa: E402, F401
 from .misc import creator_from_config  # noqa: E402, F401
 from .misc import get_solver  # noqa: E402, F401

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -291,9 +291,13 @@ class DiffractometerBase(PseudoPositioner):
         return self.core._asdict()
 
     @configuration.setter
-    def configuration(self, config: KeyValueMap) -> KeyValueMap:
+    def configuration(self, config: KeyValueMap) -> None:
         """
         Diffractometer configuration (orientation).
+
+        Delegates to :meth:`restore` so that geometry validation,
+        wavelength/beam restoration, and state clearing are all applied
+        consistently, identical to calling ``restore()`` directly.
 
         PARAMETERS
 
@@ -301,7 +305,7 @@ class DiffractometerBase(PseudoPositioner):
             Dictionary of diffractometer configuration, geometry, constraints,
             samples, reflections, orientations, solver, ...
         """
-        return self.core._fromdict(config)
+        self.restore(config)
 
     def export(self, file, comment="") -> None:
         """

--- a/src/hklpy2/tests/test_diffract.py
+++ b/src/hklpy2/tests/test_diffract.py
@@ -1329,3 +1329,74 @@ def test_digits_property(value, context):
             raise Exception("force except for coverage")
         except Exception:
             pass
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(restore_wavelength=True),
+            does_not_raise(),
+            id="setter restores wavelength",
+        ),
+        pytest.param(
+            dict(restore_wavelength=False),
+            does_not_raise(),
+            id="setter with default wavelength (no-op for setter)",
+        ),
+    ],
+)
+def test_configuration_setter_delegates_to_restore(parms, context):
+    """Configuration setter must delegate to restore(), applying geometry
+    validation, beam/wavelength restoration, and state clearing."""
+    import math
+
+    from ..incident import DEFAULT_WAVELENGTH
+    from ..misc import load_yaml_file
+
+    with context:
+        config = load_yaml_file(HKLPY2_DIR / "tests" / "e4cv_orient.yml")
+        e4cv = creator()
+        assert math.isclose(
+            e4cv.beam.wavelength.get(), DEFAULT_WAVELENGTH, abs_tol=0.001
+        )
+        # Use the property setter – should behave identically to restore()
+        e4cv.configuration = config
+        # Wavelength in e4cv_orient.yml is 1.54
+        assert math.isclose(e4cv.beam.wavelength.get(), 1.54, abs_tol=0.001)
+        # Verify geometry validation: a mis-matched config raises ConfigurationError
+        bad_config = dict(config)
+        bad_config = load_yaml_file(HKLPY2_DIR / "tests" / "e4cv_orient.yml")
+        bad_config["solver"]["geometry"] = "NONEXISTENT_GEOMETRY"
+    with pytest.raises(Exception):
+        e4cv2 = creator()
+        e4cv2.configuration = bad_config
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(name="get_run_orientation"),
+            does_not_raise(),
+            id="get_run_orientation exported",
+        ),
+        pytest.param(
+            dict(name="list_orientation_runs"),
+            does_not_raise(),
+            id="list_orientation_runs exported",
+        ),
+        pytest.param(
+            dict(name="ConfigurationRunWrapper"),
+            does_not_raise(),
+            id="ConfigurationRunWrapper exported",
+        ),
+    ],
+)
+def test_namespace_orientation_exports(parms, context):
+    """get_run_orientation and list_orientation_runs must be in hklpy2 namespace."""
+    import hklpy2
+
+    with context:
+        obj = getattr(hklpy2, parms["name"])
+        assert callable(obj)


### PR DESCRIPTION
- closes #231

## Summary

- `DiffractometerBase.configuration` setter now delegates to `restore()` so geometry validation, beam/wavelength restoration, and state clearing are applied identically whether the caller uses the setter or calls `restore()` directly.
- `get_run_orientation` and `list_orientation_runs` are now exported at the top-level `hklpy2` namespace, consistent with `ConfigurationRunWrapper`.
- Parametrized tests added for both changes.
- `RELEASE_NOTES.rst` updated.

Agent: OpenCode (claudesonnet46)