### PR TITLE
docs #294 clarify forward() contract and backend library requirements

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -52,6 +52,9 @@ describe future plans.
     Documentation
     -------------
 
+    * Clarify the ``forward()`` contract: a solver may return one or more
+      solutions in the list, and a single-element list is valid.  Document
+      backend library requirements for writing a solver. (:issue:`294`)
     * Document ``ConstraintBase.valid()`` internals, the ``forward()`` call
       sequence, and the ``LimitsConstraint`` label requirement; clarify that
       hklpy2 constraints are post-computation filters distinct from SPEC/diffcalc

--- a/docs/source/guides/how_forward_solution.rst
+++ b/docs/source/guides/how_forward_solution.rst
@@ -14,6 +14,12 @@ The :meth:`~hklpy2.diffract.DiffractometerBase.forward` method may return
 multiple valid real-axis positions for a given set of pseudo-axis coordinates.
 A *solution picker* function selects one solution from that list.
 
+The number of solutions depends on the backend |solver|'s capabilities.
+Some engines analytically enumerate all mathematically valid solutions;
+others return only one.  A single-element list is valid — the pickers
+and constraint filters handle it correctly.  See also
+:ref:`howto.solvers.write.forward_contract`.
+
 This guide explains the built-in pickers, how to switch between them, and how
 to write a custom one.
 

--- a/docs/source/guides/howto_write_solver.rst
+++ b/docs/source/guides/howto_write_solver.rst
@@ -177,7 +177,7 @@ method (or property)            description
 ``addReflection(reflection)``   Add an observed diffraction reflection.
 ``calculate_UB(r1, r2)``        Calculate the UB matrix with two reflections.
 ``extra_axis_names``            Returns list of any extra axes in the current *mode*.
