### PR TITLE
feat #233 add TypedDict structures for reflection, sample, and config dicts

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -45,6 +45,14 @@ describe future plans.
     Enhancements
     ------------
 
+    * Add ``TypedDict`` subclasses for structured solver and configuration
+      dicts: :class:`~hklpy2.backends.typing.ReflectionDict`,
+      :class:`~hklpy2.backends.typing.SampleDict`, and
+      :class:`~hklpy2.backends.typing.SolverMetadataDict` in
+      ``backends/typing.py``; :class:`~hklpy2.typing.ConfigHeaderDict` in
+      ``hklpy2/typing.py``; and ``HklSolverMetadataDict`` in
+      ``hkl_soleil.py`` as the pattern for solver-specific metadata
+      extensions. (:issue:`233`)
     * Export :func:`~hklpy2.misc.get_run_orientation` and
       :func:`~hklpy2.misc.list_orientation_runs` at the top-level ``hklpy2``
       namespace, consistent with :class:`~hklpy2.misc.ConfigurationRunWrapper`.

--- a/src/hklpy2/__init__.py
+++ b/src/hklpy2/__init__.py
@@ -54,6 +54,10 @@ if __name__ == "__main__":
     sys.exit()
 
 from .backends import SolverBase  # noqa: E402, F401
+from .backends import ReflectionDict  # noqa: E402, F401
+from .backends import SampleDict  # noqa: E402, F401
+from .backends import SolverMetadataDict  # noqa: E402, F401
+from .typing import ConfigHeaderDict  # noqa: E402, F401
 from .blocks.configure import Configuration  # noqa: E402, F401
 from .blocks.lattice import SI_LATTICE_PARAMETER  # noqa: E402, F401
 from .blocks.zone import scan_zone  # noqa: E402, F401, F403

--- a/src/hklpy2/backends/__init__.py
+++ b/src/hklpy2/backends/__init__.py
@@ -12,6 +12,10 @@ See the API documentation for details.
     ~no_op
     ~th_tth_q
     ~base
+    ~typing
 """
 
 from .base import SolverBase  # noqa: F401
+from .typing import ReflectionDict  # noqa: F401
+from .typing import SampleDict  # noqa: F401
+from .typing import SolverMetadataDict  # noqa: F401

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -24,6 +24,9 @@ from ..misc import Matrix3x3
 from ..misc import NamedFloatDict
 from ..misc import istype
 from ..misc import validate_and_canonical_unit
+from .typing import ReflectionDict
+from .typing import SampleDict
+from .typing import SolverMetadataDict
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +128,7 @@ class SolverBase(ABC):
         self._gname: str = geometry
         self.mode = mode
         self._all_extra_axis_names: Optional[List[str]] = None
-        self._sample: Optional[KeyValueMap] = None
+        self._sample: Optional[SampleDict] = None
 
         validate_and_canonical_unit(self.ANGLE_UNITS, INTERNAL_ANGLE_UNITS)
         validate_and_canonical_unit(self.LENGTH_UNITS, INTERNAL_LENGTH_UNITS)
@@ -142,7 +145,7 @@ class SolverBase(ABC):
         return f"{self.__class__.__name__}({', '.join(args)})"
 
     @property
-    def _metadata(self) -> KeyValueMap:
+    def _metadata(self) -> SolverMetadataDict:
         """Dictionary with this solver's summary metadata."""
         return {
             "name": self.name,
@@ -153,7 +156,7 @@ class SolverBase(ABC):
         }
 
     @abstractmethod
-    def addReflection(self, reflection: KeyValueMap) -> None:
+    def addReflection(self, reflection: ReflectionDict) -> None:
         """Add coordinates of a diffraction condition (a reflection)."""
 
     @property
