### PR TITLE
docs: document constraint internals and clarify cut-point distinction

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,6 +35,14 @@ describe future plans.
 
     Release expected by 2026-H1.
 
+    Documentation
+    -------------
+
+    * Document ``ConstraintBase.valid()`` internals, the ``forward()`` call
+      sequence, and the ``LimitsConstraint`` label requirement; clarify that
+      hklpy2 constraints are post-computation filters distinct from SPEC/diffcalc
+      cut points. (:issue:`275`)
+
 0.4.3
 #####
 

--- a/docs/source/concepts/constraints.rst
+++ b/docs/source/concepts/constraints.rst
@@ -17,8 +17,16 @@ of operating **mode**, narrow those candidates by:
 * Accepting only solutions where each real axis falls within a specified range.
 
 .. index:: cut points
-.. tip:: *Constraints* are implemented as *cut points* in other software.
-   Similar in concept yet not entirely identical in implementation.
+.. note:: **Relation to** *cut points* **in other software** (SPEC ``cuts``,
+   diffcalc): In SPEC, a *cut point* is a branch point that sets where an
+   angle wraps around — for example, a cut point of ``-180`` means the motor
+   is represented in the interval ``[-180, +180)``.  Its primary purpose is
+   controlling motor travel direction and angle representation, not filtering
+   solutions.  hklpy2 ``LimitsConstraint`` is a *post-computation filter*: it
+   discards solver solutions whose axis values fall outside a given range.
+   The two concepts overlap in effect when the constraint window matches the
+   cut-point interval, but they are not the same mechanism.  See
+   :ref:`spec_commands_map` for the SPEC-to-hklpy2 mapping.
 
 .. tip:: Constraints act *after* the solver computes solutions.  If you want
    the solver to *assume* a specific value for a constant axis *before*
