### PR TITLE
docs #317 restructure guides/diffract.rst as How to Work with a Diffractometer

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -54,6 +54,11 @@ describe future plans.
     Maintenance
     -----------
 
+    * Restructure ``guides/diffract.rst``: rename to "How to Work with a
+      Diffractometer", trim attribute narrative to a summary table with
+      cross-references, promote out-of-order axis sections to a top-level
+      "Advanced" section, add ``seealso`` links to the tutorial and concept
+      pages. (:issue:`317`)
     * Reframe ``examples/`` pages as worked demonstrations (not tutorials);
       add framing paragraph directing new users to the Tutorial.
       Separate user-facing and developer/contributor sections in

--- a/docs/source/guides.rst
+++ b/docs/source/guides.rst
@@ -24,8 +24,8 @@ Getting started
    * - Guide
      - Description
    * - :ref:`guide.diffract`
-     - Define a diffractometer class, connect it to a solver, and use it
-       with the bluesky RunEngine.
+     - Define a diffractometer (custom subclass or ``creator()``), use custom
+       axis names, handle axes out of order, and scan with the bluesky RunEngine.
    * - :ref:`guide.solvers`
      - List, select, and instantiate solvers; understand solver entry points.
 

--- a/docs/source/guides/diffract.rst
+++ b/docs/source/guides/diffract.rst
@@ -1,10 +1,14 @@
 .. _guide.diffract:
 
-===========================
-Diffractometer How-To Guide
-===========================
+==========================================
+How to Work with a Diffractometer
+==========================================
 
-.. seealso:: :ref:`concepts.diffract` for a concept overview.
+.. seealso::
+
+   :ref:`concepts.diffract` — conceptual overview of the diffractometer.
+
+   :ref:`tutorial` — step-by-step first experience: create, orient, and scan.
 
 Steps to Define a Diffractometer Object
 ========================================
@@ -19,178 +23,119 @@ Steps to Define a Diffractometer Object
 A Diffractometer Object
 ========================
 
-name
-----
+A :class:`~hklpy2.diffract.DiffractometerBase` instance has several key
+attributes. Brief descriptions follow; see the linked concept pages for details.
 
-The ``name`` of a :class:`~hklpy2.diffract.DiffractometerBase()` instance is
-completely at the choice of the user and conveys no specific information to
-the underlying Python support code.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
 
-One important *convention* is that the name given on the left side of the ``=``
-matches the name given by the ``name="..."`` keyword, such as this example::
+   * - Attribute
+     - Description
+   * - ``name``
+     - User-chosen label. By convention, match the Python variable name:
+       ``e4cv = hklpy2.creator(name="e4cv")``.
+   * - ``geometry``
+     - Physical arrangement of real positioners, pseudo axes, and extra
+       parameters. Choices are limited to those provided by the chosen |solver|.
+       See :ref:`geometries`.
+   * - ``core``
+     - All operations are coordinated through :ref:`concepts.ops`.
+       Accessible as ``fourc.core`` (substitute your diffractometer name).
+   * - ``beam``
+     - Incident radiation described by a
+       :class:`~hklpy2.incident.WavelengthXray` (default) or other
+       :class:`~hklpy2.incident.Wavelength` subclass.
+       See :ref:`concepts.wavelength`.
+   * - ``sample``
+     - The crystal sample, including its :ref:`lattice <concepts.lattice>`
+       and :ref:`orientation reflections <concepts.reflection>`.
+       See :ref:`concepts.sample`.
+   * - ``mode``
+     - Controls which solution :meth:`~hklpy2.diffract.DiffractometerBase.forward` returns.
+       ``fourc.core.mode`` reads/sets the current mode;
+       ``fourc.core.modes`` lists all choices.
 
-    e4cv = hklpy2.creator(name="e4cv")
+.. note::
 