@@ -173,8 +176,8 @@ class SolverBase(ABC):
     @abstractmethod
     def calculate_UB(
         self,
-        r1: KeyValueMap,
-        r2: KeyValueMap,
+        r1: ReflectionDict,
+        r2: ReflectionDict,
     ) -> Matrix3x3:
         """
         Calculate the UB (orientation) matrix with two reflections.
@@ -298,7 +301,7 @@ class SolverBase(ABC):
         # return []
 
     @abstractmethod
-    def refineLattice(self, reflections: List[KeyValueMap]) -> NamedFloatDict:
+    def refineLattice(self, reflections: List[ReflectionDict]) -> NamedFloatDict:
         """Refine the lattice parameters from a list of reflections."""
 
     @abstractmethod
@@ -306,15 +309,15 @@ class SolverBase(ABC):
         """Remove all reflections."""
 
     @property
-    def sample(self) -> Union[KeyValueMap, None]:
+    def sample(self) -> Union[SampleDict, None]:
         """
         Crystalline sample.
         """
         return self._sample
 
     @sample.setter
-    def sample(self, value: KeyValueMap) -> None:
-        if not istype(value, KeyValueMap):
+    def sample(self, value: SampleDict) -> None:
+        if not isinstance(value, dict):
             raise TypeError(f"Must supply dictionary, received {value!r}")
         self._sample = value
 
@@ -339,6 +342,9 @@ class SolverBase(ABC):
             description["modes"][mode] = desc
 
         return description
+
+    # NOTE: _summary_dict intentionally keeps KeyValueMap because its nested
+    # structure varies by engine and subclasses override it freely.
 
     @property
     def summary(self) -> Table:

--- a/src/hklpy2/backends/hkl_soleil.py
+++ b/src/hklpy2/backends/hkl_soleil.py
@@ -49,7 +49,6 @@ from numpy import typing as npt
 from pyRestTable import Table
 
 from ..misc import IDENTITY_MATRIX_3X3
-from ..misc import KeyValueMap
 from ..misc import Matrix3x3
 from ..misc import NamedFloatDict
 from ..misc import NoForwardSolutions
@@ -59,8 +58,36 @@ from ..misc import roundoff
 from ..misc import unique_name
 from .base import SolverBase
 from .hkl_soleil_utils import setup_libhkl
+from .typing import ReflectionDict
+from .typing import SampleDict
+from .typing import SolverMetadataDict
 
 logger = logging.getLogger(__name__)
+
+
+class HklSolverMetadataDict(SolverMetadataDict, total=False):
+    """
+    Solver metadata specific to the ``hkl_soleil`` backend.
+
+    Extends :class:`~hklpy2.backends.typing.SolverMetadataDict` with the
+    fields that are specific to the |libhkl|-based solver.  Using
+    ``total=False`` means all extra keys declared here are optional at
+    runtime; callers that only inspect the common
+    :class:`~hklpy2.backends.typing.SolverMetadataDict` contract are
+    unaffected.
+
+    Other solvers that need bespoke metadata keys should follow the same
+    pattern: subclass :class:`~hklpy2.backends.typing.SolverMetadataDict`
+    with ``total=False`` and place the subclass in that solver's own module.
+
+    Additional keys
+    ---------------
+    engine : str
+        Name of the computational engine (e.g. ``"hkl"``, ``"psi"``).
+    """
+
+    engine: str
+
 
 libhkl = setup_libhkl(platform.system(), "Hkl", "5.0")
 AXES_READ = 0
@@ -238,11 +265,24 @@ class HklSolver(SolverBase):
         ]
         return f"{self.__class__.__name__}({', '.join(args)})"
 
-    def addReflection(self, reflection: KeyValueMap) -> None:
+    @property
+    def _metadata(self) -> HklSolverMetadataDict:
+        """Dictionary with this solver's summary metadata, including engine."""
+        meta: HklSolverMetadataDict = {
+            "name": self.name,
+            "description": repr(self),
+            "geometry": self.geometry,
+            "real_axes": self.real_axis_names,
+            "version": self.version,
+            "engine": self.engine_name,
+        }
+        return meta
+
+    def addReflection(self, reflection: ReflectionDict) -> None:
         """Add coordinates of a diffraction condition (a reflection)."""
-        if not istype(reflection, KeyValueMap):
+        if not isinstance(reflection, dict):
             raise TypeError(
-                f"Must supply {KeyValueMap!r} object, received {reflection!r}",
+                f"Must supply a reflection dict, received {reflection!r}",
             )
 
         logger.debug("reflection: %r", reflection)
