### PR TITLE
maint #331 automate diffractometers.rst generation on docs build

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -59,6 +59,12 @@ describe future plans.
     Maintenance
     -----------
 
+    * Automate ``diffractometers.rst`` generation: refactor
+      ``make_geometries_doc.py`` to use a solver-version sentinel
+      (``.. solvers: name=version ...``) for stale detection instead of a
+      timestamp; add a ``builder-inited`` hook in ``conf.py`` so the file is
+      regenerated automatically on every docs build when solver versions
+      change; add a "Solver Versions" table to the page. (:issue:`331`)
     * Restore explanatory character of ``concepts/lattice.rst``: add prose
       explaining the role of the lattice in UB matrix computation and crystal
       symmetry; add ``seealso`` links; convert bare ``:see:`` to proper RST.

--- a/docs/make_geometries_doc.py
+++ b/docs/make_geometries_doc.py
@@ -1,14 +1,31 @@
 """
-(Re)create the `geometries.rst` document.
+(Re)create the `diffractometers.rst` document.
+
+The file is only written when the installed solver versions differ from those
+recorded in the existing file.  Version information is stored in a
+machine-readable sentinel comment at the top of the file::
+
+    .. solvers: hkl_soleil=5.1.2 th_tth=0.0.14
+
+This sentinel is also displayed on the page as a human-readable table so
+users can verify which library versions produced the geometry tables.
+
+Automation
+----------
+Call :func:`main` from a Sphinx ``builder-inited`` event in ``conf.py``
+to keep the file current automatically on every docs build.
 """
 
-import datetime
+import logging
 import pathlib
+import re
 from collections import defaultdict
 
 from pyRestTable import Table
 
 import hklpy2
+
+logger = logging.getLogger(__name__)
 
 DOCS_DIR = pathlib.Path(__file__).parent / "source"
 GEO_DOC = DOCS_DIR / "diffractometers.rst"
