### PR TITLE
docs #300 expand backend library requirements documentation

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -55,6 +55,10 @@ describe future plans.
     * Clarify the ``forward()`` contract: a solver may return one or more
       solutions in the list, and a single-element list is valid.  Document
       backend library requirements for writing a solver. (:issue:`294`)
+    * Expand backend library requirements documentation: add reflection
+      management (required), optional capabilities (lattice refinement,
+      multi-solution, modes), and design rationale explaining why these
+      cannot be factored into ``SolverBase``. (:issue:`300`)
     * Document ``ConstraintBase.valid()`` internals, the ``forward()`` call
       sequence, and the ``LimitsConstraint`` label requirement; clarify that
       hklpy2 constraints are post-computation filters distinct from SPEC/diffcalc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -180,7 +180,6 @@ rst_prolog = """
 .. |hklpy.url| replace:: https://blueskyproject.io/hklpy
 .. |hklpy2| replace:: **hklpy2**
 .. |libhkl| replace:: **Hkl/Soleil**
-.. |ophyd| replace:: **ophyd**
 .. |solver| replace:: **Solver**
 .. |spec| replace:: **SPEC**
 """

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -180,6 +180,7 @@ rst_prolog = """
 .. |hklpy.url| replace:: https://blueskyproject.io/hklpy
 .. |hklpy2| replace:: **hklpy2**
 .. |libhkl| replace:: **Hkl/Soleil**
+.. |ophyd| replace:: **ophyd**
 .. |solver| replace:: **Solver**
 .. |spec| replace:: **SPEC**
 """

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -232,7 +232,10 @@ extlinks = {
 }
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+intersphinx_mapping = {
+    "ophyd": ("https://blueskyproject.io/ophyd", None),
+    "python": ("https://docs.python.org/3", None),
+}
 inheritance_graph_attrs = {"rankdir": "LR"}
 inheritance_node_attrs = {"fontsize": 24}
 autosummary_generate = True

--- a/docs/source/guides/howto_write_solver.rst
+++ b/docs/source/guides/howto_write_solver.rst
@@ -192,20 +192,31 @@ method (or property)            description
 ``forward()`` Contract
 ^^^^^^^^^^^^^^^^^^^^^^
 
-``forward(pseudos)`` returns a ``list[NamedFloatDict]`` — all valid real-axis
-solutions the backend engine can find for the given pseudo-axis values,
-geometry, and mode.
+The ``forward()`` method appears at three layers, each with a distinct
+role and return type:
 
-The number of solutions depends on the backend library's capabilities.
-Some engines analytically enumerate all mathematically valid solutions;
-others return only one.  **A single-element list is a valid return value.**
-The :class:`~hklpy2.ops.Core` layer iterates over whatever the solver
-returns, applies :ref:`constraint filtering <concepts.constraints>`, and
-passes the survivors to a
-:ref:`solution picker <how_forward_solution>`.
+:meth:`SolverBase.forward(pseudos) <hklpy2.backends.base.SolverBase.forward>`
+    Returns ``list[NamedFloatDict]`` — all valid real-axis solutions the
+    backend engine can find for the given pseudo-axis values, geometry,
+    and mode.  **A single-element list is a valid return value.**
 
-An empty list (or raising :exc:`~hklpy2.misc.NoForwardSolutions`) signals
-that no solution exists for the requested pseudo-axis values.
+:meth:`Core.forward(pseudos) <hklpy2.ops.Core.forward>`
+    Calls the solver's ``forward()``, then applies
+    :ref:`constraint filtering <concepts.constraints>` to each solution.
+    Returns the filtered list — the full set of candidate motor angle
+    combinations that satisfy all constraints.
+
+:meth:`DiffractometerBase.forward(pseudos) <hklpy2.diffract.DiffractometerBase.forward>`
+    The |ophyd| ``PseudoPositioner`` interface, called by motion
+    commands during bluesky plans.  Calls ``Core.forward()``, then
+    applies a :ref:`solution picker <how_forward_solution>` to select
+    one solution for motor motion.  Returns a single ``NamedTuple``.
+
+When writing a solver, only ``SolverBase.forward()`` needs to be
+implemented.  The number of solutions depends on the backend library's
+capabilities.  An empty list (or raising
+:exc:`~hklpy2.misc.NoForwardSolutions`) signals that no solution
+exists for the requested pseudo-axis values.
 
 .. _howto.solvers.write.backend_requirements:
 