@@ -279,8 +319,8 @@ class HklSolver(SolverBase):
 
     def calculate_UB(
         self,
-        r1: KeyValueMap,
-        r2: KeyValueMap,
+        r1: ReflectionDict,
+        r2: ReflectionDict,
     ) -> Matrix3x3:
         """
         Calculate the UB (orientation) matrix with two reflections.
@@ -541,7 +581,7 @@ class HklSolver(SolverBase):
         return self._hkl_geometry.axis_names_get()  # Do NOT sort.
 
     @property
-    def reflections(self) -> Dict[str, KeyValueMap]:
+    def reflections(self) -> Dict[str, ReflectionDict]:
         """List of defined reflections (no store reflection names in libhkl)."""
         rlist = {}
         for refl in self._sample.reflections_get():
@@ -560,7 +600,7 @@ class HklSolver(SolverBase):
             )
         return rlist
 
-    def refineLattice(self, reflections: list[KeyValueMap]) -> NamedFloatDict:
+    def refineLattice(self, reflections: list[ReflectionDict]) -> NamedFloatDict:
         """
         Refine the lattice parameters from a list of reflections.
 
@@ -583,21 +623,22 @@ class HklSolver(SolverBase):
             self._sample.del_reflection(ref)
 
     @property
-    def sample(self) -> KeyValueMap:
+    def sample(self) -> SampleDict:
         """
         Crystalline sample.  libhkl's sample object.
         """
-        sample = dict(
+        sample: SampleDict = dict(
             name=self._sample.name_get(),
             lattice=self.lattice,
             reflections=self.reflections,
+            order=list(self.reflections.keys()),
         )
         return sample
 
     @sample.setter
-    def sample(self, value: KeyValueMap):
-        if not istype(value, dict):
-            raise TypeError(f"Must supply {KeyValueMap} object, received {value!r}")
+    def sample(self, value: SampleDict):
+        if not isinstance(value, dict):
+            raise TypeError(f"Must supply a sample dict, received {value!r}")
 
         # Just drop the old sample and make a new one.
         # Python knows its correct name.

--- a/src/hklpy2/backends/no_op.py
+++ b/src/hklpy2/backends/no_op.py
@@ -19,10 +19,10 @@ from typing import List
 
 from .. import __version__
 from ..misc import IDENTITY_MATRIX_3X3
-from ..misc import KeyValueMap
 from ..misc import Matrix3x3
 from ..misc import NamedFloatDict
 from .base import SolverBase
+from .typing import ReflectionDict
 
 logger = logging.getLogger(__name__)
 
@@ -65,10 +65,10 @@ class NoOpSolver(SolverBase):
     def __init__(self, geometry: str, **kwargs) -> None:
         super().__init__(geometry, **kwargs)
 
-    def addReflection(self, reflection: KeyValueMap) -> None:
+    def addReflection(self, reflection: ReflectionDict) -> None:
         return None
 
-    def calculate_UB(self, r1: KeyValueMap, r2: KeyValueMap) -> Matrix3x3:
+    def calculate_UB(self, r1: ReflectionDict, r2: ReflectionDict) -> Matrix3x3:
         return IDENTITY_MATRIX_3X3
 
     @property
@@ -97,7 +97,7 @@ class NoOpSolver(SolverBase):
     def real_axis_names(self) -> List[str]:
         return []  # no axes
 
-    def refineLattice(self, reflections: List[KeyValueMap]) -> NamedFloatDict:
+    def refineLattice(self, reflections: List[ReflectionDict]) -> NamedFloatDict:
         """No refinement."""
         return None
 

--- a/src/hklpy2/backends/tests/test_hkl_soleil.py
+++ b/src/hklpy2/backends/tests/test_hkl_soleil.py
@@ -9,6 +9,8 @@ from pyRestTable import Table
 from ...misc import IDENTITY_MATRIX_3X3
 from ...ops import Core
 from .. import hkl_soleil
+from ..hkl_soleil import HklSolverMetadataDict
+from ..typing import SolverMetadataDict
 
 
 def test_version():
@@ -445,3 +447,86 @@ def test_calculate_UB_degenerate(parms, context):
         assert ub is not None
         arr = np.array(ub)
         assert arr.shape == (3, 3)
+
+
+# ---------------------------------------------------------------------------
+# HklSolverMetadataDict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                meta=HklSolverMetadataDict(
+                    name="hkl_soleil",
+                    description="HklSolver(...)",
+                    geometry="E4CV",
+                    real_axes=["omega", "chi", "phi", "tth"],
+                    version="v5.0.0.3434",
+                    engine="hkl",
+                )
+            ),
+            does_not_raise(),
+            id="HklSolverMetadataDict hkl engine",
+        ),
+        pytest.param(
+            dict(
+                meta=HklSolverMetadataDict(
+                    name="hkl_soleil",
+                    description="HklSolver(...)",
+                    geometry="E6C",
+                    real_axes=["mu", "omega", "chi", "phi", "gamma", "delta"],
+                    version="v5.0.0.3434",
+                    engine="psi",
+                )
+            ),
+            does_not_raise(),
+            id="HklSolverMetadataDict psi engine",
+        ),
+    ],
+)
+def test_hkl_solver_metadata_dict(parms, context):
+    """HklSolverMetadataDict is a SolverMetadataDict subclass with engine."""
+    with context:
+        meta = parms["meta"]
+        assert isinstance(meta, dict)
+        # TypedDicts are plain dicts at runtime; verify that all required keys
+        # from the base class are present alongside the hkl-specific key.
+        assert set(SolverMetadataDict.__required_keys__).issubset(meta.keys())
+        assert isinstance(meta["name"], str)
+        assert isinstance(meta["description"], str)
+        assert isinstance(meta["geometry"], str)
+        assert isinstance(meta["real_axes"], list)
+        assert isinstance(meta["version"], str)
+        assert isinstance(meta["engine"], str)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(geometry="E4CV", engine="hkl"),
+            does_not_raise(),
+            id="HklSolver._metadata returns HklSolverMetadataDict for E4CV",
+        ),
+        pytest.param(
+            dict(geometry="E6C", engine="hkl"),
+            does_not_raise(),
+            id="HklSolver._metadata returns HklSolverMetadataDict for E6C",
+        ),
+    ],
+)
+def test_hkl_solver_metadata_live(parms, context):
+    """HklSolver._metadata includes engine alongside common keys."""
+    with context:
+        solver = hkl_soleil.HklSolver(parms["geometry"], engine=parms["engine"])
+        meta = solver._metadata
+        assert isinstance(meta, dict)
+        assert set(SolverMetadataDict.__required_keys__).issubset(meta.keys())
+        assert meta["name"] == "hkl_soleil"
+        assert meta["geometry"] == parms["geometry"]
+        assert meta["engine"] == parms["engine"]
+        assert isinstance(meta["real_axes"], list)
+        assert len(meta["real_axes"]) > 0

