### PR TITLE
SolverBase should define a UB setter

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -39,6 +39,7 @@ describe future plans.
     -----
 
     * Fix ``AttributeError`` raised by non-``hkl_soleil`` solvers when ``forward()`` calls ``set_reals()``: add no-op ``set_reals()`` to ``SolverBase``. (:issue:`347`)
+    * Fix silent UB loss in non-``hkl_soleil`` solvers: add ``U`` and ``UB`` getter/setter pair to ``SolverBase`` that stores orientation state. (:issue:`348`)
 
     Deprecations
     ------------

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -90,6 +90,13 @@ class SolverBase(ABC):
 
         ~set_reals
 
+    .. rubric:: Python Properties (concrete, overridable)
+
+    .. autosummary::
+
+        ~U
+        ~UB
+
     .. rubric:: Geometry Registry
 
     .. autosummary::
@@ -108,7 +115,6 @@ class SolverBase(ABC):
         ~lattice
         ~mode
         ~sample
-        ~UB
     """
 
     from .. import __version__
@@ -206,6 +212,8 @@ class SolverBase(ABC):
         self.mode = mode
         self._all_extra_axis_names: Optional[List[str]] = None
         self._sample: Optional[SampleDict] = None
+        self._U: Matrix3x3 = IDENTITY_MATRIX_3X3
+        self._UB: Matrix3x3 = IDENTITY_MATRIX_3X3
 
         validate_and_canonical_unit(self.ANGLE_UNITS, INTERNAL_ANGLE_UNITS)
         validate_and_canonical_unit(self.LENGTH_UNITS, INTERNAL_LENGTH_UNITS)
@@ -508,6 +516,33 @@ class SolverBase(ABC):
         return table
 
     @property
+    def U(self) -> Matrix3x3:
+        """
+        Relative orientation of the crystal on the diffractometer (3x3 rotation matrix).
+
+        The default implementation stores and returns the value set via the
+        setter, initialised to the identity matrix.  Subclasses that maintain
+        an internal backend object (e.g. ``hkl_soleil``) should override both
+        getter and setter to read/write the backend state directly.
+        """
+        return self._U
+
+    @U.setter
+    def U(self, value: Matrix3x3) -> None:
+        self._U = value
+
+    @property
     def UB(self) -> Matrix3x3:
-        """Orientation matrix (3x3)."""
-        return IDENTITY_MATRIX_3X3
+        """
+        Orientation matrix (3x3).
+
+        The default implementation stores and returns the value set via the
+        setter, initialised to the identity matrix.  Subclasses that maintain
+        an internal backend object (e.g. ``hkl_soleil``) should override both
+        getter and setter to read/write the backend state directly.
+        """
+        return self._UB
+
+    @UB.setter
+    def UB(self, value: Matrix3x3) -> None:
+        self._UB = value

--- a/src/hklpy2/backends/tests/test_base.py
+++ b/src/hklpy2/backends/tests/test_base.py
@@ -195,3 +195,73 @@ def test_SolverBase_set_reals_inherited(parms, context):
         solver = ThTthSolver(TH_TTH_Q_GEOMETRY)
         result = solver.set_reals(**parms)
         assert result is None
+
+
+# A non-identity 3x3 matrix for testing U/UB round-trips.
+_SAMPLE_MATRIX = [
+    [0.0, 1.0, 0.0],
+    [0.0, 0.0, 1.0],
+    [1.0, 0.0, 0.0],
+]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(attr="U", value=IDENTITY_MATRIX_3X3),
+            does_not_raise(),
+            id="U getter returns identity by default",
+        ),
+        pytest.param(
+            dict(attr="UB", value=IDENTITY_MATRIX_3X3),
+            does_not_raise(),
+            id="UB getter returns identity by default",
+        ),
+        pytest.param(
+            dict(attr="U", value=_SAMPLE_MATRIX),
+            does_not_raise(),
+            id="U setter stores value; getter returns it",
+        ),
+        pytest.param(
+            dict(attr="UB", value=_SAMPLE_MATRIX),
+            does_not_raise(),
+            id="UB setter stores value; getter returns it",
+        ),
+    ],
+)
+def test_SolverBase_U_UB(parms, context):
+    """SolverBase U and UB properties store and return orientation matrices."""
+    with context:
+        solver = TrivialSolver("test_geo")
+        attr = parms["attr"]
+        value = parms["value"]
+        # Verify default is identity before any assignment.
+        assert getattr(solver, attr) == IDENTITY_MATRIX_3X3
+        # Set and round-trip.
+        setattr(solver, attr, value)
+        assert getattr(solver, attr) == value
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(reals={"th": 5.0, "tth": 10.0}),
+            does_not_raise(),
+            id="ThTthSolver U/UB inherit base store-and-return behaviour",
+        ),
+    ],
+)
+def test_SolverBase_U_UB_inherited(parms, context):
+    """Non-hkl_soleil solvers inherit U/UB store-and-return without AttributeError."""
+    with context:
+        solver = ThTthSolver(TH_TTH_Q_GEOMETRY)
+        # Default is identity.
+        assert solver.U == IDENTITY_MATRIX_3X3
+        assert solver.UB == IDENTITY_MATRIX_3X3
+        # Setter stores; getter returns — no AttributeError.
+        solver.U = _SAMPLE_MATRIX
+        assert solver.U == _SAMPLE_MATRIX
+        solver.UB = _SAMPLE_MATRIX
+        assert solver.UB == _SAMPLE_MATRIX

--- a/src/hklpy2/blocks/tests/test_zone.py
+++ b/src/hklpy2/blocks/tests/test_zone.py
@@ -470,10 +470,13 @@ def test_zone_deprecated_shims(parms, context):
 
         zone_mod = importlib.import_module("hklpy2.blocks.zone")
         func = getattr(zone_mod, parms["func_name"])
-        with pytest.warns(DeprecationWarning, match=re.escape(parms["msg"])):
-            # Call the shim with dummy args to trigger the warning;
-            # wrap in a try to ignore downstream errors.
-            try:
+        # Trigger only the warnings.warn() in the shim body, without calling
+        # the underlying plan (which would create a bluesky Plan generator that
+        # crashes in __del__ if never iterated).  We do this by patching the
+        # imported plan symbol so the shim's delegation never reaches @plan.
+        from unittest.mock import patch
+
+        target = f"hklpy2.plans.{parms['func_name']}"
+        with patch(target, return_value=None):
+            with pytest.warns(DeprecationWarning, match=re.escape(parms["msg"])):
                 func()
-            except Exception as ex:
-                logging.debug("Ignoring expected downstream error from deprecated shim call", exc_info=ex)

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -944,11 +944,8 @@ class Core:
     def sample(self, value: str) -> None:
         self._sample_name = value
         if self.solver is not None:
-            try:
-                self.solver.U = self.sample.U
-                self.solver.UB = self.sample.UB
-            except AttributeError:
-                pass  # property is not settable
+            self.solver.U = self.sample.U
+            self.solver.UB = self.sample.UB
 
     @property
     def samples(self) -> Mapping[str, Sample]:
@@ -1174,10 +1171,7 @@ class Core:
             except AttributeError:
                 pass  # Some solvers have no setter for extras
 
-            try:
-                self.solver.U = self.sample.U
-                self.solver.UB = self.sample.UB
-            except AttributeError:
-                pass  # Some solvers have no setter for U & UB
+            self.solver.U = self.sample.U
+            self.solver.UB = self.sample.UB
 
             self.request_solver_update(False)


### PR DESCRIPTION
- closes #348

## Summary

- Add `U` and `UB` as a matched getter/setter pair on `SolverBase`, initialised to `IDENTITY_MATRIX_3X3` in `__init__` and backed by `_U`/`_UB` instance attributes.
- Previously `SolverBase` had no `U` property at all, and only a `UB` getter returning a hardcoded identity — so non-`hkl_soleil` solvers silently discarded orientation state on every `forward()`/`inverse()` call (the `try/except AttributeError` in `Core.update_solver()` and `Core.sample.setter` swallowed the error).
- `SolverBase` is now a proper calculator interface: `Core` can push `U`/`UB` in and read them back unchanged. Solvers that maintain an internal backend object (e.g. `hkl_soleil`) override both getter and setter to read/write backend state directly — those overrides are unchanged.
- Add parametrized tests covering default identity values, round-trip store/return for both `TrivialSolver` and `ThTthSolver`.

Agent: OpenCode (claudesonnet46)