### PR TITLE
docs #325 restore explanatory character of concepts/lattice and concepts/wavelength

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -59,6 +59,13 @@ describe future plans.
     Maintenance
     -----------
 
+    * Restore explanatory character of ``concepts/lattice.rst``: add prose
+      explaining the role of the lattice in UB matrix computation and crystal
+      symmetry; add ``seealso`` links; convert bare ``:see:`` to proper RST.
+      Add ``seealso`` in ``concepts/wavelength.rst`` tying wavelength to
+      ``forward()``/``inverse()``. Add cross-reference from
+      ``diffractometers.rst`` (via ``make_geometries_doc.py``) to the crystal
+      systems table in ``concepts/lattice.rst``. (:issue:`325`)
     * Update ``quickstart.rst``: reframe as an installation verification
       page and entry point; add prominent ``seealso`` links to the tutorial,
       how-to guides, and geometries reference; add an Installation section.

--- a/docs/make_geometries_doc.py
+++ b/docs/make_geometries_doc.py
@@ -21,6 +21,11 @@ and then, for each geometry, the calculation engines, modes of operation, pseudo
 axes required, and any additional parameters required by the
 :meth:`~hklpy2.backends.base.SolverBase.mode`.  The mode defines which axes will
 be computed, which will be held constant, and any relationships between axes.