@@ -28,6 +45,52 @@ be computed, which will be held constant, and any relationships between axes.
    systems, including the :ref:`lattice.crystal-systems` reference table.
 """
 
+# Regex to extract the sentinel line from an existing file.
+_SENTINEL_RE = re.compile(r"^\.\. solvers:\s*(.+)$", re.MULTILINE)
+
+
+def solver_versions() -> dict[str, str]:
+    """Return a dict of {solver_name: version} for all registered solvers."""
+    versions = {}
+    for sname in sorted(hklpy2.solvers()):
+        Solver = hklpy2.get_solver(sname)
+        if not Solver.geometries():
+            continue
+        gname = sorted(Solver.geometries())[0]
+        versions[sname] = Solver(gname).version
+    return versions
+
+
+def sentinel_string(versions: dict[str, str]) -> str:
+    """Render solver versions as a compact sentinel string."""
+    return " ".join(f"{k}={v}" for k, v in sorted(versions.items()))
+
+
+def is_stale(versions: dict[str, str]) -> bool:
+    """Return True if diffractometers.rst is missing or has different solver versions."""
+    if not GEO_DOC.exists():
+        logger.info("diffractometers.rst does not exist — will generate.")
+        return True
+    text = GEO_DOC.read_text()
+    m = _SENTINEL_RE.search(text)
+    if m is None:
+        logger.info("diffractometers.rst has no solver sentinel — will regenerate.")
+        return True
+    current = sentinel_string(versions)
+    recorded = m.group(1).strip()
+    if current != recorded:
+        logger.info(
+            "diffractometers.rst is stale: recorded=%r current=%r — will regenerate.",
+            recorded,
+            current,
+        )
+        return True
+    logger.info(
+        "diffractometers.rst is up to date (solvers: %s) — skipping regeneration.",
+        current,
+    )
+    return False
+
 
 def title(text: str, underchar: str = H1, both: bool = False) -> str:
     bars = underchar * len(text)
@@ -37,16 +100,35 @@ def title(text: str, underchar: str = H1, both: bool = False) -> str:
     return result
 
 
-def page_header():
+def page_header(versions: dict[str, str]) -> str:
     text = [
-        f".. author: {__file__.split('/')[-1]}",
-        f".. date: {datetime.datetime.now()}",
+        f".. author: {pathlib.Path(__file__).name}",
+        f".. solvers: {sentinel_string(versions)}",
         "",
         ".. _geometries:",
         "",
         title(PAGE_TITLE, underchar=H1, both=True),
         ".. index:: geometries",
         "",
+    ]
+    return "\n".join(text)
+
+
+def solver_versions_table(versions: dict[str, str]) -> str:
+    """RST table of solver names and versions displayed on the page."""
+    table = Table()
+    table.labels = ["Solver", "Version"]
+    for sname, ver in sorted(versions.items()):
+        table.addRow((sname, ver))
+    text = [
+        ".. _geometries.solver-versions:",
+        "",
+        title("Solver Versions", H1),
+        ".. index:: geometries; solver versions",
+        "",
+        "The geometry tables below were generated from these installed solver versions:",
+        "",
+        str(table),
     ]
     return "\n".join(text)
 
@@ -58,7 +140,7 @@ def rst_anchor(sname: str, gname: str) -> str:
     return f"geometries-{sname}-{gname}".lower()
 
 
-def table_of_reals():
+def table_of_reals() -> str:
     # Count the reals.
     circles = defaultdict(list)
     for sname in sorted(hklpy2.solvers()):
@@ -108,7 +190,7 @@ def geometry_summary_table(solver_name, geometry_name: str) -> str:
     return "\n".join(text)
 
 
-def all_summary_tables():
+def all_summary_tables() -> str:
     text = [
         ".. _geometries.summary_tables:",
         "",
@@ -146,16 +228,32 @@ def linter(text: str) -> str:
     return f"{text}\n"  # always end with blank line
 
 
-def main():
+def main() -> bool:
+    """
+    Generate ``diffractometers.rst`` if solver versions have changed.
+
+    Returns
+    -------
+    bool
+        ``True`` if the file was (re)generated, ``False`` if it was already
+        up to date and no write was performed.
+    """
+    versions = solver_versions()
+    if not is_stale(versions):
+        return False
+
     text = [
-        page_header(),
+        page_header(versions),
         PREFACE,
+        solver_versions_table(versions),
         table_of_reals(),
         all_summary_tables(),
     ]
-    with open(GEO_DOC, "w") as f:
-        f.write(linter("\n".join(text)))
+    GEO_DOC.write_text(linter("\n".join(text)))
+    logger.info("diffractometers.rst written (solvers: %s).", sentinel_string(versions))
+    return True
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     main()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -157,7 +157,7 @@ def _generate_diffractometers_rst(app):
 def setup(app):
     """Connect autoapi events, register Jinja2 filters, and auto-generate geometry docs."""
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))  # docs/
-    app.connect("builder-inited", lambda app: _generate_diffractometers_rst(app))
+    app.connect("builder-inited", _generate_diffractometers_rst)
     app.connect("autoapi-skip-member", autoapi_skip_member)
     app.config.autoapi_prepare_jinja_env = _prepare_jinja_env
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,14 +144,21 @@ def _prepare_jinja_env(jinja_env) -> None:
 
 def _generate_diffractometers_rst(app):
     """Regenerate diffractometers.rst if installed solver versions have changed."""
-    import make_geometries_doc
-
     logger = logging.getLogger(__name__)
-    updated = make_geometries_doc.main()
-    if updated:
-        logger.info("diffractometers.rst was regenerated.")
-    else:
-        logger.info("diffractometers.rst is current; no regeneration needed.")
+    try:
+        import make_geometries_doc
+
+        updated = make_geometries_doc.main()
+        if updated:
+            logger.info("diffractometers.rst was regenerated.")
+        else:
+            logger.info("diffractometers.rst is current; no regeneration needed.")
+    except Exception as exc:
+        logger.warning(
+            "diffractometers.rst auto-generation skipped: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
 
 
 def setup(app):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@
 
 # flake8: noqa
 
+import logging
 import os
 import pathlib
 import sys
@@ -141,8 +142,22 @@ def _prepare_jinja_env(jinja_env) -> None:
     jinja_env.filters["tilde_type"] = _tilde_type_str
 
 
+def _generate_diffractometers_rst(app):
+    """Regenerate diffractometers.rst if installed solver versions have changed."""
+    import make_geometries_doc
+
+    logger = logging.getLogger(__name__)
+    updated = make_geometries_doc.main()
+    if updated:
+        logger.info("diffractometers.rst was regenerated.")
+    else:
+        logger.info("diffractometers.rst is current; no regeneration needed.")
+
+
 def setup(app):
-    """Connect autoapi events and register Jinja2 filters."""
+    """Connect autoapi events, register Jinja2 filters, and auto-generate geometry docs."""
+    sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))  # docs/
+    app.connect("builder-inited", lambda app: _generate_diffractometers_rst(app))
     app.connect("autoapi-skip-member", autoapi_skip_member)
     app.config.autoapi_prepare_jinja_env = _prepare_jinja_env
 

--- a/docs/source/diffractometers.rst
+++ b/docs/source/diffractometers.rst
@@ -1,5 +1,5 @@
 .. author: make_geometries_doc.py
-.. date: 2026-04-14 22:28:02.612592
+.. solvers: hkl_soleil=5.1.3 th_tth=0.4.3.dev4+g998861fb2
 
 .. _geometries:
 
@@ -20,6 +20,22 @@ be computed, which will be held constant, and any relationships between axes.
 
    :ref:`concepts.lattice` — crystal lattice parameters and the seven crystal
    systems, including the :ref:`lattice.crystal-systems` reference table.
+
+.. _geometries.solver-versions:
+
+Solver Versions
+===============
+
+.. index:: geometries; solver versions
+
+The geometry tables below were generated from these installed solver versions:
+
+========== =====================
+Solver     Version
+========== =====================
+hkl_soleil 5.1.3
+th_tth     0.4.3.dev4+g998861fb2
+========== =====================
 
 .. _geometries.number_of_reals:
 


### PR DESCRIPTION
- closes #331

## Summary

`diffractometers.rst` was previously regenerated by a manual step (`python docs/make_geometries_doc.py`) whenever a new version of a solver library was installed.  This PR automates that step.

### Approach

Rather than comparing full file content (which would always differ due to the old timestamp), the script now writes a machine-readable sentinel comment at the top of the file:

```
.. solvers: hkl_soleil=5.1.3 th_tth=0.4.3.dev9+...
```

On each run the script reads the sentinel from the existing file, computes the current sentinel from installed solver versions, and only regenerates if they differ.  This is version-checking, not content-diffing.

### Changes

**`docs/make_geometries_doc.py`:**
- Replace `.. date: <timestamp>` header with `.. solvers: name=version ...` sentinel.
- Add `solver_versions()`, `sentinel_string()`, `is_stale()` for version-based stale detection.
- `main()` logs whether the file is current or will be regenerated (always, for diagnostics), and returns `True`/`False`.
- Add `solver_versions_table()` — displays solver name and version on the page itself so users can verify which library produced the tables.

**`docs/source/conf.py`:**
- Add `_generate_diffractometers_rst()` and connect it to the `builder-inited` Sphinx event so the file is checked (and regenerated if stale) automatically before any source is read — for every `sphinx-build` invocation including CI, `make html`, and Read the Docs.
- Logs outcome either way as a diagnostic.

**`docs/source/diffractometers.rst`:**
- Regenerated with new sentinel format and Solver Versions table.

Note: `name` and `version` are already part of the documented solver interface (`howto_write_solver.rst` lines 175–176) — no new requirements added.

Agent: OpenCode (claudesonnet46)