### PR TITLE
fix #304 Python 3.14 TypeError message for 'in' operator

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -49,6 +49,14 @@ describe future plans.
       ``extra_axis_names`` are all driven by registered ``GeometryDescriptor``
       objects instead of hard-coded string dispatch. (:issue:`292`, :issue:`293`)
 
+    Fixes
+    -----
+
+    * Fix CI test failure on Python 3.14: ``TypeError`` message for ``in``
+      operator on non-iterable changed from ``"is not iterable"`` to
+      ``"is not a container or iterable"``.  Truncate match pattern to
+      accept both. (:issue:`304`)
+
     Documentation
     -------------
 

--- a/src/hklpy2/tests/test_ops.py
+++ b/src/hklpy2/tests/test_ops.py
@@ -866,9 +866,7 @@ def test_extras_setter(
                 "samples": {},
                 "constraints": {"tth": {"class": "LimitsConstraint", "label": 0}},
             },
-            pytest.raises(
-                TypeError, match=re.escape("argument of type 'int' is not iterable")
-            ),
+            pytest.raises(TypeError, match=re.escape("argument of type 'int' is not")),
             id="real_axes-not-iterable",
         ),
         pytest.param(  # 18


### PR DESCRIPTION
## Summary

- closes #304

Python 3.14 changed the `TypeError` message raised when using the `in` operator on a non-iterable object:

- **Python ≤ 3.13**: `"argument of type 'int' is not iterable"`
- **Python 3.14**: `"argument of type 'int' is not a container or iterable"`

The test `test__fromdict[real_axes-not-iterable]` in `test_ops.py` used `re.escape("argument of type 'int' is not iterable")` as the match pattern, which failed on 3.14.

### Fix

Truncate the match string to the common prefix `"argument of type 'int' is not"`, which matches both versions.

Agent: OpenCode (claudeopus46)