@@ -214,7 +225,12 @@ Backend Library Requirements
 
 A |solver| is an adapter for a backend computation library.  The backend
 library must provide (or enable the adapter to implement) the following
-capabilities:
+capabilities.
+
+Required
+""""""""
+
+.. index:: backend requirements; required
 
 **Geometry-aware rotation chain.**
     The library must know the physical axis directions and stacking order
@@ -223,7 +239,8 @@ capabilities:
 
 **Forward transform** (pseudos to reals).
     Given pseudo-axis values, lattice parameters, orientation matrix, and
-    wavelength, compute real-axis angles.
+    wavelength, compute real-axis angles.  This is geometry- and
+    mode-specific.
 
 **Inverse transform** (reals to pseudos).
     Given real-axis angles, lattice parameters, orientation matrix, and
@@ -237,11 +254,62 @@ capabilities:
     ``forward()``, and ``inverse()`` all depend on the same rotation
     chain and cannot be separated.
 
-These capabilities are coupled through the geometry's rotation chain.  A
-library that can compute ``forward()`` and ``inverse()`` necessarily has
-the geometry knowledge to also compute ``calculate_UB()``.  A library
-that lacks this knowledge cannot serve as a complete |hklpy2| solver
-backend.
+**Reflection management.**
+    Store and retrieve measured reflections for UB matrix calculation.
+    The backend library must manage reflections because UB calculation
+    consumes them — the solver adapter passes reflections through to the
+    backend, not buffering them in the adapter layer.
+
+Optional
+""""""""
+
+.. index:: backend requirements; optional
+
+The following capabilities enhance a solver but are not required.
+Solvers that lack these features remain valid — the :class:`~hklpy2.ops.Core`
+layer handles their absence gracefully.
+
+**Lattice refinement.**
+    Refine lattice parameters from multiple reflections.  Solvers that
+    lack this capability return ``None`` from ``refineLattice()``; Core
+    raises an informative error to the user.
+
+**Multi-solution enumeration.**
+    Return multiple valid angle solutions for a given set of pseudo-axis
+    values.  A single-element list is a valid return from ``forward()``
+    (see :ref:`howto.solvers.write.forward_contract`).
+
+**Operating modes.**
+    Named constraint sets (e.g., bisector, constant-phi) that restrict
+    which axes move during ``forward()``.
+
+.. _howto.solvers.write.design_rationale:
+
+Design Rationale
+""""""""""""""""
+
+.. index:: separation of concerns
+
+The required capabilities above are coupled through the geometry's
+rotation chain: the same axis definitions that drive ``forward()`` and
+``inverse()`` are needed to compute lab-frame scattering vectors for
+``calculate_UB()``, and to manage the reflections that feed it.  A
+library that can compute ``forward()`` and ``inverse()`` necessarily
+has the geometry knowledge to also compute ``calculate_UB()``.  A
+library that lacks this knowledge cannot serve as a complete |hklpy2|
+solver backend.
+
+This coupling is why these capabilities cannot be factored into
+:class:`~hklpy2.backends.base.SolverBase`.  A "generic" implementation
+would require embedding a full geometry engine — effectively becoming a
+backend library itself, violating the separation of concerns between
+the adapter layer and the computation engine.
+
+The |solver| should be a thin adapter: it translates
+:class:`~hklpy2.backends.base.SolverBase` method calls into whatever
+the backend library needs.  Computation, data management (including
+reflections), and transport (for remote backends) belong in the
+backend or its solver adapter, not in the base class.
 
 Engineering Units System
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/guides/howto_write_solver.rst
+++ b/docs/source/guides/howto_write_solver.rst
@@ -207,7 +207,7 @@ role and return type:
     combinations that satisfy all constraints.
 
 :meth:`DiffractometerBase.forward(pseudos) <hklpy2.diffract.DiffractometerBase.forward>`
-    The |ophyd| ``PseudoPositioner`` interface, called by motion
+    The :class:`ophyd.PseudoPositioner` interface, called by motion
     commands during bluesky plans.  Calls ``Core.forward()``, then
     applies a :ref:`solution picker <how_forward_solution>` to select
     one solution for motor motion.  Returns a single ``NamedTuple``.

--- a/docs/source/guides/howto_write_solver.rst
+++ b/docs/source/guides/howto_write_solver.rst
@@ -280,8 +280,7 @@ layer handles their absence gracefully.
 
 **Operating modes.**
     Named configurations (e.g., bisector, constant-phi) that define
-    which axes will be modified by ``forward()``.  See
-    :term:`mode`.
+    which axes will be modified by ``forward()``.
 
 .. _howto.solvers.write.design_rationale:
 

--- a/docs/source/guides/howto_write_solver.rst
+++ b/docs/source/guides/howto_write_solver.rst
@@ -238,9 +238,8 @@ Required
     for all diffractometer calculations.
 
 **Forward transform** (pseudos to reals).
-    Given pseudo-axis values, lattice parameters, orientation matrix, and
-    wavelength, compute real-axis angles.  This is geometry- and
-    mode-specific.
+    Given pseudo-axis values, orientation matrix, and wavelength, compute
+    real-axis angles.  This is geometry- and mode-specific.
 
 **Inverse transform** (reals to pseudos).
     Given real-axis angles, lattice parameters, orientation matrix, and
@@ -280,8 +279,9 @@ layer handles their absence gracefully.
     (see :ref:`howto.solvers.write.forward_contract`).
 
 **Operating modes.**
-    Named constraint sets (e.g., bisector, constant-phi) that restrict
-    which axes move during ``forward()``.
+    Named configurations (e.g., bisector, constant-phi) that define
+    which axes will be modified by ``forward()``.  See
+    :term:`mode`.
 
 .. _howto.solvers.write.design_rationale:
 

--- a/docs/source/guides/howto_write_solver.rst
+++ b/docs/source/guides/howto_write_solver.rst
@@ -311,6 +311,16 @@ the backend library needs.  Computation, data management (including
 reflections), and transport (for remote backends) belong in the
 backend or its solver adapter, not in the base class.
 
+Backend library APIs vary widely.  For example,
+:meth:`HklSolver.forward() <hklpy2.backends.hkl_soleil.HklSolver.forward>`
+calls ``engine.pseudo_axis_values_set()`` — a |libhkl| GObject
+introspection binding that sets pseudo-axis values and returns a
+``GeometryList`` of solutions as a side effect.  The backend function
+name gives no indication it is computing forward solutions.  This is
+exactly why the solver adapter exists: to present a consistent
+``forward(pseudos)`` interface regardless of how the backend library
+exposes its capabilities.
+
 Engineering Units System
 ^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary

- closes #300

Expand the "Backend Library Requirements" section in the solver-writing guide, building on what PR #301 introduced.

### Changes

**`howto_write_solver.rst`**:

- **Reflection management** added as a required capability — the backend must manage reflections because UB calculation consumes them; the solver adapter passes reflections through, not buffering them.
- **Optional capabilities** section added: lattice refinement (return `None` if unsupported), multi-solution enumeration (single-element list is valid), operating modes.
- **Design rationale** section added: explains why the required capabilities are coupled through the geometry's rotation chain and cannot be factored into `SolverBase`. Documents the separation-of-concerns principle that emerged from the #289/#291 analysis — the solver is a thin adapter; computation, data management, and transport belong in the backend.
- **`forward()` contract** clarified across three layers: `SolverBase.forward()` (returns list from backend), `Core.forward()` (constraint filtering, returns filtered list), `DiffractometerBase.forward()` (ophyd `PseudoPositioner` interface for bluesky plan motor motion, applies solution picker, returns single `NamedTuple`).

**`RELEASE_NOTES.rst`**: added entry under Documentation.

### Context

Issue #300 was created during the #291 analysis to capture backend library requirements that were previously implicit. PR #301 added the initial required-capabilities section. This PR completes the documentation with optional capabilities, reflection management, design rationale, and the three-layer `forward()` distinction.

Agent: OpenCode (claudeopus46)