### PR TITLE
maint #260 review TODO & FIXME markers

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,6 +35,12 @@ describe future plans.
 
     Release expected by 2026-H1.
 
+    Maintenance
+    -----------
+
+    * Review TODO & FIXME markers: remove resolved comments, open new issues
+      for remaining concerns. (:issue:`260`)
+
 0.4.1
 #####
 

--- a/src/hklpy2/blocks/configure.py
+++ b/src/hklpy2/blocks/configure.py
@@ -5,12 +5,6 @@ Export and restore sample UB matrix and other diffractometer configuration.
 
     ~Configuration
 
-From **hklpy**, these TODO items:
-
-- bluesky runs support
-- stack support
-- set constraints
-
 .. seealso:: # https://pyyaml.org/wiki/PyYAMLDocumentation
 """
 

--- a/src/hklpy2/tests/test_i240.py
+++ b/src/hklpy2/tests/test_i240.py
@@ -134,7 +134,7 @@ def test_i240_hkl_soleil():
     solver.addReflection(r2)
 
     # Calculate UB matrix with original lattice
-    ub_original = solver.calculate_UB(r1, r2)  # TODO confirm
+    ub_original = solver.calculate_UB(r1, r2)
     assert np.isclose(
         np.linalg.norm(ub_original),
         2 * np.pi * np.sqrt(3) / SAMPLE_LATTICE_ORIGINAL,

--- a/src/hklpy2/tests/test_misc.py
+++ b/src/hklpy2/tests/test_misc.py
@@ -454,7 +454,7 @@ def test_ConfigurationRunWrapper(devices, context, enabled):
 def test_list_orientation_runs(devices, cat, RE):
     det = signal
     device_names = [d.name for d in devices]
-    crw = ConfigurationRunWrapper(*devices)  # TODO: #34 decorator
+    crw = ConfigurationRunWrapper(*devices)
     RE.preprocessors.append(crw.wrapper)
 
     def scans():


### PR DESCRIPTION
- closes #260

## Summary

- [x] Remove three resolved TODO comments from source and test files.
- [x] Remove stale TODO list from `configure.py` module docstring (items already implemented or tracked separately).
- [x] Open 10 new issues for remaining unresolved TODOs (see #260 comment for full table).
- [x] Update `RELEASE_NOTES.rst`.

Agent: OpenCode (claudesonnet46)