-geometry
---------
-
-The geometry describes the physical arrangement of real positioners, pseudo
-axes, and extra parameters that make up the diffractometer.  The choices are
-limited to those geometries provided the chosen |solver|.
-
-core
-----
-
-All operations are coordinated through :ref:`concepts.ops`.  This is ``fourc.core``.
-
-wavelength (and energy)
------------------------
-
-The `diffractometer.beam` describes the radiation source using the
-:class:`~hklpy2.incident._WavelengthBase` class (or subclass).  Wavelength is
-the term common to both neutron and X-ray diffractometer users.
-:class:`~hklpy2.incident.WavelengthXray` is the default. This supports
-conversion between wavelength and X-ray photon energy.
-
-.. tip:: Neutron users would make a similar class with different calculations
-   between wavelength and energy.
-
-.. note:: It is more common for X-ray users to describe the *energy*
-   of the incident radiation than its *wavelength*.  The
-   ``MonochromaticXrayWavelength()`` class allows the X-ray photon energy
-   to be expressed in any engineering units
-   that are convertible to the expected units (`keV`).
-
-.. note:: The wavelength, commonly written as :math:`\lambda`,
-   cannot be named in Python code as `"lambda"`.
-   Python reserves `lambda` as a type of expression:
-   `reserved <https://docs.python.org/3/reference/expressions.html#lambda>`_
-
-sample
-------
-
-The purpose of a diffractometer is to position a sample for scientific
-measurements. The ``sample`` attribute is an instance of
-:class:`~hklpy2.blocks.sample.Sample`. Behind the scenes, the
-:class:`~hklpy2.ops.Core` class maintains a *dictionary* of samples (keyed
-by ``name``), each with its own :class:`~hklpy2.blocks.lattice.Lattice` and
-orientation :class:`~hklpy2.blocks.reflection.Reflection` information.
-
-lattice
-+++++++
-
-Crystal samples have :class:`~hklpy2.blocks.lattice.Lattice` parameters defined by
-unit cell lengths and angles.  (Units here are angstroms and degrees.)
+   The wavelength, commonly written as :math:`\lambda`, cannot be named in
+   Python code as ``lambda`` — Python reserves that keyword.
 
 .. index:: vibranium
 