-``forward(pseudos)``            Compute list of solutions(reals) from pseudos.
+``forward(pseudos)``            Compute list of solutions(reals) from pseudos.  A single-element list is acceptable (see :ref:`forward() contract <howto.solvers.write.forward_contract>`).
 ``geometries``                  ``@classmethod`` [#classmethod_decorator]_ : Returns list of all geometries support by this solver.
 ``inverse(reals)``              Compute pseudos from reals.
 ``modes``                       Returns list of all modes support by this geometry.
@@ -186,6 +186,62 @@ method (or property)            description
 ``refineLattice(reflections)``  Return refined lattice parameters given reflections.
 ``removeAllReflections()``      Clears sample of all stored reflections.
 ==============================  ==================
+
+.. _howto.solvers.write.forward_contract:
+
+``forward()`` Contract
+^^^^^^^^^^^^^^^^^^^^^^
+
+``forward(pseudos)`` returns a ``list[NamedFloatDict]`` — all valid real-axis
+solutions the backend engine can find for the given pseudo-axis values,
+geometry, and mode.
+
+The number of solutions depends on the backend library's capabilities.
+Some engines analytically enumerate all mathematically valid solutions;
+others return only one.  **A single-element list is a valid return value.**
+The :class:`~hklpy2.ops.Core` layer iterates over whatever the solver
+returns, applies :ref:`constraint filtering <concepts.constraints>`, and
+passes the survivors to a
+:ref:`solution picker <how_forward_solution>`.
+
+An empty list (or raising :exc:`~hklpy2.misc.NoForwardSolutions`) signals
+that no solution exists for the requested pseudo-axis values.
+
+.. _howto.solvers.write.backend_requirements:
+
+Backend Library Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A |solver| is an adapter for a backend computation library.  The backend
+library must provide (or enable the adapter to implement) the following
+capabilities:
+
+**Geometry-aware rotation chain.**
+    The library must know the physical axis directions and stacking order
+    for each geometry it supports.  This is the irreducible foundation
+    for all diffractometer calculations.
+
+**Forward transform** (pseudos to reals).
+    Given pseudo-axis values, lattice parameters, orientation matrix, and
+    wavelength, compute real-axis angles.
+
+**Inverse transform** (reals to pseudos).
+    Given real-axis angles, lattice parameters, orientation matrix, and
+    wavelength, compute pseudo-axis values.
+
+**UB matrix calculation.**
+    Given two measured reflections (each with known pseudos, measured
+    angles, and wavelength), compute the orientation matrix.  This
+    requires the geometry's rotation chain to convert measured angles
+    into lab-frame scattering vectors.  ``calculate_UB()``,
+    ``forward()``, and ``inverse()`` all depend on the same rotation
+    chain and cannot be separated.
+
+These capabilities are coupled through the geometry's rotation chain.  A
+library that can compute ``forward()`` and ``inverse()`` necessarily has
+the geometry knowledge to also compute ``calculate_UB()``.  A library
+that lacks this knowledge cannot serve as a complete |hklpy2| solver
+backend.
 
 Engineering Units System
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -268,7 +268,40 @@ class SolverBase(ABC):
 
     @abstractmethod
     def forward(self, pseudos: NamedFloatDict) -> List[NamedFloatDict]:
-        """Compute list of solutions(reals) from pseudos (hkl -> [angles])."""
+        """
+        Compute list of solutions(reals) from pseudos (hkl -> [angles]).
+
+        Returns all valid real-axis solutions that the backend engine can
+        find for the given pseudo-axis values, geometry, and mode.  The
+        number of solutions depends on the backend library's capabilities:
+        some engines enumerate all mathematically valid solutions while
+        others return only one.  A single-element list is a valid return
+        value.
+
+        The :class:`~hklpy2.ops.Core` layer iterates over the returned
+        list, applies constraint filtering, and passes the survivors to a
+        solution picker (see :func:`~hklpy2.misc.pick_first_solution`,
+        :func:`~hklpy2.misc.pick_closest_solution`).
+
+        Parameters
+        ----------
+        pseudos : NamedFloatDict
+            Pseudo-axis values keyed by name
+            (e.g. ``{"h": 1.0, "k": 0.0, "l": 0.0}``).
+
+        Returns
+        -------
+        list[NamedFloatDict]
+            Each element is a dictionary of real-axis values keyed by name
+            (e.g. ``{"omega": 10.0, "chi": 0.0, "phi": 0.0, "tth": 20.0}``).
+            An empty list signals no solutions; a single-element list is
+            acceptable.
+
+        Raises
+        ------
+        NoForwardSolutions
+            If the backend cannot find any solution.
+        """
         # based on geometry and mode
         # return [{}]
 

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -484,7 +484,15 @@ class Core:
             self.request_solver_update(True)
 
     def forward(self, pseudos: AnyAxesType, wavelength: Optional[float] = None) -> list:
-        """Compute [{names:reals}] from {names: pseudos} (hkl -> angles)."""
+        """
+        Compute [{names:reals}] from {names: pseudos} (hkl -> angles).
+
+        Delegates to :meth:`SolverBase.forward() <hklpy2.backends.base.SolverBase.forward>`
+        which returns all solutions the backend engine can find (one or
+        more).  Each solution is then filtered against the active
+        :attr:`constraints`; only solutions that satisfy all constraints
+        are included in the returned list.
+        """
         logger.debug(
             "(%s) forward(): pseudos=%r",
             self.__class__.__name__,


### PR DESCRIPTION
## Summary

- closes #294

Clarify the `forward()` contract and document backend library requirements for writing a solver.

### Changes

- **`SolverBase.forward()` docstring** (`base.py`): expanded to document the return value contract — a single-element list is valid, the number of solutions depends on the backend.
- **`Core.forward()` docstring** (`ops.py`): expanded to describe the delegation and constraint filtering.
- **Solver-writing guide** (`howto_write_solver.rst`): added `forward()` Contract section and Backend Library Requirements section documenting that rotation chain, forward/inverse, and UB calculation are inseparable capabilities.
- **Forward solution guide** (`how_forward_solution.rst`): added note that solution count depends on the backend.
- **Release notes**: added entry under Documentation.

### Context

Analysis of #291 established that `calculate_UB()`, `forward()`, and `inverse()` all depend on the same geometry-specific rotation chain and cannot be separated. The multi-start wrapper proposed in the original #294 is not feasible without violating separation of concerns. This PR narrows #294 to its documentation component.

Agent: OpenCode (claudeopus46)