### PR TITLE
maint #247 clarify standardize_pseudos/reals layering; remove redundant pre-normalisation

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -98,6 +98,12 @@ describe future plans.
 
     * Add ``re.escape()`` to all ``pytest.raises(match=...)`` calls that were
       using raw strings. (:issue:`232`)
+    * Clarify the complementary roles of ``standardize_pseudos`` /
+      ``standardize_reals`` (solver/Core layer, returns ``AxesDict``) vs. the
+      ophyd ``@pseudo_position_argument`` / ``@real_position_argument``
+      decorators (diffractometer layer, returns namedtuple); remove three
+      redundant pre-normalisation calls in ``diffract.py`` where the ophyd
+      decorator already handles flexible input. (:issue:`247`)
     * Fix type annotations: ``*reals`` in :func:`~hklpy2.user.setor` from
       ``AnyAxesType`` to ``NUMERIC``; ``**kwargs`` in
       :func:`~hklpy2.misc.dict_device_factory` from ``KeyValueMap`` to ``Any``;

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -458,7 +458,9 @@ class DiffractometerBase(PseudoPositioner):
         """
         self.core.extras = extras  # before forward()
         self.core.update_solver()
-        solution = self.forward(self.core.standardize_pseudos(pseudos))
+        # forward() is decorated with @pseudo_position_argument, which already
+        # normalises dict/list/tuple/namedtuple input; no pre-conversion needed.
+        solution = self.forward(pseudos)
         yield from self.move_dict(solution)
 
     @plan
@@ -482,14 +484,18 @@ class DiffractometerBase(PseudoPositioner):
         """
         self.core.extras = extras
         self.core.update_solver()
-        pseudos = self.inverse(self.core.standardize_reals(reals))
+        # inverse() is decorated with @real_position_argument, which already
+        # normalises dict/list/tuple/namedtuple input; no pre-conversion needed.
+        pseudos = self.inverse(reals)
         yield from self.move_dict(pseudos)
 
     @real_position_argument
     def move_reals(self, reals: AnyAxesType) -> None:
         """(not a plan) Move the real-space axes as specified in 'real_positions'."""
-        reals = self.core.standardize_reals(reals)
-        for axis_name, position in reals.items():
+        # @real_position_argument has already converted reals to a RealPosition
+        # namedtuple; use ._asdict() directly rather than re-normalising via
+        # standardize_reals().
+        for axis_name, position in reals._asdict().items():
             hkl_axis = getattr(self, axis_name)
             hkl_axis.move(position)
 

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -1046,8 +1046,21 @@ class Core:
 
         * dict: {"h": 0, "k": 1, "l": -1}
         * namedtuple: (h=0.0, k=1.0, l=-1.0)
+        * numpy array: numpy.array([0, 1, -1])
         * ordered list: [0, 1, -1]  (for h, k, l)
         * ordered tuple: (0, 1, -1)  (for h, k, l)
+
+        .. note::
+
+            This method operates at the **solver / Core layer** and returns an
+            ordered :obj:`~hklpy2.typing.AxesDict` keyed by solver axis names.
+            It is complementary to — not a replacement for — the ophyd
+            ``@pseudo_position_argument`` decorator used on
+            :meth:`~hklpy2.diffract.Diffractometer.forward`.  That decorator
+            normalises flexible user input into an ophyd ``PseudoPosition``
+            namedtuple at the *diffractometer* layer; this method converts any
+            of those forms (plus numpy arrays) into the ``AxesDict`` that the
+            solver expects.
         """
         return axes_to_dict(pseudos, self.local_pseudo_axes)
 
@@ -1057,11 +1070,25 @@ class Core:
 
         User could provide reals in several forms:
 
-        * None: current positions
+        * None: current positions (read from the diffractometer)
         * dict: {"omega": 120, "chi": 35.3, "phi": 45, "tth": -120}
         * namedtuple: (omega=120, chi=35.3, phi=45, tth=-120)
+        * numpy array: numpy.array([120, 35.3, 45, -120])
         * ordered list: [120, 35.3, 45, -120]  (for omega, chi, phi, tth)
         * ordered tuple: (120, 35.3, 45, -120)  (for omega, chi, phi, tth)
+
+        .. note::
+
+            This method operates at the **solver / Core layer** and returns an
+            ordered :obj:`~hklpy2.typing.AxesDict` keyed by solver axis names.
+            It is complementary to — not a replacement for — the ophyd
+            ``@real_position_argument`` decorator used on
+            :meth:`~hklpy2.diffract.Diffractometer.inverse` and
+            :meth:`~hklpy2.diffract.Diffractometer.move_reals`.  That decorator
+            normalises flexible user input into an ophyd ``RealPosition``
+            namedtuple at the *diffractometer* layer; this method converts any
+            of those forms (plus ``None`` and numpy arrays) into the
+            ``AxesDict`` that the solver expects.
         """
 
         if reals is None:  # write ordered dict


### PR DESCRIPTION
- closes #247

## Summary

- Expanded docstrings on `Core.standardize_pseudos()` and `Core.standardize_reals()` to explicitly document the two-layer design: the ophyd `@pseudo_position_argument` / `@real_position_argument` decorators normalise at the *diffractometer* layer (returning ophyd namedtuples); `standardize_*` normalise at the *solver/Core* layer (returning `AxesDict`). They are complementary, not duplicates.
- Removed three redundant pre-normalisation calls in `diffract.py` where the ophyd decorator on the called method already handles flexible input: `move_forward_with_extras()`, `move_inverse_with_extras()`, and `move_reals()`.
- In `move_reals()`, replaced the `standardize_reals()` call with `._asdict()` directly, since `@real_position_argument` guarantees a `RealPosition` namedtuple on entry.

All 931 tests pass; pre-commit clean.

Agent: OpenCode (claudesonnet46)