--- a/src/hklpy2/backends/tests/test_typing.py
+++ b/src/hklpy2/backends/tests/test_typing.py
@@ -1,0 +1,258 @@
+"""Tests for backends/typing.py TypedDict structures."""
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ..typing import ReflectionDict
+from ..typing import SampleDict
+from ..typing import SolverMetadataDict
+
+
+# ---------------------------------------------------------------------------
+# ReflectionDict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                value=dict(
+                    name="r1",
+                    pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
+                    reals={"omega": 10.0, "chi": 0.0, "phi": 0.0, "tth": 20.0},
+                    wavelength=1.54,
+                )
+            ),
+            does_not_raise(),
+            id="valid ReflectionDict",
+        ),
+        pytest.param(
+            dict(
+                value=dict(
+                    name="r2",
+                    pseudos={"h": 0.0, "k": 1.0, "l": 0.0},
+                    reals={"omega": 15.0, "chi": 0.0, "phi": 0.0, "tth": 30.0},
+                    wavelength=1.0,
+                )
+            ),
+            does_not_raise(),
+            id="valid ReflectionDict different values",
+        ),
+        pytest.param(
+            dict(value="not a dict"),
+            pytest.raises(TypeError, match=re.escape("is not a")),
+            id="ReflectionDict rejects non-dict",
+        ),
+    ],
+)
+def test_reflection_dict_is_dict(parms, context):
+    """ReflectionDict is a plain dict at runtime; verify keys and types."""
+    with context:
+        value = parms["value"]
+        if not isinstance(value, dict):
+            raise TypeError(f"{value!r} is not a dict")
+        assert "name" in value
+        assert "pseudos" in value
+        assert "reals" in value
+        assert "wavelength" in value
+        assert isinstance(value["name"], str)
+        assert isinstance(value["pseudos"], dict)
+        assert isinstance(value["reals"], dict)
+        assert isinstance(value["wavelength"], (int, float))
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                refl=ReflectionDict(
+                    name="r1",
+                    pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
+                    reals={"omega": 10.0, "chi": 0.0},
+                    wavelength=1.54,
+                )
+            ),
+            does_not_raise(),
+            id="construct ReflectionDict",
+        ),
+        pytest.param(
+            dict(
+                refl=ReflectionDict(
+                    name="origin",
+                    pseudos={"h": 0.0, "k": 0.0, "l": 0.0},
+                    reals={},
+                    wavelength=2.0,
+                )
+            ),
+            does_not_raise(),
+            id="construct ReflectionDict empty reals",
+        ),
+    ],
+)
+def test_reflection_dict_construct(parms, context):
+    """ReflectionDict can be constructed and accessed like a plain dict."""
+    with context:
+        refl = parms["refl"]
+        assert isinstance(refl, dict)
+        assert isinstance(refl["name"], str)
+        assert isinstance(refl["pseudos"], dict)
+        assert isinstance(refl["reals"], dict)
+        assert isinstance(refl["wavelength"], float)
+
+
+# ---------------------------------------------------------------------------
+# SampleDict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                sample=SampleDict(
+                    name="silicon",
+                    lattice={
+                        "a": 5.431,
+                        "b": 5.431,
+                        "c": 5.431,
+                        "alpha": 90.0,
+                        "beta": 90.0,
+                        "gamma": 90.0,
+                    },
+                    reflections={},
+                    order=[],
+                )
+            ),
+            does_not_raise(),
+            id="valid SampleDict no reflections",
+        ),
+        pytest.param(
+            dict(
+                sample=SampleDict(
+                    name="copper",
+                    lattice={
+                        "a": 3.615,
+                        "b": 3.615,
+                        "c": 3.615,
+                        "alpha": 90.0,
+                        "beta": 90.0,
+                        "gamma": 90.0,
+                    },
+                    reflections={
+                        "r1": ReflectionDict(
+                            name="r1",
+                            pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
+                            reals={"omega": 10.0, "chi": 0.0, "phi": 0.0, "tth": 20.0},
+                            wavelength=1.54,
+                        )
+                    },
+                    order=["r1"],
+                )
+            ),
+            does_not_raise(),
+            id="valid SampleDict with one reflection",
+        ),
+    ],
+)
+def test_sample_dict_construct(parms, context):
+    """SampleDict can be constructed and accessed like a plain dict."""
+    with context:
+        sample = parms["sample"]
+        assert isinstance(sample, dict)
+        assert isinstance(sample["name"], str)
+        assert isinstance(sample["lattice"], dict)
+        lattice_keys = set(sample["lattice"].keys())
+        assert lattice_keys == {"a", "b", "c", "alpha", "beta", "gamma"}
+        assert isinstance(sample["reflections"], dict)
+        assert isinstance(sample["order"], list)
+        for name in sample["order"]:
+            assert name in sample["reflections"]
+
+
+# ---------------------------------------------------------------------------
+# SolverMetadataDict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                meta=SolverMetadataDict(
+                    name="no_op",
+                    description="NoOpSolver(...)",
+                    geometry="test",
+                    real_axes=[],
+                    version="0.1.0",
+                )
+            ),
+            does_not_raise(),
+            id="SolverMetadataDict no_op solver",
+        ),
+        pytest.param(
+            dict(
+                meta=SolverMetadataDict(
+                    name="th_tth",
+                    description="ThTthSolver(...)",
+                    geometry="TH TTH Q",
+                    real_axes=["th", "tth"],
+                    version="1.0.0",
+                )
+            ),
+            does_not_raise(),
+            id="SolverMetadataDict th_tth solver",
+        ),
+    ],
+)
+def test_solver_metadata_dict_construct(parms, context):
+    """SolverMetadataDict holds the common required keys for all solvers."""
+    with context:
+        meta = parms["meta"]
+        assert isinstance(meta, dict)
+        assert isinstance(meta["name"], str)
+        assert isinstance(meta["description"], str)
+        assert isinstance(meta["geometry"], str)
+        assert isinstance(meta["real_axes"], list)
+        assert isinstance(meta["version"], str)
+        assert "engine" not in meta  # engine belongs in HklSolverMetadataDict
+
+
+# ---------------------------------------------------------------------------
+# Package-level imports (backends types only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(name="ReflectionDict"),
+            does_not_raise(),
+            id="ReflectionDict importable from hklpy2",
+        ),
+        pytest.param(
+            dict(name="SampleDict"),
+            does_not_raise(),
+            id="SampleDict importable from hklpy2",
+        ),
+        pytest.param(
+            dict(name="SolverMetadataDict"),
+            does_not_raise(),
+            id="SolverMetadataDict importable from hklpy2",
+        ),
+    ],
+)
+def test_public_exports(parms, context):
+    """Backend TypedDict classes are available from the top-level hklpy2 package."""
+    with context:
+        import hklpy2
+
+        obj = getattr(hklpy2, parms["name"])
+        assert obj is not None

