### PR TITLE
docs #327 update quickstart.rst as installation verification and entry point

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -59,6 +59,10 @@ describe future plans.
     Maintenance
     -----------
 
+    * Update ``quickstart.rst``: reframe as an installation verification
+      page and entry point; add prominent ``seealso`` links to the tutorial,
+      how-to guides, and geometries reference; add an Installation section.
+      (:issue:`327`)
     * Review ``faq.rst``: replace inline answers that duplicate dedicated
       pages with concise summaries and ``seealso`` cross-references to
       the tutorial, ``how_constraints``, ``how_presets``, and

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -4,41 +4,69 @@
 Quickstart
 ==========
 
-Get started with a diffractometer object.  For example, use the diffractometer
-:func:`~hklpy2.diffract.creator()` function to build a 6-circle diffractometer
-(:ref:`E6C <geometries-hkl_soleil-e6c>` geometry). Use simulated motor
-axes.
+This page verifies that |hklpy2| is installed and working.  If you are new
+to |hklpy2|, continue to the :ref:`tutorial` after this page for a full
+guided walkthrough: sample setup, orientation reflections, UB matrix
+computation, and reciprocal-space scanning.
+
+.. seealso::
+
+   :ref:`tutorial` — start here for a complete first experience.
+
+   :ref:`guide.diffract` — how to define and work with a diffractometer.
+
+   :ref:`geometries` — available geometries and solvers.
+
+   :ref:`guides` — task-oriented how-to guides for common workflows.
+
+Installation
+------------
+
+Install |hklpy2| and its dependencies:
+
+.. code-block:: bash
+
+   pip install hklpy2
+
+Then confirm the installation:
 
 .. code-block:: python
-   :linenos:
+
+   import hklpy2
+   print(hklpy2.__version__)
+
+Create a Simulated Diffractometer
+----------------------------------
+
+Use :func:`~hklpy2.diffract.creator` to build a simulated 6-circle
+diffractometer (no hardware required):
+
+.. code-block:: python
 
    >>> import hklpy2
    >>> sixc = hklpy2.creator(name="sixc", geometry="E6C", solver="hkl_soleil")
 
-Make it the *default* diffractometer and show its current settings:
+Make it the *default* diffractometer for the interactive interface:
 
 .. code-block:: python
-   :linenos:
 
    >>> from hklpy2.user import *
    >>> set_diffractometer(sixc)
 
-Show its current settings (the brief report):
+Show the brief position report:
 
 .. code-block:: python
-   :linenos:
 
    >>> wh()  # wh: "WHere"
    h=0, k=0, l=0
    wavelength=1.0
    mu=0, omega=0, chi=0, phi=0, gamma=0, delta=0
 
-Show the full report:
+Show the full orientation report:
 
 .. code-block:: python
-   :linenos:
 
-    >>> pa()  # pa: "Print All"
+   >>> pa()  # pa: "Print All"
    diffractometer='sixc'
    HklSolver(name='hkl_soleil', version='5.1.2', geometry='E6C', engine_name='hkl', mode='bissector_vertical')
    Sample(name='sample', lattice=Lattice(a=1, system='cubic'))
@@ -55,11 +83,9 @@ Show the full report:
    wavelength=1.0
    mu=0, omega=0, chi=0, phi=0, gamma=0, delta=0
 
-Calculate the angles for :math:`hkl=(1\ \bar{1}\ 0)`, using
-:func:`~hklpy2.user.cahkl()`:
+Calculate angles for :math:`hkl=(1\ \bar{1}\ 0)` without moving motors:
 
 .. code-block:: python
-   :linenos:
 
    >>> cahkl(1, -1, 0)
    Hklpy2DiffractometerRealPos(mu=0, omega=-45.000000066239, chi=44.999999876575, phi=-89.999999917768, gamma=0, delta=-90.000000132477)
@@ -68,10 +94,9 @@ Calculate the angles for :math:`hkl=(1\ \bar{1}\ 0)`, using
    wavelength=1.0
    mu=0, omega=0, chi=0, phi=0, gamma=0, delta=0
 
-Note this was only a calculation.  The motors did not move.  Do that now.
+Note this was only a calculation — the motors did not move.  Move now:
 
 .. code-block:: python
-   :linenos:
 
    >>> sixc.move(1, -1, 0)
    MoveStatus(done=True, pos=sixc, elapsed=0.0, success=True, settle_time=0.0)
@@ -79,3 +104,7 @@ Note this was only a calculation.  The motors did not move.  Do that now.
    h=1.0, k=-1.0, l=0
    wavelength=1.0
    mu=0, omega=-45.0, chi=45.0, phi=-90.0, gamma=0, delta=-90.0
+
+If this works, |hklpy2| is installed correctly.  Continue to the
+:ref:`tutorial` to learn how to define a crystal sample, add orientation
+reflections, and compute the UB matrix.


### PR DESCRIPTION
- closes #327

## Summary

- Reframe `quickstart.rst` as an installation verification page and navigation entry point rather than a mini-tutorial.
- Add prominent `seealso` block at the top directing new users to the tutorial, how-to guides, and geometries reference.
- Add an explicit `Installation` section (`pip install hklpy2` + version check).
- Preserve all existing code examples (create, `wh()`, `pa()`, `cahkl()`, `move()`) unchanged — these serve as a useful smoke test distinct from the tutorial.
- Add a closing sentence directing users onward to the tutorial.

Note: quickstart cannot be replaced by the tutorial — the tutorial itself links to quickstart for installation instructions, and quickstart's brevity is intentional as a 2-minute smoke test.

Agent: OpenCode (claudesonnet46)