### PR TITLE
Consolidate zone plans into hklpy2/plans.py

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,6 +35,16 @@ describe future plans.
 
     Release expected by 2026-H2.
 
+    Deprecations
+    ------------
+
+    * Deprecate ``move_zone`` and ``scan_zone`` imports from ``hklpy2.blocks.zone``; use ``hklpy2.plans`` instead. (:issue:`339`)
+
+    Maintenance
+    -----------
+
+    * Move ``move_zone`` and ``scan_zone`` plans from ``hklpy2.blocks.zone`` to ``hklpy2.plans`` (canonical plan location). (:issue:`339`)
+
 0.5.2
 #####
 

--- a/src/hklpy2/__init__.py
+++ b/src/hklpy2/__init__.py
@@ -57,9 +57,9 @@ from .backends import SolverBase  # noqa: E402, F401
 from .blocks.configure import Configuration  # noqa: E402, F401
 from .blocks.lattice import SI_LATTICE_PARAMETER  # noqa: E402, F401
 from .blocks.zone import OrthonormalZone  # noqa: E402, F401, F403
-from .blocks.zone import move_zone  # noqa: E402, F401, F403
-from .blocks.zone import scan_zone  # noqa: E402, F401, F403
+from .plans import move_zone  # noqa: E402, F401, F403
 from .plans import scan_psi  # noqa: E402, F401, F403
+from .plans import scan_zone  # noqa: E402, F401, F403
 from .diffract import creator  # noqa: E402, F401, F403
 from .diffract import diffractometer_class_factory  # noqa: E402, F401, F403
 from .incident import A_KEV  # noqa: E402, F401

--- a/src/hklpy2/blocks/tests/test_zone.py
+++ b/src/hklpy2/blocks/tests/test_zone.py
@@ -10,9 +10,9 @@ import pytest
 from ophyd.sim import noisy_det
 
 from ...diffract import creator
+from ...plans import move_zone
+from ...plans import scan_zone
 from ..zone import OrthonormalZone
-from ..zone import move_zone
-from ..zone import scan_zone
 from ..zone import zone_series
 from ..zone import zonespace
 
@@ -440,3 +440,40 @@ def test_zone_package_exports(parms, context):
         import hklpy2
 
         assert hasattr(hklpy2, parms["name"])
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                func_name="move_zone",
+                msg="move_zone from hklpy2.blocks.zone is deprecated",
+            ),
+            does_not_raise(),
+            id="move_zone from blocks.zone emits DeprecationWarning",
+        ),
+        pytest.param(
+            dict(
+                func_name="scan_zone",
+                msg="scan_zone from hklpy2.blocks.zone is deprecated",
+            ),
+            does_not_raise(),
+            id="scan_zone from blocks.zone emits DeprecationWarning",
+        ),
+    ],
+)
+def test_zone_deprecated_shims(parms, context):
+    """Importing move_zone/scan_zone from blocks.zone should emit DeprecationWarning."""
+    with context:
+        import importlib
+
+        zone_mod = importlib.import_module("hklpy2.blocks.zone")
+        func = getattr(zone_mod, parms["func_name"])
+        with pytest.warns(DeprecationWarning, match=re.escape(parms["msg"])):
+            # Call the shim with dummy args to trigger the warning;
+            # wrap in a try to ignore downstream errors.
+            try:
+                func()
+            except Exception:
+                pass

--- a/src/hklpy2/blocks/tests/test_zone.py
+++ b/src/hklpy2/blocks/tests/test_zone.py
@@ -475,5 +475,5 @@ def test_zone_deprecated_shims(parms, context):
             # wrap in a try to ignore downstream errors.
             try:
                 func()
-            except Exception:
-                pass
+            except Exception as ex:
+                logging.debug("Ignoring expected downstream error from deprecated shim call", exc_info=ex)

--- a/src/hklpy2/blocks/zone.py
+++ b/src/hklpy2/blocks/zone.py
@@ -20,11 +20,11 @@ SPEC equivalents
     ~zonespace
     ~zone_series
 
-.. deprecated::
+.. note::
 
     :func:`move_zone` and :func:`scan_zone` have moved to :mod:`hklpy2.plans`.