--- a/src/hklpy2/backends/th_tth_q.py
+++ b/src/hklpy2/backends/th_tth_q.py
@@ -20,11 +20,11 @@ from typing import List
 
 from .. import __version__
 from ..misc import IDENTITY_MATRIX_3X3
-from ..misc import KeyValueMap
 from ..misc import Matrix3x3
 from ..misc import NamedFloatDict
 from ..misc import SolverError
 from .base import SolverBase
+from .typing import ReflectionDict
 
 logger = logging.getLogger(__name__)
 TH_TTH_Q_GEOMETRY = "TH TTH Q"
@@ -84,7 +84,7 @@ class ThTthSolver(SolverBase):
         self._reflections = []
         self._wavelength = None
 
-    def addReflection(self, value: KeyValueMap) -> None:
+    def addReflection(self, value: ReflectionDict) -> None:
         """Add coordinates of a diffraction condition (a reflection)."""
         if not isinstance(value, dict):
             raise TypeError(f"Must supply SolverReflection (dict), received {value!r}")
@@ -99,7 +99,7 @@ class ThTthSolver(SolverBase):
             )
         self.wavelength = wavelengths[0]
 
-    def calculate_UB(self, r1: KeyValueMap, r2: KeyValueMap) -> Matrix3x3:
+    def calculate_UB(self, r1: ReflectionDict, r2: ReflectionDict) -> Matrix3x3:
         return IDENTITY_MATRIX_3X3
 
     @property
