### PR TITLE
Refactor misc.py phase 3: solver discovery into solver_utils.py

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -61,6 +61,9 @@ describe future plans.
       ``hklpy2/devices.py``: ``VirtualPositionerBase``, ``define_real_axis``,
       ``dict_device_factory``, ``dynamic_import``, ``make_component``,
       ``make_dynamic_instance``, ``parse_factory_axes``. (:issue:`342`)
+    * Extract solver discovery machinery from ``misc.py`` into new
+      ``hklpy2/solver_utils.py``: ``SOLVER_ENTRYPOINT_GROUP``, ``get_solver``,
+      ``solver_factory``, ``solvers``. (:issue:`343`)
     * Move ``move_zone`` and ``scan_zone`` plans from ``hklpy2.blocks.zone`` to
       ``hklpy2.plans`` (canonical plan location). (:issue:`339`)
 

--- a/src/hklpy2/__init__.py
+++ b/src/hklpy2/__init__.py
@@ -63,12 +63,12 @@ from .plans import scan_zone  # noqa: E402, F401, F403
 from .diffract import creator  # noqa: E402, F401, F403
 from .diffract import diffractometer_class_factory  # noqa: E402, F401, F403
 from .incident import A_KEV  # noqa: E402, F401
-from .misc import SOLVER_ENTRYPOINT_GROUP  # noqa: E402, F401
-from .misc import ConfigurationRunWrapper  # noqa: E402, F401
 from .exceptions import SolverError  # noqa: E402, F401
+from .misc import ConfigurationRunWrapper  # noqa: E402, F401
 from .misc import creator_from_config  # noqa: E402, F401
 from .misc import get_run_orientation  # noqa: E402, F401
-from .misc import get_solver  # noqa: E402, F401
 from .misc import list_orientation_runs  # noqa: E402, F401
-from .misc import solver_factory  # noqa: E402, F401
-from .misc import solvers  # noqa: E402, F401
+from .solver_utils import SOLVER_ENTRYPOINT_GROUP  # noqa: E402, F401
+from .solver_utils import get_solver  # noqa: E402, F401
+from .solver_utils import solver_factory  # noqa: E402, F401
+from .solver_utils import solvers  # noqa: E402, F401

--- a/src/hklpy2/backends/tests/test_th_tth_q.py
+++ b/src/hklpy2/backends/tests/test_th_tth_q.py
@@ -6,8 +6,8 @@ import pytest
 
 from ...misc import IDENTITY_MATRIX_3X3
 from ...exceptions import SolverError
-from ...misc import get_solver
-from ...misc import solver_factory
+from ...solver_utils import get_solver
+from ...solver_utils import solver_factory
 from ..base import SolverBase
 from ..th_tth_q import BISECTOR_MODE
 from ..th_tth_q import TH_TTH_Q_GEOMETRY

--- a/src/hklpy2/blocks/tests/test_solver.py
+++ b/src/hklpy2/blocks/tests/test_solver.py
@@ -3,7 +3,7 @@ import re
 
 import pytest
 