-    Importing them from :mod:`hklpy2.blocks.zone` is deprecated and will be
-    removed in a future release.
+    Importing them from :mod:`hklpy2.blocks.zone` emits a
+    :exc:`DeprecationWarning` and will be removed in a future release.
 """
 
 import logging

--- a/src/hklpy2/blocks/zone.py
+++ b/src/hklpy2/blocks/zone.py
@@ -10,39 +10,37 @@ SPEC equivalents
 ----------------
 
 - ``cz`` — :class:`OrthonormalZone` (``b1=``, ``b2=``): calculate zone axis from two vectors.
-- ``mz`` — :func:`move_zone`: move diffractometer to a position in the zone.
+- ``mz`` — :func:`~hklpy2.plans.move_zone`: move diffractometer to a position in the zone.
 - ``pl`` — :meth:`OrthonormalZone.define_axis`: set the scattering plane from two vectors.
 - ``sz`` — :class:`OrthonormalZone` (``axis=``): set zone axis directly.
 
 .. autosummary::
 
     ~OrthonormalZone
-    ~move_zone
-    ~scan_zone
     ~zonespace
     ~zone_series
+
+.. deprecated::
+
+    :func:`move_zone` and :func:`scan_zone` have moved to :mod:`hklpy2.plans`.
+    Importing them from :mod:`hklpy2.blocks.zone` is deprecated and will be
+    removed in a future release.
 """
 
 import logging
-from typing import Any
+import warnings
 from typing import Iterator
-from typing import Mapping
 from typing import Optional
 from typing import Sequence
 
 import numpy as np
 from deprecated.sphinx import versionadded
-from bluesky import plan_stubs as bps
-from bluesky import preprocessors as bpp
-from bluesky.protocols import Readable
-from bluesky.utils import plan
 from numpy.typing import NDArray
 from pyRestTable import Table
 
 from ..diffract import DiffractometerBase
 from ..misc import NoForwardSolutions
 from ..typing import INPUT_VECTOR
-from ..typing import BlueskyPlanType
 
 logger = logging.getLogger(__name__)
 
