### PR TITLE
docs #315 add how-to guide for computing and setting the UB matrix

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -41,6 +41,10 @@ describe future plans.
     * Add Diátaxis tutorial: guided first experience from creating a
       simulated E4CV diffractometer through UB matrix computation to
       reciprocal-space scanning. (:issue:`318`)
+    * Add how-to guide for computing and setting the UB matrix: adding
+      reflections, computing from two reflections, setting manually,
+      swapping, inspecting, refining lattice parameters, and verifying.
+      (:issue:`315`)
 
 0.5.0
 #####

--- a/docs/source/guides.rst
+++ b/docs/source/guides.rst
@@ -50,6 +50,9 @@ Computation
 
    * - Guide
      - Description
+   * - :ref:`how_calc_ub`
+     - Add orientation reflections, compute the UB matrix, set it manually,
+       inspect, refine, and reset it.
    * - :ref:`how_constraints`
      - Set axis limits and cut points; write a custom constraint subclass.
    * - :ref:`how_forward_solution`

--- a/docs/source/guides/how_calc_ub.rst
+++ b/docs/source/guides/how_calc_ub.rst
@@ -1,0 +1,174 @@
+.. _how_calc_ub:
+
+=========================================
+How to Compute and Set the UB Matrix
+=========================================
+
+.. index::
+    !UB matrix; how-to
+    see: orientation matrix; UB matrix
+    see: calc_UB; UB matrix
+
+The :math:`UB` orientation matrix encodes how the crystal is mounted on
+the diffractometer and is required before any
+:meth:`~hklpy2.diffract.DiffractometerBase.forward` calculation can succeed.  This guide covers the common tasks: computing :math:`UB`
+from reflections, setting it manually, inspecting and refining it, and
+resetting it.
+
+.. seealso::
+
+   :ref:`tutorial` — step-by-step walkthrough of the full orientation
+   workflow for a new user.
+
+   :ref:`concepts.constraints` — filter :meth:`~hklpy2.diffract.DiffractometerBase.forward`
+   solutions after the UB matrix is set.
+
+   :ref:`guide.design` — explanation of the :math:`B`, :math:`U`, and
+   :math:`UB` matrices.
+
+Setup
+-----
+
+All examples use a simulated 4-circle diffractometer with silicon::
+
+    >>> import hklpy2
+    >>> from hklpy2.user import (
+    ...     add_sample, calc_UB, or_swap, pa,
+    ...     remove_reflection, set_diffractometer, setor,
+    ... )
+    >>> fourc = hklpy2.creator(name="fourc", geometry="E4CV", solver="hkl_soleil")
+    >>> set_diffractometer(fourc)
+    >>> add_sample("silicon", a=hklpy2.SI_LATTICE_PARAMETER)
+    >>> fourc.beam.wavelength.put(1.54)
+
+How do I add orientation reflections?
+--------------------------------------
+
+Use :func:`~hklpy2.user.setor` to record a reflection — the measured
+motor angles for a known :math:`(h, k, l)` position::
+
+    >>> r1 = setor(4, 0, 0, tth=69.0966, omega=-145.451, chi=0, phi=0)
+    >>> r2 = setor(0, 4, 0, tth=69.0966, omega=-145.451, chi=90, phi=0)
+
+:func:`~hklpy2.user.setor` uses the diffractometer's current wavelength
+at the time it is called.  To record a reflection measured at a different
+wavelength, pass ``wavelength=`` explicitly::
+
+    >>> r3 = setor(0, 0, 4, tth=69.0966, omega=-145.451, chi=90, phi=90,
+    ...            wavelength=1.00)
+
+For lower-level control, :meth:`~hklpy2.ops.Core.add_reflection` on
+``fourc.core`` accepts the same arguments and returns a
+:class:`~hklpy2.blocks.reflection.Reflection` object directly.
+
+How do I compute UB from two reflections?
+------------------------------------------
+
+Call :func:`~hklpy2.user.calc_UB` with the two reflection objects
+returned by :func:`~hklpy2.user.setor`::
+
+    >>> calc_UB(r1, r2)
+    [[-1.4134285e-05, -1.4134285e-05, -1.156906937382],
+     [0.0, -1.156906937469, 1.4134285e-05],
+     [-1.156906937469, 1.73e-10, 1.4134285e-05]]
+
+The matrix is stored on the sample and pushed to the solver
+automatically.  You can also pass reflection *names* instead of objects::
+
+    >>> calc_UB(r1.name, r2.name)
+
+Or call the equivalent method directly on ``Core``::
+
+    >>> fourc.core.calc_UB(r1, r2)
+
+How do I swap the two orienting reflections?
+---------------------------------------------
+
+:func:`~hklpy2.user.or_swap` swaps the first two reflections in the
+orientation list and recomputes :math:`UB`.  This is equivalent to
+SPEC's ``or_swap`` command::
+
+    >>> or_swap()
+
+The new :math:`UB` matrix is returned and stored automatically.
+
+How do I set UB manually from a known matrix?
+----------------------------------------------
+
+Assign directly to :attr:`~hklpy2.blocks.sample.Sample.UB` on the
+sample.  A plain nested Python list is sufficient — a numpy array is
+accepted but not required::
+
+    >>> fourc.core.sample.UB = [
+    ...     [0.0,       0.0,      -1.1569],
+    ...     [0.0,      -1.1569,    0.0   ],
+    ...     [-1.1569,   0.0,       0.0   ],
+    ... ]
+
+The solver is updated automatically on the next
+:meth:`~hklpy2.diffract.DiffractometerBase.forward` or
+:meth:`~hklpy2.diffract.DiffractometerBase.inverse` call.
+
+How do I inspect the current UB matrix?
+-----------------------------------------
+
+Call :func:`~hklpy2.user.pa` to see the full diffractometer state
+including the :math:`U` and :math:`UB` matrices::
+
+    >>> pa()
+
+Or access the matrix directly::
+
+    >>> fourc.core.sample.UB
+
+How do I remove a reflection?
+------------------------------
+
+Use :func:`~hklpy2.user.remove_reflection` with the reflection's name::
+
+    >>> remove_reflection(r1.name)
+
+To remove all reflections and reset the sample to defaults::
+
+    >>> fourc.core.reset_samples()
+
+.. note::
+
+    :meth:`~hklpy2.ops.Core.reset_samples` removes *all* samples and
+    reflections and recreates a single default sample.  Use
+    :func:`~hklpy2.user.remove_reflection` if you only want to discard
+    one reflection while keeping others.
+
+How do I refine the lattice parameters?
+-----------------------------------------
+
+If the solver supports it, :meth:`~hklpy2.ops.Core.refine_lattice`
+uses three or more reflections to refine the lattice parameters::
+
+    >>> r3 = setor(0, 0, 4, tth=69.0966, omega=-145.451, chi=90, phi=90)
+    >>> fourc.core.refine_lattice(r1, r2, r3)
+
+The refined :class:`~hklpy2.blocks.lattice.Lattice` is returned and
+stored on the sample.  Not all solvers implement lattice refinement —
+check the solver documentation if this raises ``NotImplementedError``.
+
+How do I verify the UB matrix is correct?
+-------------------------------------------
+
+The standard check is to confirm that
+:meth:`~hklpy2.diffract.DiffractometerBase.inverse` at the reflection
+angles recovers the expected :math:`(h, k, l)`, and that
+:meth:`~hklpy2.diffract.DiffractometerBase.forward` at the expected
+:math:`(h, k, l)` returns angles close to the measured ones::
+
+    >>> # inverse: angles → hkl
+    >>> fourc.inverse((-145.451, 0, 0, 69.0966))
+    Hklpy2DiffractometerPseudoPos(h=3.9999, k=0, l=0)   # ≈ (4, 0, 0) ✓
+
+    >>> # forward: hkl → angles
+    >>> fourc.forward(4, 0, 0)
+    Hklpy2DiffractometerRealPos(omega=-34.5491, chi=0.0, phi=-110.9011, tth=69.0982)
+
+Small differences (last decimal place) are normal floating-point
+rounding.  Large differences indicate the orientation reflections were
+recorded incorrectly or the wrong geometry was selected.

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -11,7 +11,7 @@ By the end of this tutorial you will be able to:
 - create a simulated 4-circle diffractometer in Python
 - define a crystal sample and its lattice parameters
 - add two orientation reflections and compute the :math:`UB` matrix