@@ -161,7 +161,7 @@ class ThTthSolver(SolverBase):
         axes = {TH_TTH_Q_GEOMETRY: "th tth".split()}
         return axes.get(self.geometry, [])
 
-    def refineLattice(self, reflections: list[KeyValueMap]) -> NamedFloatDict:
+    def refineLattice(self, reflections: list[ReflectionDict]) -> NamedFloatDict:
         """No lattice refinement in this |solver|."""
         return None
 

--- a/src/hklpy2/backends/typing.py
+++ b/src/hklpy2/backends/typing.py
@@ -1,0 +1,114 @@
+"""
+Typed dictionary structures shared across all solver backends.
+
+Replaces the broad ``KeyValueMap = Mapping[str, Any]`` alias at call-sites
+where the dict structure is well-known and fixed, enabling static type
+checking and serving as inline documentation of expected dict shapes.
+
+Solver-specific metadata extensions (e.g. ``HklSolverMetadataDict``) belong
+in their respective solver modules, not here.  To add bespoke metadata keys
+for a new solver, subclass :class:`SolverMetadataDict` with ``total=False``
+and place the subclass in that solver's module.
+
+Structures that belong above the backends layer live in
+:mod:`hklpy2.typing` (e.g. ``ConfigHeaderDict``).
+
+.. autosummary::
+
+    ~ReflectionDict
+    ~SampleDict
+    ~SolverMetadataDict
+"""
+
+from typing import Dict
+from typing import List
+from typing import TypedDict
+
+__all__ = [
+    "ReflectionDict",
+    "SampleDict",
+    "SolverMetadataDict",
+]
+
+
+class ReflectionDict(TypedDict):
+    """
+    Typed structure for a single diffraction reflection.
+
+    Keys
+    ----
+    name : str
+        Label for this reflection (e.g. ``"r1"``).
+    pseudos : Dict[str, float]
+        Pseudo-axis values at this reflection, keyed by pseudo axis name
+        (e.g. ``{"h": 1.0, "k": 0.0, "l": 0.0}``).
+    reals : Dict[str, float]
+        Real-axis values at this reflection, keyed by solver axis name
+        (e.g. ``{"omega": 10.0, "chi": 0.0, "phi": 0.0, "tth": 20.0}``).
+    wavelength : float
+        Incident wavelength (Å) used when the reflection was measured.
+    """
+
+    name: str
+    pseudos: Dict[str, float]
+    reals: Dict[str, float]
+    wavelength: float
+
+
+class SampleDict(TypedDict):
+    """
+    Typed structure for a crystalline sample.
+
+    Keys
+    ----
+    name : str
+        Human-readable label for the sample.
+    lattice : Dict[str, float]
+        Unit-cell parameters ``{"a", "b", "c", "alpha", "beta", "gamma"}``.
+    reflections : Dict[str, ReflectionDict]
+        Mapping of reflection name → :class:`ReflectionDict`.
+    order : List[str]
+        Reflection names in the order they should be added to the solver
+        (controls which two are used for UB calculation).
+    """
+
+    name: str
+    lattice: Dict[str, float]
+    reflections: Dict[str, "ReflectionDict"]
+    order: List[str]
+
+
+class SolverMetadataDict(TypedDict):
+    """
+    Typed structure for the **common** solver summary metadata.
+
+    Returned by :attr:`~hklpy2.backends.base.SolverBase._metadata` and
+    stored under the ``"solver"`` key in the configuration dictionary.
+
+    This class defines only the keys that every solver is required to
+    provide.  Solver-specific extra fields should be added by subclassing
+    with ``total=False`` in the solver's own module.  Example::
+
+        # in backends/hkl_soleil.py
+        class HklSolverMetadataDict(SolverMetadataDict, total=False):
+            engine: str
+
+    Keys
+    ----
+    name : str
+        Solver name (e.g. ``"no_op"``, ``"hkl_soleil"``).
+    description : str
+        Human-readable repr string.
+    geometry : str
+        Selected geometry name (e.g. ``"E4CV"``).
+    real_axes : List[str]
+        Ordered list of real axis names.
+    version : str
+        Version string for the solver library.
+    """
+
+    name: str
+    description: str
+    geometry: str
+    real_axes: List[str]
+    version: str

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -18,6 +18,7 @@ from typing import Optional
 from typing import Union
 
 from .backends.base import SolverBase