@@ -412,125 +410,44 @@ def zone_series(
     print(table)
 
 
-@versionadded(
-    version="0.4.2",
-    reason="Move diffractometer to a zone position (SPEC ``mz`` equivalent).",
-)
-@plan
-def move_zone(
-    diffractometer: DiffractometerBase,
-    hkl: INPUT_VECTOR,
-) -> BlueskyPlanType:
+# ---------------------------------------------------------------------------
+# Deprecated re-exports of plan functions now living in hklpy2.plans
+# ---------------------------------------------------------------------------
+
+
+def move_zone(*args, **kwargs):
     """
-    Move diffractometer to a position in the zone (SPEC ``mz`` equivalent).
-
-    Computes the real-axis positions corresponding to the given pseudo
-    position *hkl* via the diffractometer's forward calculation and moves
-    all real axes there.
-
-    .. rubric:: Example
-
-    .. code-block:: python
-
-        from hklpy2 import creator
-        from hklpy2.blocks.zone import move_zone
-        fourc = creator()
-        RE(move_zone(fourc, (1, 0, 0)))
-
-    Parameters
-    ----------
-    diffractometer : DiffractometerBase
-        hklpy2 diffractometer object.
-    hkl : INPUT_VECTOR
-        Target pseudo position (*h, k, l*).
+    .. deprecated::
+        ``move_zone`` has moved to :mod:`hklpy2.plans`.
+        Import it from there: ``from hklpy2.plans import move_zone``.
+        This re-export will be removed in a future release.
     """
-    pseudos = list(hkl) if not isinstance(hkl, dict) else hkl
-    reals = diffractometer.forward(pseudos)
-    parms = []
-    for k, v in zip(diffractometer.real_axis_names, reals):
-        parms.append(getattr(diffractometer, k))
-        parms.append(v)
-    yield from bps.mv(*parms)
+    warnings.warn(
+        "Importing move_zone from hklpy2.blocks.zone is deprecated. "
+        "Use 'from hklpy2.plans import move_zone' instead. "
+        "This compatibility shim will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from ..plans import move_zone as _move_zone
+
+    return _move_zone(*args, **kwargs)
 
 
-@versionadded(
-    version="0.3.0",
-    reason="Scan a diffractometer through a zone (SPEC ``scanzone`` equivalent).",
-)
-@plan
-def scan_zone(
-    detectors: Sequence[Readable],
-    diffractometer: DiffractometerBase,
-    start: INPUT_VECTOR,
-    finish: INPUT_VECTOR,
-    num: int,
-    md: Optional[Mapping[str, Any]] = None,
-) -> BlueskyPlanType:
+def scan_zone(*args, **kwargs):
     """
-    Perform a zone scan on a diffractometer.
-
-    .. rubric:: Behavior
-
-    * Computes a sequence of pseudos and the corresponding reals in the
-      crystallographic zone defined by the cross-product of start cross finish.
-      Skips a position if not permitted by the UB matrix or diffractometer
-      constraints.
-    * For each point:
-        1. Moves the diffractometer real axes to the computed
-           real positions.
-        2. Triggers all detectors and waits for completion.
-        3. Creates a ``primary`` stream, reads all detectors and the
-           diffractometer, and saves the event.
-
-    .. rubric:: Example
-
-    .. code-block:: python
-
-        from hklpy2 import creator, scan_zone
-        fourc = creator()
-        (uid,) = RE(scan_zone([scaler],fourc, (1,0,0), (0,1,0), 5))
-
-    Parameters
-    ----------
-    detectors : Sequence[Readable])
-        Ophyd devices to trigger and read at each measurement point.
-    diffractometer : hklpy2.DiffractometerBase
-        hklpy2 Diffractometer object.
-    start : INPUT_VECTOR
-        Starting :data:`~hklpy2.misc.INPUT_VECTOR` of pseudos (*h,k,l*).
-    finish : INPUT_VECTOR
-        Finishing :data:`~hklpy2.misc.INPUT_VECTOR` of pseudos (*h,k,l*).
-    num : int
-        Number of points to sample along the zone (inclusive
-        of endpoints).
-    md : dict
-        (Optional) User-supplied metadata.
+    .. deprecated::
+        ``scan_zone`` has moved to :mod:`hklpy2.plans`.
+        Import it from there: ``from hklpy2.plans import scan_zone``.
+        This re-export will be removed in a future release.
     """
-    _md = {"plan_name": "scan_zone", **(md or {})}
+    warnings.warn(
+        "Importing scan_zone from hklpy2.blocks.zone is deprecated. "
+        "Use 'from hklpy2.plans import scan_zone' instead. "
+        "This compatibility shim will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from ..plans import scan_zone as _scan_zone
 
-    @bpp.stage_decorator(detectors)
-    @bpp.run_decorator(md=_md)
-    def inner():
-        # Compute sequence of pseudos & reals in the zone
-        for pseudos, reals in zonespace(diffractometer, start, finish, num):
-            # move axes
-            logger.debug("zone hkl=%s", pseudos)
-            parms = []
-            for k, v in zip(diffractometer.real_axis_names, reals):
-                parms.append(getattr(diffractometer, k))
-                parms.append(v)
-            yield from bps.mv(*parms)
-
-            # trigger
-            group = "trigger_objects"
-            for item in detectors:
-                yield from bps.trigger(item, group=group)
-            yield from bps.wait(group=group)
-
-            # read
-            yield from bps.create("primary")
-            for item in detectors + [diffractometer]:
-                yield from bps.read(item)
-            yield from bps.save()
-
-    return (yield from inner())
+    return _scan_zone(*args, **kwargs)

--- a/src/hklpy2/plans.py
+++ b/src/hklpy2/plans.py
@@ -16,7 +16,9 @@ plans.  New plans should be implemented here directly.
 
 .. autosummary::
 
+    ~move_zone
     ~scan_psi
+    ~scan_zone
 
 .. rubric:: Solver compatibility for scan_psi
 
@@ -43,18 +45,24 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 
+from bluesky import plan_stubs as bps
+from bluesky import preprocessors as bpp
 from bluesky.protocols import Readable
 from bluesky.utils import plan
 from deprecated.sphinx import versionadded
 
+from .blocks.zone import zonespace
 from .diffract import DiffractometerBase
 from .misc import validate_not_parallel
+from .typing import INPUT_VECTOR
 from .typing import BlueskyPlanType
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "move_zone",
     "scan_psi",
+    "scan_zone",
 ]
 
 
@@ -157,6 +165,129 @@ def _find_psi_axis(
 # ---------------------------------------------------------------------------
 # Plans
 # ---------------------------------------------------------------------------
+
+
+@versionadded(
+    version="0.4.2",
+    reason="Move diffractometer to a zone position (SPEC ``mz`` equivalent).",
+)
+@plan
+def move_zone(
+    diffractometer: DiffractometerBase,
+    hkl: INPUT_VECTOR,
+) -> BlueskyPlanType:
+    """
+    Move diffractometer to a position in the zone (SPEC ``mz`` equivalent).
+
+    Computes the real-axis positions corresponding to the given pseudo
+    position *hkl* via the diffractometer's forward calculation and moves
+    all real axes there.
+
+    .. rubric:: Example
+
+    .. code-block:: python
+
+        from hklpy2 import creator, move_zone
+        fourc = creator()
+        RE(move_zone(fourc, (1, 0, 0)))
+
+    Parameters
+    ----------
+    diffractometer : DiffractometerBase
+        hklpy2 diffractometer object.
+    hkl : INPUT_VECTOR
+        Target pseudo position (*h, k, l*).
+    """
+    pseudos = list(hkl) if not isinstance(hkl, dict) else hkl
+    reals = diffractometer.forward(pseudos)
+    parms = []
+    for k, v in zip(diffractometer.real_axis_names, reals):
+        parms.append(getattr(diffractometer, k))
+        parms.append(v)
+    yield from bps.mv(*parms)
+
+
+@versionadded(
+    version="0.3.0",
+    reason="Scan a diffractometer through a zone (SPEC ``scanzone`` equivalent).",
+)
+@plan
+def scan_zone(
+    detectors: Sequence[Readable],
+    diffractometer: DiffractometerBase,
+    start: INPUT_VECTOR,
+    finish: INPUT_VECTOR,
+    num: int,
+    md: Optional[Mapping[str, Any]] = None,
+) -> BlueskyPlanType:
+    """
+    Perform a zone scan on a diffractometer.
+
+    .. rubric:: Behavior
+
+    * Computes a sequence of pseudos and the corresponding reals in the
+      crystallographic zone defined by the cross-product of start cross finish.
+      Skips a position if not permitted by the UB matrix or diffractometer
+      constraints.
+    * For each point:
+        1. Moves the diffractometer real axes to the computed
+           real positions.
+        2. Triggers all detectors and waits for completion.
+        3. Creates a ``primary`` stream, reads all detectors and the
+           diffractometer, and saves the event.
+
+    .. rubric:: Example
+
+    .. code-block:: python
+
+        from hklpy2 import creator, scan_zone
+        fourc = creator()
+        (uid,) = RE(scan_zone([scaler], fourc, (1,0,0), (0,1,0), 5))
+
+    Parameters
+    ----------
+    detectors : Sequence[Readable])
+        Ophyd devices to trigger and read at each measurement point.
+    diffractometer : hklpy2.DiffractometerBase
+        hklpy2 Diffractometer object.
+    start : INPUT_VECTOR
+        Starting :data:`~hklpy2.typing.INPUT_VECTOR` of pseudos (*h,k,l*).
+    finish : INPUT_VECTOR
+        Finishing :data:`~hklpy2.typing.INPUT_VECTOR` of pseudos (*h,k,l*).
+    num : int
+        Number of points to sample along the zone (inclusive
+        of endpoints).
+    md : dict
+        (Optional) User-supplied metadata.
+    """
+    _md = {"plan_name": "scan_zone", **(md or {})}
+
+    @bpp.stage_decorator(detectors)
+    @bpp.run_decorator(md=_md)
+    def inner():
+        # Compute sequence of pseudos & reals in the zone
+        for pseudos, reals in zonespace(diffractometer, start, finish, num):
+            # move axes
+            logger.debug("zone hkl=%s", pseudos)
+            parms = []
+            for k, v in zip(diffractometer.real_axis_names, reals):
+                parms.append(getattr(diffractometer, k))
+                parms.append(v)
+            yield from bps.mv(*parms)
+
+            # trigger
+            group = "trigger_objects"
+            for item in detectors:
+                yield from bps.trigger(item, group=group)
+            yield from bps.wait(group=group)
+
+            # read
+            yield from bps.create("primary")
+            for item in detectors + [diffractometer]:
+                yield from bps.read(item)
+            yield from bps.save()
+
+    return (yield from inner())
 
 
 @versionadded(

--- a/src/hklpy2/tests/test_plans.py
+++ b/src/hklpy2/tests/test_plans.py
@@ -14,7 +14,9 @@ from ..misc import creator_from_config
 from ..misc import validate_not_parallel
 from ..plans import _find_psi_axis
 from ..plans import _find_psi_mode
+from ..plans import move_zone
 from ..plans import scan_psi
+from ..plans import scan_zone
 
 HKLPY2_DIR = Path(__file__).parent.parent
 
@@ -447,6 +449,86 @@ def test_scan_psi_metadata(parms, context):
 
 
 # ---------------------------------------------------------------------------
+# move_zone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(hkl=(1, 0, 0)),
+            does_not_raise(),
+            id="move_zone to (1,0,0) tuple",
+        ),
+        pytest.param(
+            dict(hkl=(0, 1, 0)),
+            does_not_raise(),
+            id="move_zone to (0,1,0) tuple",
+        ),
+    ],
+)
+def test_move_zone(parms, context):
+    with context:
+        fourc = creator()
+        RE = bluesky.RunEngine()
+        RE(move_zone(fourc, parms["hkl"]))
+        for name, val in zip(fourc.pseudo_axis_names, parms["hkl"]):
+            assert getattr(fourc, name).get().readback == pytest.approx(val, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# scan_zone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(start=(1, 0, 0), finish=(0, 1, 0), num=5, md=None),
+            does_not_raise(),
+            id="scan_zone basic",
+        ),
+        pytest.param(
+            dict(start=(1, 0, 0), finish=(0, 1, 0), num=3, md={"user": "test"}),
+            does_not_raise(),
+            id="scan_zone with metadata",
+        ),
+        pytest.param(
+            dict(start=(1, 0, 0), finish=(0, 1, 0), num=3, md=None),
+            does_not_raise(),
+            id="scan_zone metadata defaults to plan_name only",
+        ),
+    ],
+)
+def test_scan_zone(parms, context):
+    with context:
+        fourc = creator()
+        RE = bluesky.RunEngine()
+        docs = []
+        RE.subscribe(lambda name, doc: docs.append((name, doc)))
+        (uid,) = RE(
+            scan_zone(
+                [noisy_det],
+                fourc,
+                parms["start"],
+                parms["finish"],
+                parms["num"],
+                md=parms["md"],
+            )
+        )
+        assert isinstance(uid, str)
+        assert len(uid) > 0
+        starts = [doc for name, doc in docs if name == "start"]
+        assert len(starts) == 1
+        assert starts[0]["plan_name"] == "scan_zone"
+        if parms["md"]:
+            for k, v in parms["md"].items():
+                assert starts[0][k] == v
+
+
+# ---------------------------------------------------------------------------
 # Package exports
 # ---------------------------------------------------------------------------
 
