### PR TITLE
feat: add GeometryDescriptor and SolverBase geometry registry (Phase 1)

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -167,7 +167,7 @@ jobs:
           # combine and report
           python -m coverage combine || true
           python -m coverage xml -i -o coverage.xml || true
-          python -m coverage report --precision 3 -m || true
+          python -m coverage report --precision 3 -m
 
           # check junit for failures
           if [ -f reports/junit.xml ]; then

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -69,6 +69,7 @@ jobs:
     name: Python ${{ matrix.python-version }}
     needs: lint
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
         python-version:
@@ -76,7 +77,10 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          # - "3.14"  # not installable because it requires python_rc =* *, which does not exist
+        include:
+          # 3.14-dev: tracked for early warning; allowed to fail.
+          - python-version: "3.14"
+            experimental: true
       max-parallel: 5
 
     steps:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,6 +35,20 @@ describe future plans.
 
     Release expected by 2026-H1.
 
+    New Features
+    ------------
+
+    * Add ``GeometryDescriptor`` dataclass to ``hklpy2.backends.typing``:
+      decouples geometry identity (axis names, modes, description) from the
+      solver backend that implements the mathematics. (:issue:`293`)
+    * Add ``SolverBase._geometry_registry`` and ``SolverBase.register_geometry()``
+      so solver subclasses can register geometries dynamically at runtime,
+      enabling user-defined and ad-hoc diffractometer geometries. (:issue:`292`)
+    * Refactor ``ThTthSolver`` to use the new registry: ``geometries()``,
+      ``pseudo_axis_names``, ``real_axis_names``, ``modes``, and
+      ``extra_axis_names`` are all driven by registered ``GeometryDescriptor``
+      objects instead of hard-coded string dispatch. (:issue:`292`, :issue:`293`)
+
     Documentation
     -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,16 @@ force_single_line = true
 line_length = 115
 src_paths = ["."]
 
+[tool.coverage.report]
+fail_under = 100
+# Exclude lines that are genuinely untestable or unreachable in the test
+# environment (e.g. abstract-method stubs, TYPE_CHECKING guards).
+exclude_also = [
+    "^\\s*@(abc\\.)?abstractmethod",
+    "^\\s*if TYPE_CHECKING:",
+    "^\\s*\\.\\.\\.\\s*$",
+]
+
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]
 # filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,14 @@ force_single_line = true
 line_length = 115
 src_paths = ["."]
 
+[tool.coverage.run]
+# Do not measure coverage of the test files themselves; only measure
+# production code under src/hklpy2 (excluding the tests/ subdirectories).
+omit = [
+    "*/tests/*",
+    "*/tests/**",
+]
+
 [tool.coverage.report]
 fail_under = 100
 # Exclude lines that are genuinely untestable or unreachable in the test

--- a/src/hklpy2/backends/__init__.py
+++ b/src/hklpy2/backends/__init__.py
@@ -16,6 +16,7 @@ See the API documentation for details.
 """
 
 from .base import SolverBase  # noqa: F401
+from .typing import GeometryDescriptor  # noqa: F401
 from .typing import ReflectionDict  # noqa: F401
 from .typing import SampleDict  # noqa: F401
 from .typing import SolverMetadataDict  # noqa: F401

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -10,6 +10,7 @@ import logging
 from abc import ABC
 from abc import abstractmethod
 from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
@@ -24,6 +25,7 @@ from ..misc import validate_and_canonical_unit
 from ..typing import KeyValueMap
 from ..typing import Matrix3x3
 from ..typing import NamedFloatDict
+from .typing import GeometryDescriptor
 from .typing import ReflectionDict
 from .typing import SampleDict
 from .typing import SolverMetadataDict
@@ -80,6 +82,13 @@ class SolverBase(ABC):
         ~refineLattice
         ~removeAllReflections
 
+    .. rubric:: Geometry Registry
+
+    .. autosummary::
+
+        ~_geometry_registry
+        ~register_geometry
+
     .. rubric:: Python Properties
 
     .. autosummary::
@@ -117,6 +126,63 @@ class SolverBase(ABC):
     Solver can override this **constant**.  Must be convertible to
     ``INTERNAL_LENGTH_UNITS``.
     """
