### PR TITLE
feat #299 provide default reflection management in SolverBase

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -49,6 +49,15 @@ describe future plans.
       ``extra_axis_names`` are all driven by registered ``GeometryDescriptor``
       objects instead of hard-coded string dispatch. (:issue:`292`, :issue:`293`)
 
+    Enhancements
+    ------------
+
+    * Provide default reflection management in ``SolverBase``:
+      ``addReflection()``, ``removeAllReflections()``, ``refineLattice()``,
+      and ``reflections`` property are no longer abstract.  Add ``UB`` setter
+      to ``SolverBase``.  Simplify ``NoOpSolver`` and ``ThTthSolver`` to
+      inherit defaults where appropriate. (:issue:`299`)
+
     Documentation
     -------------
 

--- a/docs/source/guides/howto_write_solver.rst
+++ b/docs/source/guides/howto_write_solver.rst
@@ -56,7 +56,6 @@ methods (methods marked with decorator ``@abstractmethod``
 
     from hklpy2.backends.base import SolverBase
     from hklpy2.misc import IDENTITY_MATRIX_3X3
-    from hklpy2.misc import KeyValueMap
     from hklpy2.misc import Matrix3x3
     from hklpy2.misc import NamedFloatDict
 
@@ -68,11 +67,7 @@ methods (methods marked with decorator ``@abstractmethod``
             super().__init__(geometry, **kwargs)
 
         # Required abstract methods
-        def addReflection(self, reflection: KeyValueMap) -> None:
-            """Add an observed diffraction reflection."""
-            pass  # TODO: send to your library
-
-        def calculate_UB(self, r1: KeyValueMap, r2: KeyValueMap) -> Matrix3x3:
+        def calculate_UB(self, r1: dict, r2: dict) -> Matrix3x3:
             """Calculate the UB matrix with two reflections."""
             return IDENTITY_MATRIX_3X3  # TODO: calculate with your library
 
@@ -83,14 +78,6 @@ methods (methods marked with decorator ``@abstractmethod``
         def inverse(self, reals: NamedFloatDict) -> NamedFloatDict:
             """Compute pseudos from reals."""
             return {}  # TODO: calculate with your library
-
-        def refineLattice(self, reflections: list[KeyValueMap]) -> NamedFloatDict:
-            """Refine lattice parameters from reflections."""
-            return {}  # TODO: calculate with your library
-
-        def removeAllReflections(self) -> None:
-            """Remove all reflections."""
-            pass  # TODO: use your library
 
         # Required properties
         @property
@@ -117,6 +104,12 @@ methods (methods marked with decorator ``@abstractmethod``
         def real_axis_names(self) -> list[str]:
             """Ordered list of real axis names (omega, chi, phi, tth)."""
             return []
+
+    # Optional overrides — SolverBase provides working defaults:
+    # addReflection(reflection)   — stores in internal list
+    # removeAllReflections()      — clears internal list
+    # refineLattice(reflections)  — returns None (not supported)
+    # reflections                 — returns copy of internal list
 
 Step 2. Register as Entry Point
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,12 +162,13 @@ Required Methods Contract
 
 All solvers must implement these attributes, methods, and properties:
 
+**Required** (abstract — subclasses must implement):
+
 ==============================  ==================
 method (or property)            description
 ==============================  ==================
 ``name``                        (string attribute) Name of this solver.
 ``version``                     (string attribute) Version of this solver.
-``addReflection(reflection)``   Add an observed diffraction reflection.
 ``calculate_UB(r1, r2)``        Calculate the UB matrix with two reflections.
 ``extra_axis_names``            Returns list of any extra axes in the current *mode*.
 ``forward(pseudos)``            Compute list of solutions(reals) from pseudos.
@@ -183,9 +177,19 @@ method (or property)            description
 ``modes``                       Returns list of all modes support by this geometry.
 ``pseudo_axis_names``           Returns list of all pseudos support by this geometry.
 ``real_axis_names``             Returns list of all reals support by this geometry.
-``refineLattice(reflections)``  Return refined lattice parameters given reflections.
-``removeAllReflections()``      Clears sample of all stored reflections.
 ==============================  ==================
+
+**Optional** (``SolverBase`` provides working defaults — override if your
+backend library has its own reflection management or lattice refinement):
+
+=================================  ==================
+method (or property)               default behavior
+=================================  ==================
+``addReflection(reflection)``      Stores in internal list.
+``reflections``                    Returns copy of internal list.
+``refineLattice(reflections)``     Returns ``None`` (not supported).
+``removeAllReflections()``         Clears internal list.
+=================================  ==================
 
 Engineering Units System
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -70,7 +70,6 @@ class SolverBase(ABC):
 
     .. autosummary::
 
-        ~addReflection
         ~calculate_UB
         ~extra_axis_names
         ~forward
@@ -79,7 +78,17 @@ class SolverBase(ABC):
         ~modes
         ~pseudo_axis_names
         ~real_axis_names
+
+    .. rubric:: Default Implementations
+
+    Subclasses may override these methods if the backend library
+    provides its own reflection management or lattice refinement.
+
+    .. autosummary::
+
+        ~addReflection
         ~refineLattice
+        ~reflections
         ~removeAllReflections
 
     .. rubric:: Geometry Registry
@@ -195,6 +204,8 @@ class SolverBase(ABC):
         self.mode = mode
         self._all_extra_axis_names: Optional[List[str]] = None
         self._sample: Optional[SampleDict] = None
+        self._reflections: List[ReflectionDict] = []
+        self._UB: Matrix3x3 = IDENTITY_MATRIX_3X3
 
         validate_and_canonical_unit(self.ANGLE_UNITS, INTERNAL_ANGLE_UNITS)
         validate_and_canonical_unit(self.LENGTH_UNITS, INTERNAL_LENGTH_UNITS)
@@ -221,9 +232,18 @@ class SolverBase(ABC):
             "version": self.version,
         }
 
-    @abstractmethod
     def addReflection(self, reflection: ReflectionDict) -> None:
-        """Add coordinates of a diffraction condition (a reflection)."""
+        """
+        Add coordinates of a diffraction condition (a reflection).
+
+        Default implementation stores the reflection in an internal list.
+        Solvers that delegate reflection management to their backend
+        library (e.g. :class:`~hklpy2.backends.hkl_soleil.HklSolver`)
+        should override this method.
+        """
+        if not isinstance(reflection, dict):
+            raise TypeError(f"Must supply ReflectionDict, received {reflection!r}")
+        self._reflections.append(reflection)
 
     @property
     def all_extra_axis_names(self) -> List[str]:
@@ -371,13 +391,37 @@ class SolverBase(ABC):
         # Do NOT sort.
         # return []
 
-    @abstractmethod
     def refineLattice(self, reflections: List[ReflectionDict]) -> NamedFloatDict | None:
-        """Refine the lattice parameters from a list of reflections."""
+        """
+        Refine the lattice parameters from a list of reflections.
 
-    @abstractmethod
+        Default implementation returns ``None`` to signal that lattice
+        refinement is not supported.  Solvers whose backend library
+        provides refinement (e.g.
+        :class:`~hklpy2.backends.hkl_soleil.HklSolver`) should override.
+        """
+        return None
+
     def removeAllReflections(self) -> None:
-        """Remove all reflections."""
+        """
+        Remove all reflections.
+
+        Default implementation clears the internal reflection list.
+        Solvers that delegate reflection management to their backend
+        library should override this method.
+        """
+        self._reflections.clear()
+
+    @property
+    def reflections(self) -> List[ReflectionDict]:
+        """
+        List of stored reflections.
+
+        Default implementation returns a copy of the internal list.
+        Solvers that delegate reflection storage to their backend
+        library should override this property.
+        """
+        return list(self._reflections)
 
     @property
     def sample(self) -> Union[SampleDict, None]:
@@ -443,4 +487,16 @@ class SolverBase(ABC):
     @property
     def UB(self) -> Matrix3x3:
         """Orientation matrix (3x3)."""
-        return IDENTITY_MATRIX_3X3
+        return self._UB
+
+    @UB.setter
+    def UB(self, value: Matrix3x3) -> None:
+        """
+        Set the orientation matrix (3x3).
+
+        Default implementation stores the value for later retrieval.
+        Solvers that delegate UB storage to their backend library
+        (e.g. :class:`~hklpy2.backends.hkl_soleil.HklSolver`) should
+        override this setter.
+        """
+        self._UB = value

--- a/src/hklpy2/backends/no_op.py
+++ b/src/hklpy2/backends/no_op.py
@@ -33,11 +33,16 @@ class NoOpSolver(SolverBase):
 
     |solver| that has no reciprocal space transformations.
 
+    Inherits default reflection management
+    (:meth:`~hklpy2.backends.base.SolverBase.addReflection`,
+    :meth:`~hklpy2.backends.base.SolverBase.removeAllReflections`,
+    :meth:`~hklpy2.backends.base.SolverBase.refineLattice`) from
+    :class:`~hklpy2.backends.base.SolverBase`.
+
     .. rubric:: Python Methods
 
     .. autosummary::
 
-        ~addReflection
         ~calculate_UB
         ~extra_axis_names
         ~forward
@@ -45,8 +50,6 @@ class NoOpSolver(SolverBase):
         ~inverse
         ~pseudo_axis_names
         ~real_axis_names
-        ~refineLattice
-        ~removeAllReflections
 
     .. rubric:: Python Properties
 
@@ -64,9 +67,6 @@ class NoOpSolver(SolverBase):
 
     def __init__(self, geometry: str, **kwargs) -> None:
         super().__init__(geometry, **kwargs)
-
-    def addReflection(self, reflection: ReflectionDict) -> None:
-        return None
 
     def calculate_UB(self, r1: ReflectionDict, r2: ReflectionDict) -> Matrix3x3:
         return IDENTITY_MATRIX_3X3
@@ -96,11 +96,3 @@ class NoOpSolver(SolverBase):
     @property
     def real_axis_names(self) -> List[str]:
         return []  # no axes
-
-    def refineLattice(self, reflections: List[ReflectionDict]) -> NamedFloatDict | None:
-        """No refinement."""
-        return None
-
-    def removeAllReflections(self) -> None:
-        """Remove all reflections."""
-        pass

--- a/src/hklpy2/backends/tests/test_base.py
+++ b/src/hklpy2/backends/tests/test_base.py
@@ -3,11 +3,11 @@
 # Many features are tested, albeit indrectly, in specific solvers.
 
 import re
+from contextlib import nullcontext as does_not_raise
 
 import pyRestTable
 import pytest
 
-from ...blocks.lattice import Lattice
 from ...blocks.reflection import Reflection
 from ...misc import IDENTITY_MATRIX_3X3
 from ..base import SolverBase
@@ -16,10 +16,10 @@ from ..th_tth_q import ThTthSolver
 
 
 class TrivialSolver(SolverBase):
-    """Trivial implementation for testing."""
+    """Trivial implementation for testing.
 
-    def addReflection(self, reflection: Reflection):
-        """."""
+    Uses inherited default reflection management from SolverBase.
+    """
 
     def calculate_UB(
         self,
@@ -64,13 +64,6 @@ class TrivialSolver(SolverBase):
         # Do NOT sort.
         return []
 
-    def refineLattice(self, reflections: list[Reflection]) -> Lattice:
-        """Refine the lattice parameters from a list of reflections."""
-        return Lattice(1.0)  # always cubic, for testing
-
-    def removeAllReflections(self) -> None:
-        """Remove all reflections."""
-
 
 def test_SolverBase():
     assert TrivialSolver.geometries() == []
@@ -92,7 +85,7 @@ def test_SolverBase():
     assert solver.inverse({}) == {}
     assert solver.pseudo_axis_names == [], f"{solver.pseudo_axis_names=}"
     assert solver.real_axis_names == [], f"{solver.real_axis_names=}"
-    assert solver.refineLattice([]) == Lattice(a=1.0)
+    assert solver.refineLattice([]) is None
 
     delattr(solver, "_mode")
     assert solver.mode == ""
@@ -153,3 +146,149 @@ def test_SolverBase_abstractmethods():
         match=re.escape("Cannot change 'geometry' after solver is created."),
     ):
         solver.geometry = TH_TTH_Q_GEOMETRY
+
+
+SAMPLE_REFLECTION = dict(
+    name="r1",
+    pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
+    reals={"omega": 10.0, "chi": 0.0, "phi": 0.0, "tth": 20.0},
+    wavelength=1.54,
+)
+
+SAMPLE_REFLECTION_2 = dict(
+    name="r2",
+    pseudos={"h": 0.0, "k": 1.0, "l": 0.0},
+    reals={"omega": 15.0, "chi": 0.0, "phi": 90.0, "tth": 30.0},
+    wavelength=1.54,
+)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(reflection=SAMPLE_REFLECTION),
+            does_not_raise(),
+            id="valid reflection dict",
+        ),
+        pytest.param(
+            dict(reflection="not a dict"),
+            pytest.raises(TypeError, match=re.escape("Must supply ReflectionDict")),
+            id="string raises TypeError",
+        ),
+        pytest.param(
+            dict(reflection=42),
+            pytest.raises(TypeError, match=re.escape("Must supply ReflectionDict")),
+            id="int raises TypeError",
+        ),
+    ],
+)
+def test_addReflection_default(parms, context):
+    solver = TrivialSolver("test_geo")
+    with context:
+        solver.addReflection(**parms)
+        assert len(solver.reflections) == 1
+        assert solver.reflections[0] == parms["reflection"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(reflections=[SAMPLE_REFLECTION, SAMPLE_REFLECTION_2]),
+            does_not_raise(),
+            id="add two then remove all",
+        ),
+        pytest.param(
+            dict(reflections=[]),
+            does_not_raise(),
+            id="remove from empty list",
+        ),
+    ],
+)
+def test_removeAllReflections_default(parms, context):
+    solver = TrivialSolver("test_geo")
+    with context:
+        for r in parms["reflections"]:
+            solver.addReflection(r)
+        assert len(solver.reflections) == len(parms["reflections"])
+        solver.removeAllReflections()
+        assert len(solver.reflections) == 0
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(reflections=[]),
+            does_not_raise(),
+            id="empty list returns None",
+        ),
+        pytest.param(
+            dict(reflections=[SAMPLE_REFLECTION]),
+            does_not_raise(),
+            id="one reflection returns None",
+        ),
+    ],
+)
+def test_refineLattice_default(parms, context):
+    solver = TrivialSolver("test_geo")
+    with context:
+        result = solver.refineLattice(**parms)
+        assert result is None
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                reflections=[SAMPLE_REFLECTION, SAMPLE_REFLECTION_2],
+                expected_count=2,
+            ),
+            does_not_raise(),
+            id="two reflections stored",
+        ),
+        pytest.param(
+            dict(
+                reflections=[],
+                expected_count=0,
+            ),
+            does_not_raise(),
+            id="empty reflections list",
+        ),
+    ],
+)
+def test_reflections_property(parms, context):
+    solver = TrivialSolver("test_geo")
+    with context:
+        for r in parms["reflections"]:
+            solver.addReflection(r)
+        result = solver.reflections
+        assert len(result) == parms["expected_count"]
+        # Verify it returns a copy, not the internal list.
+        result.append({"dummy": True})
+        assert len(solver.reflections) == parms["expected_count"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(ub=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            does_not_raise(),
+            id="set identity UB",
+        ),
+        pytest.param(
+            dict(ub=[[2, 0, 0], [0, 2, 0], [0, 0, 2]]),
+            does_not_raise(),
+            id="set non-identity UB",
+        ),
+    ],
+)
+def test_UB_setter(parms, context):
+    solver = TrivialSolver("test_geo")
+    assert solver.UB == IDENTITY_MATRIX_3X3
+    with context:
+        solver.UB = parms["ub"]
+        assert solver.UB == parms["ub"]