@@ -455,9 +537,19 @@ def test_scan_psi_metadata(parms, context):
     "parms, context",
     [
         pytest.param(
+            dict(name="move_zone"),
+            does_not_raise(),
+            id="move_zone exported from hklpy2",
+        ),
+        pytest.param(
             dict(name="scan_psi"),
             does_not_raise(),
             id="scan_psi exported from hklpy2",
+        ),
+        pytest.param(
+            dict(name="scan_zone"),
+            does_not_raise(),
+            id="scan_zone exported from hklpy2",
         ),
     ],
 )


### PR DESCRIPTION
- closes #339

## Summary

- Move `move_zone` and `scan_zone` implementations from `hklpy2/blocks/zone.py` into `hklpy2/plans.py`, making it the single canonical location for all standalone hklpy2 plans.
- `hklpy2/__init__.py` now imports `move_zone` and `scan_zone` from `hklpy2.plans` (unchanged user-facing API).
- `hklpy2/blocks/zone.py` retains `OrthonormalZone`, `zonespace`, and `zone_series`; adds deprecated compatibility shims for `move_zone` and `scan_zone` that emit `DeprecationWarning` and delegate to `hklpy2.plans`.
- All existing import paths (`hklpy2.move_zone`, `hklpy2.scan_zone`, `hklpy2.blocks.zone.move_zone`, `hklpy2.blocks.zone.scan_zone`) continue to work.
- Add `move_zone`/`scan_zone` tests to `test_plans.py`; add deprecation shim tests to `test_zone.py`.
- Update `RELEASE_NOTES.rst` with Deprecations and Maintenance entries.

Agent: OpenCode (claudesonnet46)