+
+    _geometry_registry: Dict[str, GeometryDescriptor] = {}
+    """
+    Per-class registry of :class:`~hklpy2.backends.typing.GeometryDescriptor`
+    objects, keyed by geometry name.
+
+    Each concrete solver subclass owns an **independent** registry — populated
+    either at class-definition time (via :meth:`register_geometry`) or
+    dynamically at runtime.  The base-class dict is intentionally empty; do
+    not write to it directly.
+
+    .. note::
+        Subclasses must define their own ``_geometry_registry = {}`` class
+        variable to avoid sharing the base-class dict across siblings.
+    """
+
+    @classmethod
+    def register_geometry(cls, descriptor: GeometryDescriptor) -> None:
+        """
+        Add or replace a geometry in this solver's registry.
+
+        Registers *descriptor* under ``descriptor.name`` in
+        :attr:`_geometry_registry`.  Calling this method on a subclass
+        affects only that subclass's registry, not the base class or any
+        sibling solver.
+
+        Parameters
+        ----------
+        descriptor : GeometryDescriptor
+            The geometry to register.  The :attr:`~GeometryDescriptor.name`
+            attribute is used as the registry key.
+
+        Raises
+        ------
+        TypeError
+            If *descriptor* is not a :class:`~hklpy2.backends.typing.GeometryDescriptor`.
+
+        Examples
+        --------
+        >>> from hklpy2.backends.typing import GeometryDescriptor
+        >>> from hklpy2.backends.th_tth_q import ThTthSolver
+        >>> geo = GeometryDescriptor(
+        ...     name="MY GEO",
+        ...     pseudo_axis_names=["h", "k", "l"],
+        ...     real_axis_names=["mu", "delta", "nu", "eta", "chi", "phi"],
+        ...     modes=["lifting detector"],
+        ... )
+        >>> ThTthSolver.register_geometry(geo)
+        >>> "MY GEO" in ThTthSolver.geometries()
+        True
+        """
+        if not isinstance(descriptor, GeometryDescriptor):
+            raise TypeError(
+                f"Expected GeometryDescriptor, received {type(descriptor)!r}."
+            )
+        cls._geometry_registry[descriptor.name] = descriptor
+        logger.debug("Registered geometry %r on %s", descriptor.name, cls.__name__)
 
     def __init__(
         self,
@@ -210,7 +276,12 @@ class SolverBase(ABC):
     @abstractmethod
     def geometries(cls) -> List[str]:
         """
-        Ordered list of the geometry names.
+        Ordered list of the geometry names supported by this solver.
+
+        Implementations that use the :attr:`_geometry_registry` should return
+        ``sorted(cls._geometry_registry.keys())``.  Solvers backed by an
+        external library (e.g. :class:`~hklpy2.backends.hkl_soleil.HklSolver`)
+        may query that library's own registry instead.
 
         EXAMPLES::
 

--- a/src/hklpy2/backends/tests/test_base.py
+++ b/src/hklpy2/backends/tests/test_base.py
@@ -127,6 +127,8 @@ def test_SolverBase():
 
     with pytest.raises(TypeError, match=re.escape("Must supply")):
         solver.sample = 1.0
+    solver.sample = {"name": "si", "lattice": {}, "reflections": {}, "order": []}
+    assert solver.sample is not None
 
 
 def test_SolverBase_abstractmethods():

--- a/src/hklpy2/backends/tests/test_geometry_descriptor.py
+++ b/src/hklpy2/backends/tests/test_geometry_descriptor.py
@@ -1,0 +1,345 @@
+"""Tests for GeometryDescriptor and SolverBase geometry registry."""
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ..base import SolverBase
+from ..th_tth_q import TH_TTH_Q_GEOMETRY
+from ..th_tth_q import ThTthSolver
+from ..typing import GeometryDescriptor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_descriptor(name="MY GEO", pseudo=None, real=None, modes=None, **kwargs):
+    """Return a minimal GeometryDescriptor for testing."""
+    return GeometryDescriptor(
+        name=name,
+        pseudo_axis_names=pseudo or ["h", "k", "l"],
+        real_axis_names=real or ["mu", "delta"],
+        modes=modes or ["mode_a"],
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GeometryDescriptor construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                name="TH TTH Q",
+                pseudo_axis_names=["q"],
+                real_axis_names=["th", "tth"],
+                modes=["bissector"],
+                default_mode="bissector",
+                description="theta/two-theta",
+            ),
+            does_not_raise(),
+            id="full specification",
+        ),
+        pytest.param(
+            dict(
+                name="MINIMAL",
+                pseudo_axis_names=["h"],
+                real_axis_names=["omega"],
+                modes=[],
+            ),
+            does_not_raise(),
+            id="minimal - no modes, no description",
+        ),
+        pytest.param(
+            dict(
+                name="WITH EXTRAS",
+                pseudo_axis_names=["h", "k", "l"],
+                real_axis_names=["omega", "chi", "phi", "tth"],
+                modes=["mode_a", "mode_b"],
+                extra_axis_names={"mode_a": ["psi"], "mode_b": []},
+            ),
+            does_not_raise(),
+            id="with per-mode extra axis names",
+        ),
+    ],
+)
+def test_geometry_descriptor_construction(parms, context):
+    with context:
+        desc = GeometryDescriptor(**parms)
+        assert desc.name == parms["name"]
+        assert desc.pseudo_axis_names == parms["pseudo_axis_names"]
+        assert desc.real_axis_names == parms["real_axis_names"]
+        assert desc.modes == parms["modes"]
+        # defaults
+        assert isinstance(desc.default_mode, str)
+        assert isinstance(desc.description, str)
+        assert isinstance(desc.extra_axis_names, dict)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(name="A", pseudo_axis_names=["q"], real_axis_names=["th"], modes=[]),
+            does_not_raise(),
+            id="extra_axis_names defaults to empty dict",
+        ),
+    ],
+)
+def test_geometry_descriptor_defaults(parms, context):
+    with context:
+        desc = GeometryDescriptor(**parms)
+        assert desc.extra_axis_names == {}
+        assert desc.default_mode == ""
+        assert desc.description == ""
+
+
+# ---------------------------------------------------------------------------
+# GeometryDescriptor instances are independent (mutable default field safety)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(), does_not_raise(), id="extra_axis_names not shared between instances"
+        ),
+    ],
+)
+def test_geometry_descriptor_field_independence(parms, context):
+    with context:
+        desc_a = GeometryDescriptor(
+            name="A", pseudo_axis_names=[], real_axis_names=[], modes=[]
+        )
+        desc_b = GeometryDescriptor(
+            name="B", pseudo_axis_names=[], real_axis_names=[], modes=[]
+        )
+        desc_a.extra_axis_names["mode_x"] = ["psi"]
+        assert "mode_x" not in desc_b.extra_axis_names
+
+
+# ---------------------------------------------------------------------------
+# SolverBase.register_geometry() — using ThTthSolver as the concrete class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(descriptor=_make_descriptor("DYNAMIC GEO")),
+            does_not_raise(),
+            id="register a valid descriptor",
+        ),
+        pytest.param(
+            dict(descriptor="not a descriptor"),
+            pytest.raises(TypeError, match=re.escape("Expected GeometryDescriptor")),
+            id="non-descriptor raises TypeError",
+        ),
+        pytest.param(
+            dict(descriptor=42),
+            pytest.raises(TypeError, match=re.escape("Expected GeometryDescriptor")),
+            id="integer raises TypeError",
+        ),
+    ],
+)
+def test_register_geometry(parms, context):
+    # Use a fresh isolated subclass so tests don't pollute ThTthSolver's registry.
+    class _IsolatedSolver(ThTthSolver):
+        _geometry_registry = {}
+
+    with context:
+        _IsolatedSolver.register_geometry(parms["descriptor"])
+        assert parms["descriptor"].name in _IsolatedSolver._geometry_registry
+        assert parms["descriptor"].name in _IsolatedSolver.geometries()
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(names=["GEO A", "GEO B", "GEO C"]),
+            does_not_raise(),
+            id="geometries() returns sorted list of registered names",
+        ),
+        pytest.param(
+            dict(names=[]),
+            does_not_raise(),
+            id="empty registry returns empty list",
+        ),
+    ],
+)
+def test_geometries_sorted(parms, context):
+    class _IsolatedSolver(ThTthSolver):
+        _geometry_registry = {}
+
+    with context:
+        for name in parms["names"]:
+            _IsolatedSolver.register_geometry(_make_descriptor(name))
+        result = _IsolatedSolver.geometries()
+        assert result == sorted(parms["names"])
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(name="OVERWRITE"),
+            does_not_raise(),
+            id="registering same name overwrites previous entry",
+        ),
+    ],
+)
+def test_register_geometry_overwrite(parms, context):
+    class _IsolatedSolver(ThTthSolver):
+        _geometry_registry = {}
+
+    with context:
+        desc_v1 = _make_descriptor(parms["name"], real=["a"])
+        desc_v2 = _make_descriptor(parms["name"], real=["x", "y"])
+        _IsolatedSolver.register_geometry(desc_v1)
+        _IsolatedSolver.register_geometry(desc_v2)
+        stored = _IsolatedSolver._geometry_registry[parms["name"]]
+        assert stored.real_axis_names == ["x", "y"]
+
+
+# ---------------------------------------------------------------------------
+# Registry isolation: ThTthSolver registry must not pollute SolverBase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(dict(), does_not_raise(), id="base class registry stays empty"),
+    ],
+)
+def test_registry_isolation(parms, context):
+    with context:
+        # SolverBase._geometry_registry should be empty (no geometries registered
+        # directly on the abstract base).
+        assert SolverBase._geometry_registry == {}
+        # ThTthSolver has its own registry with the built-in geometry.
+        assert TH_TTH_Q_GEOMETRY in ThTthSolver._geometry_registry
+        # They must be different objects.
+        assert ThTthSolver._geometry_registry is not SolverBase._geometry_registry
+
+
+# ---------------------------------------------------------------------------
+# ThTthSolver property dispatch via registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(geometry=TH_TTH_Q_GEOMETRY, expected_extras=[]),
+            does_not_raise(),
+            id="built-in geometry: correct axes and modes from descriptor",
+        ),
+        pytest.param(
+            dict(
+                geometry="GEO WITH EXTRAS",
+                extra_axis_names={"mode_a": ["psi", "eta"], "mode_b": ["phi"]},
+                expected_extras=["eta", "phi", "psi"],
+            ),
+            does_not_raise(),
+            id="geometry with per-mode extra axis names: union returned sorted",
+        ),
+    ],
+)
+def test_th_tth_solver_uses_registry(parms, context):
+    class _IsolatedSolver(ThTthSolver):
+        _geometry_registry = {}
+
+    # Pre-populate with the built-in geometry so the TH_TTH_Q case works.
+    _IsolatedSolver.register_geometry(ThTthSolver._geometry_registry[TH_TTH_Q_GEOMETRY])
+
+    if parms["geometry"] != TH_TTH_Q_GEOMETRY:
+        _IsolatedSolver.register_geometry(
+            GeometryDescriptor(
+                name=parms["geometry"],
+                pseudo_axis_names=["h"],
+                real_axis_names=["omega"],
+                modes=list(parms.get("extra_axis_names", {}).keys()),
+                extra_axis_names=parms.get("extra_axis_names", {}),
+            )
+        )
+
+    with context:
+        solver = _IsolatedSolver(parms["geometry"])
+        desc = _IsolatedSolver._geometry_registry[parms["geometry"]]
+        assert solver.pseudo_axis_names == desc.pseudo_axis_names
+        assert solver.real_axis_names == desc.real_axis_names
+        assert solver.modes == desc.modes
+        assert solver.extra_axis_names == parms["expected_extras"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(geometry="UNREGISTERED"),
+            does_not_raise(),
+            id="unregistered geometry: empty axes and modes",
+        ),
+    ],
+)
+def test_th_tth_solver_unregistered_geometry(parms, context):
+    with context:
+        solver = ThTthSolver(parms["geometry"])
+        assert solver.pseudo_axis_names == []
+        assert solver.real_axis_names == []
+        assert solver.modes == []
+        assert solver.extra_axis_names == []
+
+
+# ---------------------------------------------------------------------------
+# Dynamic runtime registration and immediate use
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                name="RUNTIME GEO",
+                pseudo=["h", "k", "l"],
+                real=["mu", "delta", "nu"],
+                modes=["mode_a", "mode_b"],
+                default_mode="mode_a",
+            ),
+            does_not_raise(),
+            id="geometry registered at runtime is immediately usable",
+        ),
+    ],
+)
+def test_dynamic_registration(parms, context):
+    class _IsolatedSolver(ThTthSolver):
+        _geometry_registry = {}
+
+    with context:
+        desc = GeometryDescriptor(
+            name=parms["name"],
+            pseudo_axis_names=parms["pseudo"],
+            real_axis_names=parms["real"],
+            modes=parms["modes"],
+            default_mode=parms["default_mode"],
+        )
+        _IsolatedSolver.register_geometry(desc)
+        assert parms["name"] in _IsolatedSolver.geometries()
+
+        solver = _IsolatedSolver(parms["name"])
+        assert solver.pseudo_axis_names == parms["pseudo"]
+        assert solver.real_axis_names == parms["real"]
+        assert solver.modes == parms["modes"]

--- a/src/hklpy2/backends/th_tth_q.py
+++ b/src/hklpy2/backends/th_tth_q.py
@@ -24,12 +24,22 @@ from ..misc import SolverError
 from ..typing import Matrix3x3
 from ..typing import NamedFloatDict
 from .base import SolverBase
+from .typing import GeometryDescriptor
 from .typing import ReflectionDict
 
 logger = logging.getLogger(__name__)
 TH_TTH_Q_GEOMETRY = "TH TTH Q"
-TH_Q_GEOMETRY = "TH Q"  # TODO: Second geometry?
 BISECTOR_MODE = "bissector"  # spelled same as in E4CV
+
+#: Built-in geometry descriptor for the theta/two-theta/Q geometry.
+_TH_TTH_Q_DESCRIPTOR = GeometryDescriptor(
+    name=TH_TTH_Q_GEOMETRY,
+    pseudo_axis_names=["q"],
+    real_axis_names=["th", "tth"],
+    modes=[BISECTOR_MODE],
+    default_mode=BISECTOR_MODE,
+    description="theta / two-theta powder diffractometer (Q transform)",
+)
 
 
 class ThTthSolver(SolverBase):
@@ -49,6 +59,9 @@ class ThTthSolver(SolverBase):
     reflections must have the same :index:`wavelength`.
 
     No orientation matrix is used in this geometry.
+
+    New geometries can be added at runtime via
+    :meth:`~hklpy2.backends.base.SolverBase.register_geometry`.
 
     .. rubric:: Python Methods
 
@@ -79,10 +92,18 @@ class ThTthSolver(SolverBase):
     name = "th_tth"
     version = __version__
 
+    # Each ThTthSolver subclass (or the class itself) has its own registry,
+    # independent of SolverBase._geometry_registry.
+    _geometry_registry = {}
+
     def __init__(self, geometry: str, **kwargs) -> None:
         super().__init__(geometry, **kwargs)
         self._reflections = []
         self._wavelength = None
+
+    def _descriptor(self) -> GeometryDescriptor:
+        """Return the GeometryDescriptor for the current geometry, or None."""
+        return self._geometry_registry.get(self.geometry)
 
     def addReflection(self, value: ReflectionDict) -> None:
         """Add coordinates of a diffraction condition (a reflection)."""
@@ -104,15 +125,23 @@ class ThTthSolver(SolverBase):
 
     @property
     def extra_axis_names(self) -> List[str]:
-        return []
+        desc = self._descriptor()
+        if desc is None:
+            return []
+        # extra_axis_names is a per-mode dict; return all unique names
+        all_extras: List[str] = []
+        for names in desc.extra_axis_names.values():
+            all_extras += names
+        return sorted(set(all_extras))
 
     def forward(self, pseudos: NamedFloatDict) -> List[NamedFloatDict]:
         """Transform pseudos to list of reals."""
         if not isinstance(pseudos, dict):
             raise TypeError(f"Must supply dict, received {pseudos!r}")
 
+        desc = self._descriptor()
         solutions = []
-        if self.geometry == TH_TTH_Q_GEOMETRY:
+        if desc is not None and self.geometry == TH_TTH_Q_GEOMETRY:
             q = pseudos.get("q")
             if q is None:
                 raise SolverError(f"'q' not defined. Received {pseudos!r}.")
@@ -126,15 +155,17 @@ class ThTthSolver(SolverBase):
 
     @classmethod
     def geometries(cls) -> List[str]:
-        return [TH_TTH_Q_GEOMETRY]  # only one geometry
+        """Sorted list of registered geometry names."""
+        return sorted(cls._geometry_registry.keys())
 
     def inverse(self, reals: NamedFloatDict) -> NamedFloatDict:
         """Transform reals to pseudos."""
         if not isinstance(reals, dict):
             raise TypeError(f"Must supply dict, received {reals!r}")
 
+        desc = self._descriptor()
         pseudos = {}
-        if self.geometry == TH_TTH_Q_GEOMETRY:
+        if desc is not None and self.geometry == TH_TTH_Q_GEOMETRY:
             tth = reals.get("tth")
             if tth is None:
                 raise SolverError(f"'tth' not defined. Received {reals!r}.")
@@ -148,19 +179,24 @@ class ThTthSolver(SolverBase):
 
     @property
     def modes(self) -> List[str]:
-        if self.geometry == TH_TTH_Q_GEOMETRY:
-            return [BISECTOR_MODE]
-        return []
+        desc = self._descriptor()
+        if desc is None:
+            return []
+        return list(desc.modes)
 
     @property
     def pseudo_axis_names(self) -> List[str]:
-        axes = {TH_TTH_Q_GEOMETRY: ["q"]}
-        return axes.get(self.geometry, [])
+        desc = self._descriptor()
+        if desc is None:
+            return []
+        return list(desc.pseudo_axis_names)
 
     @property
     def real_axis_names(self) -> List[str]:
-        axes = {TH_TTH_Q_GEOMETRY: "th tth".split()}
-        return axes.get(self.geometry, [])
+        desc = self._descriptor()
+        if desc is None:
+            return []
+        return list(desc.real_axis_names)
 
     def refineLattice(self, reflections: list[ReflectionDict]) -> NamedFloatDict | None:
         """No lattice refinement in this |solver|."""
@@ -183,3 +219,7 @@ class ThTthSolver(SolverBase):
         if value <= 0:
             raise ValueError(f"Must supply positive number, received {value!r}")
         self._wavelength = value
+
+
+# Register the built-in TH TTH Q geometry at import time.
+ThTthSolver.register_geometry(_TH_TTH_Q_DESCRIPTOR)

--- a/src/hklpy2/backends/typing.py
+++ b/src/hklpy2/backends/typing.py
@@ -15,20 +15,94 @@ Structures that belong above the backends layer live in
 
 .. autosummary::
 
+    ~GeometryDescriptor
     ~ReflectionDict
     ~SampleDict
     ~SolverMetadataDict
 """
 
+from dataclasses import dataclass
+from dataclasses import field
 from typing import Dict
 from typing import List
 from typing import TypedDict
 
 __all__ = [
+    "GeometryDescriptor",
     "ReflectionDict",
     "SampleDict",
     "SolverMetadataDict",
 ]
+
+
+@dataclass
+class GeometryDescriptor:
+    """
+    Describes a diffractometer geometry independently of any solver backend.
+
+    A :class:`GeometryDescriptor` captures the static facts about a geometry —
+    its axis names, available modes, and optional description — decoupled from
+    the solver library that implements the mathematics.  It serves two roles:
+
+    1. **Registry entry** — stored in a solver class's
+       :attr:`~hklpy2.backends.base.SolverBase._geometry_registry` so that
+       :meth:`~hklpy2.backends.base.SolverBase.geometries` can enumerate
+       available geometries without creating a solver instance.
+
+    2. **Dispatch table** — used by pure-Python solvers (e.g.
+       :class:`~hklpy2.backends.th_tth_q.ThTthSolver`) to look up axis lists
+       and modes by geometry name, replacing hard-coded ``if self.geometry ==
+       ...`` branching in every property.
+
+    Parameters
+    ----------
+    name : str
+        Canonical geometry name, e.g. ``"TH TTH Q"`` or ``"E4CV"``.  Used as
+        the dictionary key in the registry and must match the string passed to
+        the solver's constructor.
+    pseudo_axis_names : list of str
+        Ordered pseudo-axis names, e.g. ``["h", "k", "l"]`` or ``["q"]``.
+        Order is significant — solvers must not sort this list.
+    real_axis_names : list of str
+        Ordered real-axis names, e.g. ``["omega", "chi", "phi", "tth"]`` or
+        ``["th", "tth"]``.  Order is significant — solvers must not sort.
+    modes : list of str
+        All valid operating mode names for this geometry.
+    default_mode : str
+        Mode to use when ``mode=""`` is requested.  Must be one of
+        :attr:`modes` or ``""`` (meaning the solver chooses).
+    description : str
+        Optional human-readable description of this geometry.
+
+    Examples
+    --------
+    >>> from hklpy2.backends.typing import GeometryDescriptor
+    >>> geo = GeometryDescriptor(
+    ...     name="TH TTH Q",
+    ...     pseudo_axis_names=["q"],
+    ...     real_axis_names=["th", "tth"],
+    ...     modes=["bissector"],
+    ...     default_mode="bissector",
+    ...     description="theta / two-theta powder diffractometer",
+    ... )
+    >>> geo.name
+    'TH TTH Q'
+    >>> geo.real_axis_names
+    ['th', 'tth']
+    """
+
+    name: str
+    pseudo_axis_names: List[str]
+    real_axis_names: List[str]
+    modes: List[str]
+    default_mode: str = ""
+    description: str = ""
+    extra_axis_names: Dict[str, List[str]] = field(default_factory=dict)
+    """Per-mode extra parameter names: ``{mode_name: [param_names, ...]}``.
+
+    Used by solvers that expose additional named parameters (e.g. azimuthal
+    angle) for specific modes.  Defaults to an empty dict (no extras).
+    """
 
 
 class ReflectionDict(TypedDict):


### PR DESCRIPTION
- closes #292
- closes #293

## Summary

Phase 1 of the SolverBase generalisation effort (#289), addressing the two
foundational issues needed to unblock the ad_hoc_diffractometer solver.

### Commit 1 — `GeometryDescriptor` (#293)

Adds `GeometryDescriptor` (a `dataclasses.dataclass`) to
`hklpy2.backends.typing` and exports it from `hklpy2.backends`.  It captures
the static facts about a geometry — `name`, `pseudo_axis_names`,
`real_axis_names`, `modes`, `default_mode`, per-mode `extra_axis_names`, and
`description` — independently of any backend library.

### Commit 2 — Geometry registry and `ThTthSolver` refactor (#292)

- Adds `SolverBase._geometry_registry: dict[str, GeometryDescriptor]` — a
  per-class dict (each subclass owns an independent registry).
- Adds `SolverBase.register_geometry(descriptor)` classmethod: validates the
  argument type and stores the descriptor under `descriptor.name`.
- Updates `SolverBase.geometries()` docstring to document the registry
  contract.
- Refactors `ThTthSolver` to drive all property dispatch
  (`pseudo_axis_names`, `real_axis_names`, `modes`, `extra_axis_names`,
  `geometries()`) from its registry, replacing hard-coded `if self.geometry
  == ...` branching.  The built-in `TH TTH Q` geometry is registered at
  module import time via a module-level `GeometryDescriptor`.
- Adds `src/hklpy2/backends/tests/test_geometry_descriptor.py` with
  parametrized tests covering construction, field independence,
  `register_geometry()` type validation, `geometries()` ordering, overwrite
  semantics, registry isolation, property dispatch, and dynamic runtime
  registration.

### Breaking change

`ThTthSolver.geometries()` now returns `sorted(registry.keys())` instead of
the hard-coded `[TH_TTH_Q_GEOMETRY]`.  The result is identical for the
default case; existing code is unaffected.  The `TH_Q_GEOMETRY = "TH Q"`
TODO constant has been removed — that geometry can be added at runtime via
`register_geometry()` if needed.

Agent: OpenCode (claudesonnet46)