### PR TITLE
maint #230 fix type annotations in setor(), dict_device_factory(), Matrix3x3

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -85,6 +85,11 @@ describe future plans.
 
     * Add ``re.escape()`` to all ``pytest.raises(match=...)`` calls that were
       using raw strings. (:issue:`232`)
+    * Fix type annotations: ``*reals`` in :func:`~hklpy2.user.setor` from
+      ``AnyAxesType`` to ``NUMERIC``; ``**kwargs`` in
+      :func:`~hklpy2.misc.dict_device_factory` from ``KeyValueMap`` to ``Any``;
+      ``Matrix3x3`` from deprecated ``typing.List`` to built-in ``list``.
+      (:issue:`230`)
     * Remove deprecated ``assert_context_result()`` helper and all 117 call
       sites; fold error message strings into ``match=re.escape(...)`` on
       ``pytest.raises()``; convert bare list param sets to ``pytest.param()``

--- a/src/hklpy2/misc.py
+++ b/src/hklpy2/misc.py
@@ -88,7 +88,6 @@ from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
-from typing import List
 from typing import Mapping
 from typing import NamedTuple
 from typing import Optional
@@ -160,7 +159,7 @@ ordered tuple   (0, 1, -1)                  AxesTuple
 =============   =========================   ====================
 """
 
-Matrix3x3 = List[List[float]]
+Matrix3x3 = list[list[float]]
 """Python type annotation: mutable orientation & rotation matrices."""
 
 NamedFloatDict = Mapping[str, NUMERIC]
@@ -652,7 +651,7 @@ def define_real_axis(
     return class_name, args, kwargs
 
 
-def dict_device_factory(data: KeyValueMap, **kwargs: KeyValueMap) -> type:
+def dict_device_factory(data: KeyValueMap, **kwargs: Any) -> type:
     """
     Create a ``DictionaryDevice()`` class using the supplied dictionary.
 

--- a/src/hklpy2/user.py
+++ b/src/hklpy2/user.py
@@ -41,7 +41,6 @@ from .blocks.reflection import Reflection
 from .blocks.sample import Sample
 from .diffract import DiffractometerBase
 from .misc import NUMERIC
-from .misc import AnyAxesType
 from .misc import AxesDict
 from .misc import AxesTuple
 from .misc import BlueskyPlanType
@@ -666,7 +665,7 @@ def setor(
     h,
     k,
     l,  # noqa: E741
-    *reals: AnyAxesType,
+    *reals: NUMERIC,
     wavelength=None,
     name=None,
     **kwreals: AxesDict,
@@ -700,7 +699,7 @@ def setor(
 
     h, k, l: float
         Reciprocal-space coordinates of this reflection.
-    reals: AnyAxesType
+    reals: NUMERIC
         (optional)
         Real-space values of this reflection.  Must provide all values in the
         order expected by the geometry.


### PR DESCRIPTION
- closes #230

## Summary

- `*reals` in `setor()`: `AnyAxesType` → `NUMERIC` — each positional element is a single number; dict/named forms are handled by `**kwreals`, so no API reduction.
- `**kwargs` in `dict_device_factory()`: `KeyValueMap` → `Any` — `**kwargs: X` types each *value* as `X`; `KeyValueMap` (a `Mapping`) was wrong for arbitrary keyword values.
- `Matrix3x3`: `typing.List[List[float]]` → `list[list[float]]` — removes the deprecated `typing.List` import.
- Remove now-unused imports: `AnyAxesType` from `user.py`, `List` from `misc.py`.

Agent: OpenCode (claudesonnet46)