@@ -34,3 +42,124 @@ Many of the :ref:`examples` show how to adjust :ref:`constraints <examples.const
    ``forward()`` computation.
 
    :ref:`glossary`
+
+.. _concepts.constraints.internals:
+
+How Constraints Work Internally
+================================
+
+.. _concepts.constraints.valid:
+
+The ``valid()`` Method
+-----------------------
+
+Every constraint class inherits from
+:class:`~hklpy2.blocks.constraints.ConstraintBase` and must implement the
+abstract method :meth:`~hklpy2.blocks.constraints.ConstraintBase.valid`.
+
+.. code-block:: python
+
+   def valid(self, **values: dict) -> bool:
+       ...
+
+The method receives the **full set of real-axis positions** (as keyword
+arguments, ``axis_name=value``) and returns ``True`` when the constraint is
+satisfied or ``False`` when it is not.
+
+The built-in implementation,
+:class:`~hklpy2.blocks.constraints.LimitsConstraint`, checks whether the
+axis value falls within the configured ``[low_limit, high_limit]`` range:
+
+.. code-block:: python
+
+   # simplified from hklpy2/blocks/constraints.py
+   def valid(self, **values):
+       value = values[self.label]
+       return (
+           (value + ENDPOINT_TOLERANCE) >= self.low_limit
+           and (value - ENDPOINT_TOLERANCE) <= self.high_limit
+       )
+
+A small tolerance (``ENDPOINT_TOLERANCE = 1e-4``) is applied at each
+endpoint so that solver solutions that land exactly on a limit boundary
+are not rejected due to floating-point rounding.
+
+.. _concepts.constraints.forward_call:
+
+How ``valid()`` Is Called During ``forward()``
+----------------------------------------------
+
+After the solver returns its candidate solutions,
+:meth:`~hklpy2.ops.Core.forward` iterates over every solution and calls
+:meth:`~hklpy2.blocks.constraints.RealAxisConstraints.valid` on the
+collection of constraints:
+
+.. code-block:: python
+
+   # simplified from hklpy2/ops.py  Core.forward()
+   for solution in self.solver.forward(pseudos):
+       reals = {axis: <computed_value>, ...}   # full set of real-axis values
+       if self.constraints.valid(**reals):
+           solutions.append(reals)             # solution passes all constraints
+       # solutions that fail are discarded (and logged at INFO level)
+
+:meth:`~hklpy2.blocks.constraints.RealAxisConstraints.valid` in turn calls
+:meth:`~hklpy2.blocks.constraints.LimitsConstraint.valid` on each individual
+constraint and returns ``True`` only when **all** constraints are satisfied.
+Solutions that fail at least one constraint are silently discarded; the
+reasons are recorded at the ``logging.INFO`` level.
+
+.. seealso::
+
+   :ref:`concepts.presets` — supply a fixed value for a constant axis
+   *before* the solver runs, rather than filtering solutions *after*.
+
+.. _concepts.constraints.label:
+
+The ``LimitsConstraint`` Label
+-------------------------------
+
+The ``label`` attribute of a
+:class:`~hklpy2.blocks.constraints.LimitsConstraint` **must match the real
+axis name** as it appears on the diffractometer.  This is because
+``valid()`` looks up the axis value from the ``**values`` keyword-argument
+dictionary using ``self.label`` as the key:
+
+.. code-block:: python
+
+   # from LimitsConstraint.valid()
+   value = values[self.label]   # KeyError / ConstraintsError if label is wrong
+
+The same name is used as the dictionary key in
+``diffractometer.core.constraints``, which is a
+:class:`~hklpy2.blocks.constraints.RealAxisConstraints` instance (a ``dict``
+subclass):
+
+.. code-block:: python
+
+   diffractometer.core.constraints
+   # {
+   #   "omega": LimitsConstraint(label="omega", ...),
+   #   "chi":   LimitsConstraint(label="chi",   ...),
+   #   "phi":   LimitsConstraint(label="phi",   ...),
+   #   "tth":   LimitsConstraint(label="tth",   ...),
+   # }
+
+Constraints are created automatically for every real axis when the
+diffractometer is initialised (or when
+:meth:`~hklpy2.ops.Core.reset_constraints` is called).  The ``label`` is set
+to the axis name at that point.  You do not normally need to set the label
+manually; if you create a :class:`~hklpy2.blocks.constraints.LimitsConstraint`
+directly you must supply a ``label`` that matches a real axis name, otherwise
+:meth:`~hklpy2.blocks.constraints.LimitsConstraint.valid` will raise a
+:exc:`~hklpy2.misc.ConstraintsError`.
+
+.. rubric:: Example — adjusting a constraint
+
+.. code-block:: python
+
+   # Restrict chi to the range [0, 90] degrees.
+   diffractometer.core.constraints["chi"].limits = (0, 90)
+
+   # Reset all constraints to defaults (±180 degrees).
+   diffractometer.core.reset_constraints()

--- a/docs/source/examples/constraints.rst
+++ b/docs/source/examples/constraints.rst
@@ -7,13 +7,18 @@ Constraints
 :ref:`Constraints <concepts.constraints>` are used to filter
 acceptable solutions computed by a |solver| ``forward()`` method.
 One or more constraints
-(:class:`~hklpy2.blocks.constraints.ConstraintBase`) (a.k.a, cut points),
-together with a choice of operating **mode** are used to control
+(:class:`~hklpy2.blocks.constraints.ConstraintBase`),
+together with a choice of operating **mode**, are used to control
 the over-determined transformation from :math:`hkl` to motor angles.
 
 .. index:: cut points
-.. tip:: *Constraints* are implemented as *cut points* in other software.
-    Similar in concept yet not entirely identical in implementation.
+.. note:: **Relation to** *cut points* **in other software** (SPEC ``cuts``):
+    In SPEC, a *cut point* is a branch point that sets where an angle wraps
+    around (e.g., ``-180`` → ``[-180, +180)``), controlling motor travel
+    direction rather than filtering solutions.  hklpy2 ``LimitsConstraint``
+    is a *post-computation filter* that discards solutions outside a range.
+    The two overlap in effect when the constraint window matches the
+    cut-point interval, but the mechanisms differ.
 
 Show the current constraints
 ----------------------------

--- a/docs/source/guides/spec_xref.rst
+++ b/docs/source/guides/spec_xref.rst
@@ -33,8 +33,8 @@ the tools in Bluesky's |hklpy2| package.
 ``reflex``       :func:`~hklpy2.blocks.sample.Sample.refine_lattice()`          Refinement of lattice parameters from list of 3 or more reflections
 ``reflex_beg``   not necessary                                                  Initializes the reflections file
 ``reflex_end``   not necessary                                                  Closes the reflections file
---               ``diffractometer.core.constraints``                            Show the current set of constraints (cut points).
-``cuts``         See :meth:`~hklpy2.blocks.constraints.LimitsConstraint`        Add constraints to the diffractometer ``forward()`` computation.
+--               ``diffractometer.core.constraints``                            Show the current set of constraints.
+``cuts``         See :meth:`~hklpy2.blocks.constraints.LimitsConstraint`        Set axis range limits (cut points in SPEC set angle wrap; hklpy2 filters ``forward()`` solutions — related but not identical).
 ``freeze``       :ref:`presets <how_presets>`                                   Hold an axis constant during the diffractometer ``forward()`` computation.
 ``unfreeze``     :ref:`presets <how_presets.pop>`                               Remove a preset constant value for an axis.
 --               :func:`~hklpy2.user.calc_UB`                                   Compute the UB matrix with two reflections.

--- a/src/hklpy2/blocks/constraints.py
+++ b/src/hklpy2/blocks/constraints.py
@@ -2,8 +2,8 @@
 Limitations on acceptable positions for computed 'forward()' solutions.
 
 Computation of the real-space axis positions given a set of reciprocal-space
-coordinates can have many solutions. One or more constraints (Constraint)
-(a.k.a, cut points), together with a choice of operating *mode*, can:
+coordinates can have many solutions. One or more constraints (Constraint),
+together with a choice of operating *mode*, can:
 
 * Limit the range of ``forward()`` solutions accepted for that positioner.
 * Declare the value to use when the positioner should be kept constant. (not


### PR DESCRIPTION
- closes #275

## Summary

- Expands `docs/source/concepts/constraints.rst` with a new **How Constraints
  Work Internally** section covering:
  - How `ConstraintBase.valid()` is defined (abstract, receives full real-axis
    positions as `**kwargs`, returns `bool`)
  - How `valid()` is called during `forward()` — the per-solution filter loop
    in `Core.forward()`, including the `logging.INFO` discard messages
  - Why `LimitsConstraint.label` must match the real axis name and is the same
    key used in `diffractometer.core.constraints`
  - A `.. seealso::` cross-reference to `concepts.presets` at the point where
    the before/after distinction is most relevant

- Corrects the misleading *"constraints are implemented as cut points in other
  software"* tip in `concepts/constraints.rst`, `examples/constraints.rst`,
  the `constraints.py` module docstring, and `guides/spec_xref.rst`.
  SPEC/diffcalc cut points are *branch-cut / angle-wrapping* tools that
  control motor travel direction; hklpy2 `LimitsConstraint` is a
  *post-computation solution filter*.  The corrected note explains both
  the overlap and the distinction.  A new issue (#296) has been opened to
  track adding a proper cut-point feature.

Agent: OpenCode (claudesonnet46)