--- a/src/hklpy2/backends/tests/test_no_op.py
+++ b/src/hklpy2/backends/tests/test_no_op.py
@@ -1,7 +1,19 @@
 """Test the no_op solver class."""
 
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
 from ...misc import IDENTITY_MATRIX_3X3
 from ..no_op import NoOpSolver
+
+SAMPLE_REFLECTION = dict(
+    name="r1",
+    pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
+    reals={"omega": 10.0, "chi": 0.0, "phi": 0.0, "tth": 20.0},
+    wavelength=1.54,
+)
 
 
 def test_NoOpSolver():
@@ -14,4 +26,26 @@ def test_NoOpSolver():
     assert solver.forward({}) == [{}]
     assert solver.inverse({}) == {}
     assert solver.calculate_UB(None, None) == IDENTITY_MATRIX_3X3
-    assert solver.addReflection(None) is None
+    assert solver.reflections == []
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(reflection=SAMPLE_REFLECTION),
+            does_not_raise(),
+            id="valid reflection dict",
+        ),
+        pytest.param(
+            dict(reflection=None),
+            pytest.raises(TypeError, match=re.escape("Must supply ReflectionDict")),
+            id="None raises TypeError",
+        ),
+    ],
+)
+def test_NoOpSolver_addReflection(parms, context):
+    solver = NoOpSolver("no_geometry")
+    with context:
+        solver.addReflection(**parms)
+        assert len(solver.reflections) == 1