-- verify the orientation with ``forward()`` and ``inverse()``
+- verify the orientation with :meth:`~hklpy2.diffract.DiffractometerBase.forward` and :meth:`~hklpy2.diffract.DiffractometerBase.inverse`
 - move to a reciprocal-space position
 - run a simple scan in reciprocal space
 
@@ -33,7 +33,7 @@ diffractometer.
 
    :ref:`geometries` — full table of available geometries and solvers.
 
-   :ref:`concepts.constraints` — how constraints filter ``forward()`` solutions.
+   :ref:`concepts.constraints` — how constraints filter :meth:`~hklpy2.diffract.DiffractometerBase.forward` solutions.
 
 
 Prerequisites
@@ -91,9 +91,9 @@ modelled on common SPEC commands.  We import the ones we need and tell
 
    set_diffractometer(fourc)
 
-All subsequent calls to ``pa()``, ``wh()``, ``setor()``, etc. will
-operate on ``fourc`` until you call ``set_diffractometer()`` again with
-a different object.
+All subsequent calls to :func:`~hklpy2.user.pa`, :func:`~hklpy2.user.wh`,
+:func:`~hklpy2.user.setor`, etc. will operate on ``fourc`` until you call
+:func:`~hklpy2.user.set_diffractometer` again with a different object.
 
 
 Step 3 — Add a sample