+from .typing import ConfigHeaderDict
 from .blocks.configure import Configuration
 from .blocks.constraints import RealAxisConstraints
 from .blocks.lattice import Lattice
@@ -130,12 +131,13 @@ class Core:
         """Describe the diffractometer as a dictionary."""
         from .__init__ import __version__
 
+        header: ConfigHeaderDict = {
+            "datetime": str(datetime.datetime.now()),
+            "hklpy2_version": __version__,
+            "python_class": self.diffractometer.__class__.__name__,
+        }
         config = {
-            "_header": {
-                "datetime": str(datetime.datetime.now()),
-                "hklpy2_version": __version__,
-                "python_class": self.diffractometer.__class__.__name__,
-            },
+            "_header": header,
             "name": self.diffractometer.name,
             "axes": {
                 "pseudo_axes": self.diffractometer.pseudo_axis_names,
@@ -151,9 +153,6 @@ class Core:
             "beam": self.diffractometer.beam._asdict(),
             "presets": self._mode_presets,
         }
-
-        if "engine_name" in dir(self.solver):
-            config["solver"]["engine"] = self.solver.engine_name
 
         return config
 

--- a/src/hklpy2/tests/test_typing.py
+++ b/src/hklpy2/tests/test_typing.py
@@ -1,0 +1,73 @@
+"""Tests for hklpy2/typing.py TypedDict structures."""
+
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ..typing import ConfigHeaderDict
+
+
+# ---------------------------------------------------------------------------
+# ConfigHeaderDict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                header=ConfigHeaderDict(
+                    datetime="2026-04-03T12:00:00",
+                    hklpy2_version="1.0.0",
+                    python_class="MyDiffractometer",
+                )
+            ),
+            does_not_raise(),
+            id="valid ConfigHeaderDict",
+        ),
+        pytest.param(
+            dict(
+                header=ConfigHeaderDict(
+                    datetime="2025-01-01T00:00:00",
+                    hklpy2_version="0.9.0",
+                    python_class="DiffractometerBase",
+                )
+            ),
+            does_not_raise(),
+            id="valid ConfigHeaderDict alternate values",
+        ),
+    ],
+)
+def test_config_header_dict_construct(parms, context):
+    """ConfigHeaderDict can be constructed and accessed like a plain dict."""
+    with context:
+        header = parms["header"]
+        assert isinstance(header, dict)
+        assert isinstance(header["datetime"], str)
+        assert isinstance(header["hklpy2_version"], str)
+        assert isinstance(header["python_class"], str)
+
+
+# ---------------------------------------------------------------------------
+# Package-level import
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(name="ConfigHeaderDict"),
+            does_not_raise(),
+            id="ConfigHeaderDict importable from hklpy2",
+        ),
+    ],
+)
+def test_public_exports(parms, context):
+    """ConfigHeaderDict is available from the top-level hklpy2 package."""
+    with context:
+        import hklpy2
+
+        obj = getattr(hklpy2, parms["name"])
+        assert obj is not None

