### PR TITLE
SolverBase should define set_reals() for the presets feature

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,6 +35,11 @@ describe future plans.
 
     Release expected by 2026-H2.
 
+    Fixes
+    -----
+
+    * Fix ``AttributeError`` raised by non-``hkl_soleil`` solvers when ``forward()`` calls ``set_reals()``: add no-op ``set_reals()`` to ``SolverBase``. (:issue:`347`)
+
 0.5.2
 #####
 

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -84,6 +84,12 @@ class SolverBase(ABC):
         ~refineLattice
         ~removeAllReflections
 
+    .. rubric:: Python Methods (concrete, overridable)
+
+    .. autosummary::
+
+        ~set_reals
+
     .. rubric:: Geometry Registry
 
     .. autosummary::
@@ -416,6 +422,29 @@ class SolverBase(ABC):
     @abstractmethod
     def removeAllReflections(self) -> None:
         """Remove all reflections."""
+
+    def set_reals(self, reals: NamedFloatDict) -> None:
+        """
+        Set current real-axis values in the solver's internal geometry object.
+
+        This method is called by :meth:`~hklpy2.ops.Core.forward` to push
+        the current motor positions (or preset values for constant axes) into
+        the solver before computing forward-calculation solutions.  Solvers
+        that maintain an internal geometry object with real-axis state (such
+        as ``hkl_soleil``, which calls ``axis_values_set`` on its libhkl
+        geometry) **must** override this method.
+
+        The default implementation is a deliberate no-op so that solvers
+        which do not require real-axis state (e.g. pure function-based
+        backends) can inherit from :class:`SolverBase` without needing to
+        define this method.
+
+        Parameters
+        ----------
+        reals : NamedFloatDict
+            Dictionary mapping solver real-axis names to their current values
+            (in the solver's internal angle units).
+        """
 
     @property
     def sample(self) -> Union[SampleDict, None]:

--- a/src/hklpy2/backends/tests/test_base.py
+++ b/src/hklpy2/backends/tests/test_base.py
@@ -3,6 +3,7 @@
 # Many features are tested, albeit indrectly, in specific solvers.
 
 import re
+from contextlib import nullcontext as does_not_raise
 
 import pyRestTable
 import pytest
@@ -153,3 +154,44 @@ def test_SolverBase_abstractmethods():
         match=re.escape("Cannot change 'geometry' after solver is created."),
     ):
         solver.geometry = TH_TTH_Q_GEOMETRY
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(reals={}),
+            does_not_raise(),
+            id="set_reals() on TrivialSolver is a no-op (empty dict)",
+        ),
+        pytest.param(
+            dict(reals={"th": 10.0, "tth": 20.0}),
+            does_not_raise(),
+            id="set_reals() on TrivialSolver is a no-op (with values)",
+        ),
+    ],
+)
+def test_SolverBase_set_reals_noop(parms, context):
+    """SolverBase.set_reals() is a no-op; any solver inheriting it must not raise."""
+    with context:
+        solver = TrivialSolver("test_geo")
+        result = solver.set_reals(**parms)
+        assert result is None
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(reals={"th": 5.0, "tth": 10.0}),
+            does_not_raise(),
+            id="set_reals() on ThTthSolver (non-hkl_soleil) succeeds via inherited no-op",
+        ),
+    ],
+)
+def test_SolverBase_set_reals_inherited(parms, context):
+    """Non-hkl_soleil solvers inheriting set_reals() must not raise AttributeError."""
+    with context:
+        solver = ThTthSolver(TH_TTH_Q_GEOMETRY)
+        result = solver.set_reals(**parms)
+        assert result is None


### PR DESCRIPTION
- closes #347

## Summary

- Add a concrete no-op `set_reals(reals)` to `SolverBase` so that all solvers work with the presets feature without raising `AttributeError`.
- `Core.forward()` calls `self.solver.set_reals()` unconditionally; previously only `HklSolver` defined it (libhkl-specific). Any non-`hkl_soleil` solver raised `AttributeError`.
- The default no-op means pure function-based backends need not override it; `HklSolver`'s existing override is unchanged.
- Add parametrized tests covering the no-op on `TrivialSolver` and the inherited no-op on `ThTthSolver`.

Agent: OpenCode (claudesonnet46)