@@ -107,7 +107,7 @@ silicon lattice parameter as a built-in constant:
    add_sample("silicon", a=hklpy2.SI_LATTICE_PARAMETER)
 
 Silicon is cubic so only one lattice parameter ``a`` is needed.
-Notice that ``add_sample()`` prints a confirmation:
+Notice that :func:`~hklpy2.user.add_sample` prints a confirmation:
 
 .. code-block:: text
 
@@ -203,16 +203,17 @@ negative:
    fourc.core.constraints["tth"].limits = -0.001, 180
    fourc.core.constraints["omega"].limits = (-180, 0.001)
 
-Now check ``inverse()`` — given the angles of the first reflection,
-do we recover :math:`(4, 0, 0)`?
+Now check :meth:`~hklpy2.diffract.DiffractometerBase.inverse` — given
+the angles of the first reflection, do we recover :math:`(4, 0, 0)`?
 
 .. code-block:: python
 
    fourc.inverse((-145.451, 0, 0, 69.0966))
    # → Hklpy2DiffractometerPseudoPos(h=3.9999, k=0, l=0)  ✓
 
-And ``forward()`` — given :math:`(4, 0, 0)`, do we get back angles
-close to the measured reflection?
+And :meth:`~hklpy2.diffract.DiffractometerBase.forward` — given
+:math:`(4, 0, 0)`, do we get back angles close to the measured
+reflection?
 
 .. code-block:: python
 
@@ -222,10 +223,11 @@ close to the measured reflection?
 
 .. note::
 
-   The ``forward()`` answer may differ from the measured reflection angles
-   — both are valid positions for :math:`(4, 0, 0)`.  There are often
-   multiple geometrically equivalent solutions.  Use
-   :func:`~hklpy2.user.cahkl_table` to see all of them:
+   The :meth:`~hklpy2.diffract.DiffractometerBase.forward` answer may
+   differ from the measured reflection angles — both are valid positions
+   for :math:`(4, 0, 0)`.  There are often multiple geometrically
+   equivalent solutions.  Use :func:`~hklpy2.user.cahkl_table` to see
+   all of them:
 
    .. code-block:: python
 
@@ -248,7 +250,7 @@ l)` position is straightforward:
    reflections the diffractometer can reach.  The wavelength sets the
    radius of the Ewald sphere and therefore determines which
    reciprocal-lattice points are in range at all; changing the wavelength
-   (or equivalently the energy) shifts that boundary.  If ``forward()``
+   (or equivalently the energy) shifts that boundary.     If :meth:`~hklpy2.diffract.DiffractometerBase.forward`
    returns no solutions, the position is inaccessible under the current
    configuration.
 
@@ -312,7 +314,7 @@ In this tutorial we:
 3. Set the X-ray wavelength
 4. Recorded two orientation reflections with :func:`~hklpy2.user.setor`
 5. Computed the :math:`UB` orientation matrix with :func:`~hklpy2.user.calc_UB`
-6. Verified the orientation with ``forward()`` and ``inverse()``
+6. Verified the orientation with :meth:`~hklpy2.diffract.DiffractometerBase.forward` and :meth:`~hklpy2.diffract.DiffractometerBase.inverse`
 7. Moved to a reciprocal-space position with :meth:`~hklpy2.diffract.DiffractometerBase.move`
 8. Ran a Bluesky scan along a reciprocal-space direction
 


### PR DESCRIPTION
- closes #315
- part of #308 (Diátaxis gap analysis)

## Summary

Adds `docs/source/guides/how_calc_ub.rst` covering the full UB matrix workflow as a Diátaxis how-to guide:

- Add orientation reflections with `setor()` (including at a different wavelength)
- Compute UB from two reflections with `calc_UB()`
- Swap orienting reflections with `or_swap()`
- Set UB manually from a plain Python list (numpy not required)
- Inspect the current UB matrix via `pa()` or direct attribute access
- Remove a single reflection with `remove_reflection()`
- Reset all samples with `reset_samples()`
- Refine lattice parameters with `refine_lattice()`
- Verify correctness with `forward()` and `inverse()`

Also links all bare code references in both this guide and `tutorial.rst`.

Agent: OpenCode (claudesonnet46)