-This table describes the lattice of crystalline Vibranium [#vibranium]_:
+Here is an example set of orientation reflections for crystalline
+Vibranium [#vibranium]_ on an E4CV diffractometer:
 
-========= ============  ============   ============   ===== ====  =====
-sample    a             b              c              alpha beta  gamma
-========= ============  ============   ============   ===== ====  =====
-vibranium :math:`2\pi`  :math:`2\pi`   :math:`2\pi`   90    90    90
-========= ============  ============   ============   ===== ====  =====
+= = = = ======== ==== ==== ======= ========== =====
+# h k l omega    chi  phi  tth     wavelength order
+= = = = ======== ==== ==== ======= ========== =====
+1 4 0 0 -145.451 0.0  0.0  69.0966 1.54       --
+2 0 4 0 -145.451 0.0  90.0 69.0966 1.54       1
+3 0 0 4 -145.451 90.0 0.0  69.0966 1.54       2
+= = = = ======== ==== ==== ======= ========== =====
+
+The **order** column shows each reflection's position in
+``fourc.sample.reflections.order`` (``--`` means not selected).
+The reflections labeled 1 and 2 in that column are the first and second
+orienting reflections passed to :meth:`~hklpy2.ops.Core.calc_UB`
+to compute the UB matrix.  Reflection 1 is stored but not selected
+— it can serve as a verification point or be promoted later via
+:meth:`~hklpy2.blocks.reflection.ReflectionsDict.set_orientation_reflections`.
 
 .. [#vibranium] Vibranium (https://en.wikipedia.org/wiki/Vibranium)
-   is a fictional metal.  Here, we have decided it has a cubic lattice
-   with lattice parameter of exactly :math:`2\pi`.
+   is a fictional metal.  Here, it has a cubic lattice with parameter
+   :math:`2\pi` Å (:math:`a = b = c = 2\pi`, :math:`\alpha = \beta = \gamma = 90°`).
 
-orientation
-+++++++++++
-
-The **UB** matrix describes the :meth:`~hklpy2.diffract.DiffractometerBase.forward()`
-and :meth:`~hklpy2.diffract.DiffractometerBase.inverse()` transformations that allow
-precise positioning of a crystalline sample's atomic planes in the laboratory
-reference system of the diffractometer.  It is common to compute the **UB** matrix
-from two orientation reflections using :meth:`~hklpy2.ops.Core.calc_UB()`.
-
-orientation reflections
-~~~~~~~~~~~~~~~~~~~~~~~
-
-An orientation reflection consists of a set of matching pseudos
-and reals at a specified wavelength.  These values may be
-measured or computed.
-
-There are several use cases for a set of reflections:
-
-* Computation of the :math:`UB` matrix (for 2 or more non-parallel reflections).
-* Documentation of observed (or theoretical) reflection settings.
-* Reference settings so as to re-position the diffractometer.
-* Define a crystallographic zone or axis to guide the diffractometer for measurements.
-
-Here is an example of three orientation reflections for a sample of crystalline
-vibranium [#vibranium]_ as mounted on a diffractometer with
-:ref:`E4CV <geometries-hkl_soleil-e4cv>` geometry:
-
-= === === === ======== ==== ==== ======= ========== =======
-# h   k   l   omega    chi  phi  tth     wavelength orient?
-= === === === ======== ==== ==== ======= ========== =======
-1 4.0 0.0 0.0 -145.451 0.0  0.0  69.0966 1.54       False
-2 0.0 4.0 0.0 -145.451 0.0  90.0 69.0966 1.54       True
-3 0.0 0.0 4.0 -145.451 90.0 0.0  69.0966 1.54       True
-= === === === ======== ==== ==== ======= ========== =======
-
-mode
-----
-
-The ``forward()`` transformation can have many solutions.  The
-diffractometer is set to a mode (chosen from a list specified by the
-diffractometer geometry) that controls how values for each of the real
-positioners will be controlled. A mode can control relationships between
-real positioners in addition to limiting the motion of a real positioner.
-Further, a mode can specify an additional reflection which will be used to
-determine the outcome of the ``forward()`` transformation.
-
-=====================  =======================
-object                 meaning
-=====================  =======================
-``DFRCT.core.mode``    mode selected now
-``DFRCT.core.modes``   list of possible modes
-=====================  =======================
-
-Here, ``DFRCT`` is the diffractometer object (such as ``e4cv`` above).
+.. _diffract_scans:
 
 Use a Diffractometer with the bluesky RunEngine
 ===============================================
 
+.. seealso:: :ref:`tutorial` for the basic create-orient-move workflow.
+
 The positioners of a :class:`~hklpy2.diffract.DiffractometerBase` object may be
 used with the `bluesky RunEngine
 <https://blueskyproject.io/bluesky/generated/bluesky.run_engine.RunEngine.html?highlight=runengine>`_
-with any of the `pre-assembled plans
-<https://blueskyproject.io/bluesky/plans.html#pre-assembled-plans>`_ or
-in custom plans of your own.
+with any of the plans in :mod:`bluesky.plans` or in custom plans of your own.
+Multiple motors may be scanned simultaneously (as in the `0kl` and diagonal
+examples below).  Consult :mod:`bluesky.plans` for the full list of available
+scan plans.
 
-   .. code-block:: Python
-      :linenos:
+.. code-block:: Python
+   :linenos:
 
-      from hklpy2.misc import ConfigurationRunWrapper
+   from hklpy2.misc import ConfigurationRunWrapper
 
-      fourc = hklpy2.creator(name="fourc")
+   fourc = hklpy2.creator(name="fourc")
 
-      # Save configuration with every run
-      crw = ConfigurationRunWrapper(fourc)
-      RE.preprocessors.append(crw.wrapper)
+   # Save configuration with every run
+   crw = ConfigurationRunWrapper(fourc)
+   RE.preprocessors.append(crw.wrapper)
 
-      # steps not shown here:
-      #   define a sample & orientation reflections, and compute UB matrix
+   # steps not shown here:
+   #   define a sample & orientation reflections, and compute UB matrix
 
-      # record the diffractometer metadata to a run
-      RE(bp.count([fourc]))
+   # record the diffractometer metadata to a run
+   RE(bp.count([fourc]))
 
-      # relative *(h00)* scan
-      RE(bp.rel_scan([scaler, fourc], fourc.h, -0.1, 0.1, 21))
+   # relative (h00) scan — first move k and l to 0
+   fourc.move(0, 0, 0)
+   RE(bp.rel_scan([scaler, fourc], fourc.h, -0.1, 0.1, 21))
 
-      # absolute *(0kl)* scan
-      RE(bp.scan([scaler, fourc], fourc.k, 0.9, 1.1, fourc.l, 2, 3, 21))
+   # absolute (0kl) scan — first move h to 0
+   fourc.move(0, 1, 1)
+   RE(bp.scan([scaler, fourc], fourc.k, 0.9, 1.1, fourc.l, 2, 3, 21))
 
-      # absolute ``chi`` scan
-      RE(bp.scan([scaler, fourc], fourc.chi, 30, 60, 31))
+   # scan h, k, l together along a diagonal — all three vary, no pre-move needed
+   RE(bp.scan([scaler, fourc], fourc.h, 0.9, 1.1, fourc.k, 0.9, 1.1, fourc.l, 0.9, 1.1, 21))
+
+   # absolute chi scan (real axis)
+   RE(bp.scan([scaler, fourc], fourc.chi, 30, 60, 31))
 
 Keep in mind these considerations:
 
 1. Use the :class:`hklpy2.misc.ConfigurationRunWrapper` to save configuration
-   as part of every run.  Here's an example:
+   as part of every run:
 
    .. code-block:: Python
      :linenos:
@@ -201,30 +146,30 @@ Keep in mind these considerations:
 
    .. seealso:: :doc:`/guides/configuration_save_restore`
 
-2. Don't mix axis types (pseudos *v.* reals) in a scan.  You can only
-   scan with either *pseudo* axes (``h``, ``k``, ``l``, ``q``, ...) or *real*
-   axes (``omega``, ``tth``, ``chi``, ...) at one time.  You cannot scan with
-   both types (such as ``h`` and ``tth``) in a single scan (because the
-   :meth:`~hklpy2.diffract.DiffractometerBase.forward()` and
-   :meth:`~hklpy2.diffract.DiffractometerBase.inverse()` methods cannot
-   resolve).  Example:
+2. Only restore orientation reflections from a **matching**
+   diffractometer geometry (such as ``E4CV``).  Mismatch will trigger an exception.
+
+3. Scans use either
+   :meth:`~hklpy2.diffract.DiffractometerBase.forward` (pseudo axes → real
+   positions) or
+   :meth:`~hklpy2.diffract.DiffractometerBase.inverse` (real positions →
+   pseudo axes), but never both at once.  This means you must scan
+   **only pseudo axes** (``h``, ``k``, ``l``, ...) or **only real axes**
+   (``omega``, ``chi``, ``phi``, ``tth``, ...) in a single scan — never a
+   mix of both types:
 
    .. code-block:: Python
       :linenos:
 
-      # Cannot scan both ``k`` and ``chi`` at the same time.
+      # Cannot mix pseudo and real axes in a single scan.
       # This will raise a `ValueError` exception.
       RE(bp.scan([scaler, fourc], fourc.k, 0.9, 1.1, fourc.chi, 2, 3, 21))
 
-
-3. When scanning with pseudo axes (``h``, ``k``, ``l``, ``q``, ...), first
+4. When scanning with pseudo axes (``h``, ``k``, ``l``, ``q``, ...), first
    check that all steps in the scan can be computed successfully with
    the :meth:`~hklpy2.diffract.DiffractometerBase.forward()` computation::
 
         fourc.forward(1.9, 0, 0)
-
-4. Only restore orientation reflections from a **matching**
-   diffractometer geometry (such as ``E4CV``).  Mismatch will trigger an exception.
 
 .. _diffract_axes:
 
@@ -235,22 +180,37 @@ In |hklpy2|, the names of diffractometer axes (pseudos and reals) are
 not required to match any particular |solver| library.  Users are free
 to use any names allowed by ophyd.
 
+Every |solver| geometry defines a fixed expected order for its pseudo and
+real axes (for example, the E4CV geometry expects pseudos ``h, k, l`` and
+reals ``omega, chi, phi, tth`` in that order).  By default,
+:func:`~hklpy2.diffract.creator()` maps user-defined axis names to solver
+axis slots **positionally** — first user name to first solver slot, and so
+on.  This works automatically when the names are supplied in the solver's
+expected order.
+
+When user-defined names are supplied in a **different order** than the
+solver expects, or when **extra axes** are present, positional mapping
+produces a silently incorrect ``axes_xref``.  Use the ``_pseudo`` and/or
+``_real`` keywords to declare the correct mapping explicitly.  See
+:ref:`diffract_axes.out-of-order` for details and examples.
+
 User-defined axis names
 -----------------------
 
 Let's see examples of diffractometers built with user-defined names.
 
-* :ref:`diffract_axes.diffractometer-factory` with automatic mapping
-* :ref:`diffract_axes.direct-assign` with directed mapping
+* :ref:`diffract_axes.diffractometer-factory` — automatic (positional) mapping
+* :ref:`diffract_axes.direct-assign` — directed mapping with ``_real``
 
 .. _diffract_axes.diffractometer-factory:
 
 Diffractometer Creator
 +++++++++++++++++++++++++++++++
 
-The :func:`~hklpy2.diffract.creator()` function constructs a diffractometer object using the
-supplied `reals={}` to define their names.  These are mapped to the names used
-by the |solver|.  Let's show this cross-reference map with just a few commands::
+The :func:`~hklpy2.diffract.creator()` function constructs a diffractometer
+object using the supplied `reals={}` to define their names.  These are mapped to
+the names used by the |solver|.  Let's show this cross-reference map
+(``twoc.core.axes_xref``, in this case) with just a few commands::
 
     >>> import hklpy2
 
@@ -423,10 +383,21 @@ to |solver| axis names (as defined in our MyTwoC class above):
     >>> twoc.core.axes_xref
     {'q': 'q', 'theta': 'th', 'ttheta': 'tth'}
 
+.. _diffract_axes.out-of-order:
+
+Advanced: Axes Supplied Out of Order
+=====================================
+
+When custom axis names are defined in a different order than the |solver|
+expects — or when extra axes are present — use the ``_pseudo`` and ``_real``
+keywords to declare the correct mapping explicitly.  Without them, axes are
+zipped positionally and can be **silently swapped**, causing incorrect
+``axes_xref`` entries and potentially degenerate UB matrices.
+
 .. _diffract_axes.pseudos-out-of-order:
 
 Pseudos supplied in a different order than the solver expects
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-------------------------------------------------------------
 
 .. index:: _pseudo; pseudos out of order
 
@@ -506,7 +477,7 @@ mapping:
 .. _diffract_axes.reals-out-of-order:
 
 Reals supplied in a different order than the solver expects
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+-----------------------------------------------------------
 
 .. index:: _real; reals out of order
 


### PR DESCRIPTION
- closes #317

## Summary

- Rename page title to "How to Work with a Diffractometer" (Q4 from issue comments).
- Replace long attribute narrative with a compact summary table and `seealso` links to concept pages; keep Vibranium reflections table with improved `order` column (`1`/`2`/`--`) replacing opaque `True`/`False`.
- Expand "Diffractometer Axis Names" intro to explain the solver's expected axis order, positional mapping, and when `_pseudo`/`_real` are needed — with a forward reference to the Advanced section.
- Add bluesky RunEngine scan examples: `h00`, `0kl`, `hkl` diagonal, `chi`; include `fourc.move()` pre-moves to fix unvaried pseudos; note multi-motor scanning and link to `bluesky.plans`.
- Reorder considerations list: geometry-mismatch caveat moved to item 2 (before scanning details).
- Promote out-of-order axis sections to a top-level "Advanced: Axes Supplied Out of Order" section.
- Fix `beam` attribute cross-references: replace private `_WavelengthBase` (no autoapi anchor) with public `Wavelength` and `WavelengthXray`.
- Replace `DFRCT` placeholder with `fourc` throughout, consistent with all other docs.
- Update `guides.rst` description for `guide.diffract`.
- Add `RELEASE_NOTES.rst` entry under 0.5.1 Maintenance.

Agent: OpenCode (claudesonnet46)