--- a/src/hklpy2/typing.py
+++ b/src/hklpy2/typing.py
@@ -1,0 +1,46 @@
+"""
+Package-level typed dictionary structures for |hklpy2|.
+
+This module is the future consolidation point for all type aliases and
+``TypedDict`` subclasses currently scattered across the codebase (see
+:issue:`252` for the full ``misc.py`` migration plan).
+
+At present it holds structures that belong above the backends layer:
+
+.. autosummary::
+
+    ~ConfigHeaderDict
+
+Solver-internal typed structures (``ReflectionDict``, ``SampleDict``,
+``SolverMetadataDict``) live in :mod:`hklpy2.backends.typing`.
+Solver-specific metadata extensions (e.g. ``HklSolverMetadataDict``) live
+in the solver's own module (e.g. :mod:`hklpy2.backends.hkl_soleil`).
+"""
+
+from typing import TypedDict
+
+__all__ = [
+    "ConfigHeaderDict",
+]
+
+
+class ConfigHeaderDict(TypedDict):
+    """
+    Typed structure for the configuration ``_header`` block.
+
+    Written by :meth:`~hklpy2.ops.Core._asdict` to record provenance
+    information alongside saved diffractometer configurations.
+
+    Keys
+    ----
+    datetime : str
+        ISO-8601 timestamp when the configuration was saved.
+    hklpy2_version : str
+        Version of |hklpy2| used to write the configuration.
+    python_class : str
+        ``__class__.__name__`` of the diffractometer.
+    """
+
+    datetime: str
+    hklpy2_version: str
+    python_class: str


### PR DESCRIPTION
- closes #233

## Summary

- Add `ReflectionDict`, `SampleDict`, `SolverMetadataDict` to `backends/typing.py` — typed dict structures shared across all solver backends, replacing the broad `KeyValueMap = Mapping[str, Any]` annotation at every call-site where the dict shape is well-known and fixed.
- Add `ConfigHeaderDict` to `hklpy2/typing.py` (new package-level module, the future home for type-alias consolidation per #252) — describes the `_header` provenance block written by `Core._asdict()`.
- Add `HklSolverMetadataDict` to `hkl_soleil.py` — extends `SolverMetadataDict` with the hkl-soleil-specific `engine` key, and serves as the pattern for solver-specific metadata extensions (kept in the solver's own module, not in the shared typing module).
- Update all `isinstance`/`istype` runtime checks that previously tested against `KeyValueMap` to use `isinstance(value, dict)`.
- Remove the `ops.py` engine-injection hack (`if "engine_name" in dir(self.solver): config["solver"]["engine"] = ...`); each solver's `_metadata` property now owns its own shape.
- Open follow-on issue #252 for migrating the remaining type aliases from `misc.py` into `hklpy2/typing.py`.

## Test coverage

- New `src/hklpy2/backends/tests/test_typing.py` — 100% coverage of `backends/typing.py`
- New `src/hklpy2/tests/test_typing.py` — 100% coverage of `hklpy2/typing.py`
- `HklSolverMetadataDict` tests added to `backends/tests/test_hkl_soleil.py` (static construction + live `solver._metadata`)
- 905 tests pass, 7 skipped

Agent: OpenCode (claudesonnet46)