+
+.. seealso::
+
+   :ref:`concepts.lattice` — crystal lattice parameters and the seven crystal
+   systems, including the :ref:`lattice.crystal-systems` reference table.
 """
 
 

--- a/docs/source/concepts/lattice.rst
+++ b/docs/source/concepts/lattice.rst
@@ -6,17 +6,43 @@ Crystal Lattice
 
 .. index:: !lattice
 
-.. sample('EuPtIn4_eh1_ver', a=4.542, b=16.955, c=7.389)
+A crystal lattice describes the periodic arrangement of atoms in a crystal.
+Its geometry is characterised by six parameters: three unit-cell edge lengths
+:math:`a, b, c` (in ångströms) and three inter-edge angles
+:math:`\alpha, \beta, \gamma` (in degrees).
 
-Record a sample's crystalline :index:`lattice` parameters: :math:`a, b, c,
-\alpha, \beta, \gamma`. Information for a crystal lattice is stored in an
-instance of :class:`hklpy2.blocks.lattice.Lattice()`.  This class will examine
-the lattice parameters and report the crystal system.  If the parameters do not
-match any of these crystal systems, an exception will be raised.
+The lattice matters to diffractometer operation for two reasons:
 
-A lattice is stored as part of the :ref:`sample <concepts.sample>`.
+1. **UB matrix** — the :math:`B` matrix is computed directly from the lattice
+   parameters and transforms Miller indices :math:`(h, k, l)` into Cartesian
+   reciprocal-space coordinates.  Without accurate lattice parameters the
+   :math:`UB` matrix, and therefore every
+   :meth:`~hklpy2.diffract.DiffractometerBase.forward` and
+   :meth:`~hklpy2.diffract.DiffractometerBase.inverse` calculation, will be
+   wrong.
 
-.. rubric:: Examples of the Seven 3-D Crystal Systems (highest to lowest symmetry)
+2. **Crystal symmetry** — the crystal system (cubic, hexagonal, …) constrains
+   which lattice parameters are independent.  |hklpy2| determines the crystal
+   system from the supplied parameters automatically and reports it; if the
+   parameters are inconsistent with any known system an exception is raised.
+
+In |hklpy2|, lattice parameters are stored in an instance of
+:class:`~hklpy2.blocks.lattice.Lattice`, which is part of the
+:ref:`sample <concepts.sample>`.
+
+.. seealso::
+
+   :ref:`concepts.sample` — the sample that owns the lattice.
+
+   :ref:`how_calc_ub` — computing the UB matrix from the lattice and orientation reflections.
+
+   :ref:`glossary` — definitions of lattice, UB matrix, and related terms.
+
+.. _lattice.crystal-systems:
+
+.. rubric:: The Seven 3-D Crystal Systems (highest to lowest symmetry)
+
+.. index:: crystal system
 
 =============== =================================== = === === ===== ====== =====
 system          command                             a b   c   alpha beta   gamma
@@ -30,15 +56,10 @@ monoclinic      ``Lattice(4, 5, 3, beta=75)``       4 5   3   *90*  75     *90*
 triclinic       ``Lattice(4, 5, 3, 75., 85., 95.)`` 4 5   3   75    85     95
 =============== =================================== = === === ===== ====== =====
 
-Default values are *italicized*.  It is not necessary to supply the default parameters.
+Default values are *italicized*.  It is not necessary to supply the default
+parameters.
 
-:see: https://dictionary.iucr.org/Crystal_system
-:see: https://en.wikipedia.org/wiki/Crystal_system
-
-.. rubric:: EXAMPLES
-
-It is not necessary to enter any of the default information for any lattice
-(such as the 90 degree angles for an orthorhombic crystals).
+.. rubric:: Examples
 
 .. code-block:: Python
     :linenos:
@@ -65,4 +86,10 @@ It is not necessary to enter any of the default information for any lattice
     >>> Lattice(4, 5, 3, 75., 85., 95.)
     Lattice(a=4, b=5, c=3, alpha=75.0, beta=85.0, gamma=95.0)
 
-.. seealso:: :ref:`glossary`
+.. seealso::
+
+   :ref:`lattice.crystal-systems` is also cross-referenced from :ref:`geometries`.
+
+   `IUCr: Crystal system <https://dictionary.iucr.org/Crystal_system>`_
+
+   `Wikipedia: Crystal system <https://en.wikipedia.org/wiki/Crystal_system>`_

--- a/docs/source/concepts/wavelength.rst
+++ b/docs/source/concepts/wavelength.rst
@@ -14,24 +14,29 @@ accessible to the experiment.
     diffractometer users at X-ray synchrotrons, *wavelength* is the general term
     used by diffraction science.
 
-Here, a diffractometer (as a subclass of
-:class:`~hklpy2.diffract.DiffractometerBase`) is a *positioner* that expects the
-incident radiation to be *monochromatic*.  Knowledge of wavelength is essential
-for diffractometer operations.  Simulators are provided for the general case
-(:class:`~hklpy2.incident.Wavelength()`) for any type of monochromatic
-radiation) and for the case of X-rays
-(:class:`~hklpy2.incident.WavelengthXray()`) where photon energy is computed
-from the wavelength.
+A diffractometer (as a subclass of
+:class:`~hklpy2.diffract.DiffractometerBase`) expects the incident radiation to
+be *monochromatic*.  Wavelength is used directly in every
+:meth:`~hklpy2.diffract.DiffractometerBase.forward` and
+:meth:`~hklpy2.diffract.DiffractometerBase.inverse` calculation — it sets the
+scale of the reciprocal lattice and determines which :math:`hkl` reflections
+lie within the Ewald sphere and are therefore reachable.
 
-When the wavelength (and possibly the energy) is known from EPICS, *read-only*
-support is provided for the general case
-(:class:`~hklpy2.incident.EpicsWavelengthRO()`) and for a monochromator
-(:class:`~hklpy2.incident.EpicsMonochromatorRO()`) which provides both
-wavelength and energy. Control of these EPICS PVs is beyond the scope of
-diffractometer controls. Refer to EPICS for control of the monochromator or
-wavelength PV.  Or, create a custom subclass of
-:class:`~hklpy2.incident._WavelengthBase()`.
+|hklpy2| provides wavelength classes for several common situations:
 
-.. seealso:: The :mod:`~hklpy2.incident` module.
+- :class:`~hklpy2.incident.Wavelength` — general monochromatic source
+  (simulated, any radiation type).
+- :class:`~hklpy2.incident.WavelengthXray` — X-ray source with energy/wavelength
+  conversion (default for most geometries).
+- :class:`~hklpy2.incident.EpicsWavelengthRO` — read wavelength from an EPICS PV
+  (read-only; control of the PV is outside the diffractometer).
+- :class:`~hklpy2.incident.EpicsMonochromatorRO` — read both wavelength and
+  energy from a monochromator EPICS PV (read-only).
+
+.. seealso::
+
+   :mod:`hklpy2.incident` — full API reference for wavelength classes.
+
+   :ref:`guide.diffract` — how to connect wavelength to a diffractometer object.
 
 .. [#] https://dictionary.iucr.org/Ewald_sphere

--- a/docs/source/diffractometers.rst
+++ b/docs/source/diffractometers.rst
@@ -1,5 +1,5 @@
 .. author: make_geometries_doc.py
-.. date: 2025-03-11 13:31:21.554744
+.. date: 2026-04-14 22:28:02.612592
 
 .. _geometries:
 
@@ -7,7 +7,6 @@
 Diffractometers
 ===============
 
-.. index:: diffractometers
 .. index:: geometries
 
 
@@ -16,6 +15,11 @@ and then, for each geometry, the calculation engines, modes of operation, pseudo
 axes required, and any additional parameters required by the
 :meth:`~hklpy2.backends.base.SolverBase.mode`.  The mode defines which axes will
 be computed, which will be held constant, and any relationships between axes.
+
+.. seealso::
+
+   :ref:`concepts.lattice` — crystal lattice parameters and the seven crystal
+   systems, including the :ref:`lattice.crystal-systems` reference table.
 
 .. _geometries.number_of_reals:
 


### PR DESCRIPTION
- closes #325

## Summary

**`concepts/lattice.rst`:**
- Add explanatory prose answering *why* the lattice matters: its role in the `B` matrix (and therefore every `forward()`/`inverse()` call) and how crystal symmetry constrains the independent parameters.
- Add `seealso` links to `concepts.sample`, `how_calc_ub`, and the glossary.
- Add `_lattice.crystal-systems` anchor so the crystal systems table can be cross-referenced from other pages.
- Convert bare `:see:` directives to proper `.. seealso::` RST.
- Keep the crystal systems table and code examples in place (table stays in `concepts/lattice.rst` per decision — not moved to `diffractometers.rst` which is script-generated).

**`concepts/wavelength.rst`:**
- Rewrite the class enumeration as an explanatory bullet list with a sentence tying wavelength directly to `forward()`/`inverse()` and the Ewald sphere.
- Replace bare `.. seealso::` with a structured block linking to the `hklpy2.incident` API reference and `guide.diffract`.
- Remove reference to private `_WavelengthBase`.

**`docs/make_geometries_doc.py` / `docs/source/diffractometers.rst`:**
- Add `seealso` in `PREFACE` pointing to `concepts.lattice` and the `lattice.crystal-systems` table, so the cross-reference survives future regeneration of `diffractometers.rst`.
- Regenerate `diffractometers.rst` to include the new `seealso`.

Note: automating `make_geometries_doc.py` as part of the docs build is tracked separately as #331.

Agent: OpenCode (claudesonnet46)