-from ...misc import get_solver
+from ...solver_utils import get_solver
 
 
 @pytest.mark.parametrize(

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -1170,7 +1170,7 @@ def diffractometer_class_factory(
     from .devices import make_component
     from .devices import parse_factory_axes
     from .misc import DEFAULT_MOTOR_LABELS
-    from .misc import solver_factory
+    from .solver_utils import solver_factory
 
     if not isinstance(pseudos, list):
         raise TypeError(f"Expected a list.  Received {pseudos=!r}")

--- a/src/hklpy2/misc.py
+++ b/src/hklpy2/misc.py
@@ -11,7 +11,6 @@ Miscellaneous Support.
     ~distance_between_pos_tuples
     ~flatten_lists
     ~get_run_orientation
-    ~get_solver
     ~istype
     ~list_orientation_runs
     ~load_yaml
@@ -20,8 +19,6 @@ Miscellaneous Support.
     ~pick_first_solution
     ~roundoff
     ~creator_from_config
-    ~solver_factory
-    ~solvers
     ~unique_name
     ~validate_and_canonical_unit
     ~validate_not_parallel
@@ -29,12 +26,12 @@ Miscellaneous Support.
 .. note::
 
     Device construction helpers have moved to :mod:`hklpy2.devices`.
+    Solver discovery functions have moved to :mod:`hklpy2.solver_utils`.
 
 .. rubric: Symbols
 .. autosummary::
 
     ~IDENTITY_MATRIX_3X3
-    ~SOLVER_ENTRYPOINT_GROUP
 
 .. rubric: Custom Preprocessors
 .. autosummary::
@@ -56,7 +53,7 @@ import sys
 import uuid
 import warnings
 from collections.abc import Iterable
-from importlib.metadata import entry_points
+
 
 from deprecated.sphinx import versionadded
 from deprecated.sphinx import versionchanged
@@ -77,7 +74,6 @@ import yaml
 from ophyd import Device
 
 from .exceptions import NoForwardSolutions
-from .exceptions import SolverError
 from .typing import AnyAxesType
 from .typing import AxesArray
 from .typing import AxesDict
@@ -103,7 +99,6 @@ __all__ = [
     "INTERNAL_XRAY_ENERGY_UNITS",
     "MISSING_HEADER_KEY_MSG",
     "PINT_ERRORS",
-    "SOLVER_ENTRYPOINT_GROUP",
     "UREG",
     # Classes
     "ConfigurationRunWrapper",
@@ -116,7 +111,6 @@ __all__ = [
     "distance_between_pos_tuples",
     "flatten_lists",
     "get_run_orientation",
-    "get_solver",
     "istype",
     "list_orientation_runs",
     "load_yaml",
@@ -124,8 +118,6 @@ __all__ = [
     "pick_closest_solution",
     "pick_first_solution",
     "roundoff",
-    "solver_factory",
-    "solvers",
     "unique_name",
     "validate_and_canonical_unit",
 ]
@@ -137,9 +129,6 @@ IDENTITY_MATRIX_3X3: Matrix3x3 = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
 MISSING_HEADER_KEY_MSG: str = "Configuration is missing '_header' key."
 """Error message for missing _header key in configuration dicts."""
-
-SOLVER_ENTRYPOINT_GROUP: str = "hklpy2.solver"
-"""Name by which |hklpy2| |solver| classes are grouped."""
 
 DEFAULT_DIGITS: int = 4
 DEFAULT_START_KEY: str = "diffractometers"
@@ -419,23 +408,6 @@ def flatten_lists(
             yield from flatten_lists(x)
         else:
             yield x
-
-
-def get_solver(solver_name: str) -> "SolverBase":
-    """
-    Load a Solver class from a named entry point.
-
-    ::
-
-        import hklpy2
-        SolverClass = hklpy2.get_solver("hkl_soleil")
-        libhkl_solver = SolverClass()
-    """
-    if solver_name not in solvers():
-        raise SolverError(f"{solver_name=!r} unknown.  Pick one of: {solvers()!r}")
-    logger.debug("Loading solver %r from entry points", solver_name)
-    entries = entry_points(group=SOLVER_ENTRYPOINT_GROUP)
-    return entries[solver_name].load()
 
 
 @versionadded(
@@ -720,33 +692,6 @@ def pick_first_solution(
 def roundoff(value: float, digits=4) -> float:
     """Round a number to specified precision."""
     return round(value, ndigits=digits) or 0  # "-0" becomes "0"
-
-
-def solver_factory(
-    solver_name: str,
-    geometry: str,
-    **kwargs: Mapping,
-) -> "SolverBase":
-    """
-    Create a |solver| object with geometry and axes.
-    """
-    logger.debug(
-        "Creating solver %r geometry=%r kwargs=%r", solver_name, geometry, kwargs
-    )
-    solver_class = get_solver(solver_name)
-    return solver_class(geometry, **kwargs)
-
-
-def solvers() -> Mapping[str, "SolverBase"]:
-    """
-    Dictionary of available Solver classes, mapped by entry point name.
-
-    ::
-
-        import hklpy2
-        print(hklpy2.solvers())
-    """
-    return {ep.name: ep.value for ep in entry_points(group=SOLVER_ENTRYPOINT_GROUP)}
 
 
 @versionadded(

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -27,7 +27,7 @@ from .exceptions import CoreError
 from .exceptions import NoForwardSolutions
 from .misc import axes_to_dict
 from .misc import convert_units
-from .misc import solver_factory
+from .solver_utils import solver_factory
 from .misc import unique_name
 from .typing import AnyAxesType
 from .typing import AxesDict

--- a/src/hklpy2/solver_utils.py
+++ b/src/hklpy2/solver_utils.py
@@ -1,0 +1,79 @@
+"""
+Solver discovery and instantiation for |hklpy2|.
+
+These utilities locate |solver| backend classes via Python entry points and
+create solver instances for use by :class:`~hklpy2.ops.Core`.
+
+.. autosummary::
+
+    ~get_solver
+    ~solver_factory
+    ~solvers
+    ~SOLVER_ENTRYPOINT_GROUP
+"""
+
+import logging
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+from typing import Mapping
+
+from .exceptions import SolverError
+
+if TYPE_CHECKING:
+    from .backends.base import SolverBase  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SOLVER_ENTRYPOINT_GROUP",
+    "get_solver",
+    "solver_factory",
+    "solvers",
+]
+
+SOLVER_ENTRYPOINT_GROUP: str = "hklpy2.solver"
+"""Name by which |hklpy2| |solver| classes are grouped."""
+
+
+def get_solver(solver_name: str) -> "SolverBase":
+    """
+    Load a Solver class from a named entry point.
+
+    ::
+
+        import hklpy2
+        SolverClass = hklpy2.get_solver("hkl_soleil")
+        libhkl_solver = SolverClass()
+    """
+    if solver_name not in solvers():
+        raise SolverError(f"{solver_name=!r} unknown.  Pick one of: {solvers()!r}")
+    logger.debug("Loading solver %r from entry points", solver_name)
+    entries = entry_points(group=SOLVER_ENTRYPOINT_GROUP)
+    return entries[solver_name].load()
+
+
+def solver_factory(
+    solver_name: str,
+    geometry: str,
+    **kwargs: Mapping,
+) -> "SolverBase":
+    """
+    Create a |solver| object with geometry and axes.
+    """
+    logger.debug(
+        "Creating solver %r geometry=%r kwargs=%r", solver_name, geometry, kwargs
+    )
+    solver_class = get_solver(solver_name)
+    return solver_class(geometry, **kwargs)
+
+
+def solvers() -> Mapping[str, "SolverBase"]:
+    """
+    Dictionary of available Solver classes, mapped by entry point name.
+
+    ::
+
+        import hklpy2
+        print(hklpy2.solvers())
+    """
+    return {ep.name: ep.value for ep in entry_points(group=SOLVER_ENTRYPOINT_GROUP)}

--- a/src/hklpy2/tests/test_backends.py
+++ b/src/hklpy2/tests/test_backends.py
@@ -3,7 +3,7 @@ import pytest
 from .. import SolverBase as AppBase
 from ..backends.base import SolverBase as BackendBase
 from ..backends.no_op import NoOpSolver as BackendSolver
-from ..misc import get_solver
+from ..solver_utils import get_solver
 from . import NO_OP_SOLVER_TYPE_STR
 
 

--- a/src/hklpy2/tests/test_misc.py
+++ b/src/hklpy2/tests/test_misc.py
@@ -38,7 +38,7 @@ from ..misc import convert_units
 from ..misc import distance_between_pos_tuples
 from ..misc import flatten_lists
 from ..misc import get_run_orientation
-from ..misc import get_solver
+from ..solver_utils import get_solver
 from ..misc import istype
 from ..misc import list_orientation_runs
 from ..misc import load_yaml_file


### PR DESCRIPTION
- closes #343
- part of #340

## Summary

- Create `hklpy2/solver_utils.py` with `SOLVER_ENTRYPOINT_GROUP`, `get_solver`, `solver_factory`, and `solvers` — the four solver entry-point discovery items from `misc.py`.
- No re-export shim in `misc.py` — all imports updated directly at source.
- Files updated: `__init__.py`, `ops.py`, `diffract.py` (deferred import inside `creator()`), `backends/tests/test_th_tth_q.py`, `blocks/tests/test_solver.py`, `tests/test_backends.py`, `tests/test_misc.py`.
- `solver_utils.py` lives at the `hklpy2/` peer level (not inside `backends/`) to keep imports flat for `ops.py` and `diffract.py`, which are at the same level.

Agent: OpenCode (claudesonnet46)