### PR TITLE
test: add reflection comparison assertions in restore test

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -38,6 +38,8 @@ describe future plans.
     Maintenance
     -----------
 
+    * Add reflection comparison assertions (pseudo, real, wavelength) in
+      ``test_configure.py`` restore test. (:issue:`270`)
     * Address CodeQL findings:
 
       - Unused local variables: ``lattice.py``, ``test_lattice.py``;

--- a/src/hklpy2/blocks/tests/test_configure.py
+++ b/src/hklpy2/blocks/tests/test_configure.py
@@ -223,9 +223,25 @@ def test_fromdict():
     )
 
     assert len(fourc.sample.reflections) == 3
-    for refl in fourc.sample.reflections.order:
-        assert refl in fourc.sample.reflections
-    # TODO: compare reflections
+    sample_cfg = config["samples"][config["sample_name"]]
+    for refl_name in fourc.sample.reflections.order:
+        assert refl_name in fourc.sample.reflections
+        refl = fourc.sample.reflections[refl_name]
+        cfg_refl = sample_cfg["reflections"][refl_name]
+        # Compare pseudo positions.
+        for axis, value in cfg_refl["pseudos"].items():
+            assert refl.pseudos[axis] == pytest.approx(value), (
+                f"{refl_name=!r} pseudo {axis=!r}: {refl.pseudos[axis]=} != {value=}"
+            )
+        # Compare real positions.
+        for axis, value in cfg_refl["reals"].items():
+            assert refl.reals[axis] == pytest.approx(value), (
+                f"{refl_name=!r} real {axis=!r}: {refl.reals[axis]=} != {value=}"
+            )
+        # Compare wavelength.
+        assert refl.wavelength == pytest.approx(cfg_refl["wavelength"]), (
+            f"{refl_name=!r} {refl.wavelength=} != {cfg_refl['wavelength']=}"
+        )
 
     assert len(fourc.core.constraints) == len(config["constraints"])
     for key, constraint in fourc.core.constraints.items():


### PR DESCRIPTION
- closes #270

After restoring a configuration, the test previously only checked the number and names of reflections. This PR adds assertions comparing each reflection's pseudo positions, real positions, and wavelength against the original `config` dict, and removes the `# TODO: compare reflections` comment.

Agent: OpenCode (claudesonnet46)