--- a/src/hklpy2/backends/th_tth_q.py
+++ b/src/hklpy2/backends/th_tth_q.py
@@ -75,7 +75,6 @@ class ThTthSolver(SolverBase):
         ~inverse
         ~pseudo_axis_names
         ~real_axis_names
-        ~refineLattice
         ~removeAllReflections
 
     .. rubric:: Python Properties
@@ -197,10 +196,6 @@ class ThTthSolver(SolverBase):
         if desc is None:
             return []
         return list(desc.real_axis_names)
-
-    def refineLattice(self, reflections: list[ReflectionDict]) -> NamedFloatDict | None:
-        """No lattice refinement in this |solver|."""
-        return None
 
     def removeAllReflections(self) -> None:
         """Remove all reflections."""


### PR DESCRIPTION
## Summary

- closes #299

Provide default reflection storage and management in `SolverBase`, reducing boilerplate for simple solvers.

### Changes

- **`SolverBase`** (`base.py`):
  - `addReflection()`: no longer abstract; default stores reflection in `self._reflections` list with type validation.
  - `removeAllReflections()`: no longer abstract; default clears `self._reflections`.
  - `refineLattice()`: no longer abstract; default returns `None` (not supported).
  - New `reflections` property: returns a copy of the internal list.
  - New `UB` setter: stores the value for later retrieval (was read-only, returning identity).
  - `__init__` initializes `self._reflections` and `self._UB`.
- **`NoOpSolver`** (`no_op.py`): removed `addReflection`, `refineLattice`, `removeAllReflections` — now inherits working defaults from `SolverBase`.
- **`ThTthSolver`** (`th_tth_q.py`): removed `refineLattice` — inherits default `return None`. Keeps `addReflection` override (wavelength validation) and `removeAllReflections` override (resets `_wavelength`).
- **Solver-writing guide** (`howto_write_solver.rst`): updated to show required vs. optional methods, simplified example code.
- **Tests**: updated `test_base.py` with parametrized tests for default reflection management and UB setter. Updated `test_no_op.py` to test inherited behavior.
- **Release notes**: added entry under Enhancements.

### No merge conflict with PR #301

This PR does not touch `ops.py`, `how_forward_solution.rst`, or the `SolverBase.forward()` docstring — the files modified by #301. Both PRs modify `howto_write_solver.rst` and `RELEASE_NOTES.rst` but in different, non-overlapping sections.

Agent: OpenCode (claudeopus46)