### PR TITLE
docs #314 reframe examples as demonstrations; add Developer section to guides

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -51,6 +51,15 @@ describe future plans.
       ``solver_summary``, ``scan_extra``, and quick-reference SPEC table.
       (:issue:`316`)
 
+    Maintenance
+    -----------
+
+    * Reframe ``examples/`` pages as worked demonstrations (not tutorials);
+      add framing paragraph directing new users to the Tutorial.
+      Separate user-facing and developer/contributor sections in
+      ``guides/``; move solver-writing, release, design, and checklist
+      guides under a new "Developer / Contributor" heading. (:issue:`314`)
+
 0.5.0
 #####
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -4,8 +4,12 @@
 Examples
 ==========
 
-Example documents and notebooks to demonstrate |hklpy2|. The notebooks are
-available for download from the source code website:
+These notebooks are **worked demonstrations** — they show |hklpy2| working
+on specific use cases with real (or simulated) hardware configurations.
+They are not tutorials: they assume you already know the basic workflow.
+If you are new to |hklpy2|, start with the :ref:`tutorial` first.
+
+The notebooks are available for download from the source code website:
 https://github.com/bluesky/hklpy2/docs/source/examples.
 
 .. toctree::

--- a/docs/source/guides.rst
+++ b/docs/source/guides.rst
@@ -10,7 +10,9 @@ Guides
 
    guides/*
 
-Guides, how-to documents, notebooks and tutorials.
+User-facing how-to guides for beamline scientists and instrument scientists.
+For developer and contributor documentation, see the
+`Developer / Contributor`_ section below.
 
 Getting started
 ---------------
@@ -81,8 +83,6 @@ Configuration and solvers
        reflections) and restore it later.
    * - :ref:`how_creator_from_config`
      - Create a simulated diffractometer directly from a saved config file.
-   * - :ref:`howto.solvers.write`
-     - Write and register a new solver plugin using Python entry points.
 
 Reference and background
 -------------------------
@@ -97,7 +97,24 @@ Reference and background
      - Cross-reference of common SPEC commands to their |hklpy2| equivalents.
    * - :ref:`guide.migration_from_hklpy_v1`
      - How code written for |hklpy| (v1) maps to |hklpy2|.
+
+Developer / Contributor
+------------------------
+
+These guides are aimed at developers extending |hklpy2| or maintaining
+the project — not at beamline users.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Guide
+     - Description
    * - :ref:`guide.design`
-     - Design rationale and architectural decisions behind |hklpy2|.
+     - Architecture and design decisions behind |hklpy2|.
+   * - :ref:`howto.solvers.write`
+     - Write and register a new solver plugin using Python entry points.
+   * - :ref:`how_release`
+     - Step-by-step release process for maintainers.
    * - :ref:`v2_checklist`
      - Feature checklist tracking the v2 build (historical reference).


### PR DESCRIPTION
- closes #314
- part of #308 (Diátaxis gap analysis)

## Summary

**`examples.rst`** — adds a framing paragraph making clear these notebooks
are worked demonstrations of specific use cases, not tutorials. Directs new
users to the Tutorial first.

**`guides.rst`** — adds a "Developer / Contributor" section grouping the
pages aimed at developers extending or maintaining hklpy2:
- Architecture & Design Decisions (`guide.design`)
- How to write a solver plugin (`howto.solvers.write`)
- Release process (`how_release`)
- v2 feature checklist (`v2_checklist`)

Removes `howto.solvers.write` from the "Configuration and solvers"
user-facing section where it was misplaced.

Agent: OpenCode (claudesonnet46)