### PR TITLE
docs: cross-references and named motor positions for UB notebooks

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -38,6 +38,9 @@ describe future plans.
     Fixes
     -----
 
+    * Fix stale ``from hklpy2.misc import`` in ``hkl_soleil-ub_set.ipynb``
+      (now ``hklpy2.utils``). (:issue:`353`)
+
     * Fix ``AttributeError`` raised by non-``hkl_soleil`` solvers when
       ``forward()`` calls ``set_reals()``: add no-op ``set_reals()`` to
       ``SolverBase``. (:issue:`347`)
@@ -67,6 +70,9 @@ describe future plans.
     * Extract solver discovery machinery from ``misc.py`` into new
       ``hklpy2/solver_utils.py``: ``SOLVER_ENTRYPOINT_GROUP``, ``get_solver``,
       ``solver_factory``, ``solvers``. (:issue:`343`)
+    * Add cross-references between ``hkl_soleil-ub_calc.ipynb``,
+      ``hkl_soleil-ub_set.ipynb``, and ``how_calc_ub.rst``; use named motor
+      positions (``dict(omega=…)``) in notebook examples. (:issue:`353`)
     * Rename remaining ``misc.py`` utilities to ``hklpy2/utils.py`` and delete
       ``misc.py``; rename ``test_misc.py`` to ``test_utils.py``. Completes the
       ``misc.py`` refactor. (:issue:`345`, closes :issue:`340`)

--- a/docs/source/examples/hkl_soleil-ub_calc.ipynb
+++ b/docs/source/examples/hkl_soleil-ub_calc.ipynb
@@ -13,6 +13,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "crossref-how-calc-ub",
+   "metadata": {},
+   "source": [
+    "```{seealso}\n",
+    "The how-to guide [How to Compute and Set the UB Matrix](../guides/how_calc_ub.rst) ",
+    "covers the same workflow in prose form and includes additional patterns ",
+    "such as setting UB directly and refining the lattice.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Create a diffractometer object\n",
@@ -96,9 +108,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add two non-parallel reflections.  Here, just the values of the pseudos and\n",
-    "reals are specified as Python tuples, in the exact order expected by the\n",
-    "*solver* geometry."
+    "Add two non-parallel reflections.  The motor positions are specified\n",
+    "as a dictionary of named real-axis values, making the example readable\n",
+    "regardless of the solver's internal axis order."
    ]
   },
   {
@@ -108,10 +120,14 @@
    "outputs": [],
    "source": [
     "r100 = diffractometer.add_reflection(\n",
-    "    (1, 0, 0), (-145.451, 5, -5, 69.0966), name=\"(100)\"\n",
+    "    (1, 0, 0),\n",
+    "    dict(omega=-145.451, chi=5, phi=-5, tth=69.0966),\n",
+    "    name=\"(100)\",\n",
     ")\n",
     "r010 = diffractometer.add_reflection(\n",
-    "    (0, 1, 0), (-145.451, 5, 85, 69.0966), name=\"(010)\"\n",
+    "    (0, 1, 0),\n",
+    "    dict(omega=-145.451, chi=5, phi=85, tth=69.0966),\n",
+    "    name=\"(010)\",\n",
     ")"
    ]
   },

--- a/docs/source/examples/hkl_soleil-ub_set.ipynb
+++ b/docs/source/examples/hkl_soleil-ub_set.ipynb
@@ -19,6 +19,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "crossref-how-calc-ub-set",
+   "metadata": {},
+   "source": [
+    "```{seealso}\n",
+    "The how-to guide [How to Compute and Set the UB Matrix](../guides/how_calc_ub.rst) ",
+    "covers both setting and computing UB in prose form.\n",
+    "See also the companion notebook [hkl_soleil-ub_calc](./hkl_soleil-ub_calc.ipynb) ",
+    "for computing UB from two reflections.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Quick example\n",
@@ -227,7 +240,7 @@
     }
    ],
    "source": [
-    "diffractometer.inverse(-60, -35, 45, -120)"
+    "diffractometer.inverse(dict(omega=-60, chi=-35, phi=45, tth=-120))"
    ]
   },
   {
@@ -299,7 +312,7 @@
     }
    ],
    "source": [
-    "diffractometer.inverse(-60, -35, 45, -120)"
+    "diffractometer.inverse(dict(omega=-60, chi=-35, phi=45, tth=-120))"
    ]
   },
   {
@@ -402,10 +415,7 @@
     }
    ],
    "source": [
-    "from hklpy2.misc import pick_closest_solution\n",
-    "\n",
-    "diffractometer._forward_solution = pick_closest_solution\n",
-    "diffractometer.forward(1, 1, 1)"
+    "from hklpy2.utils import pick_closest_solution\n\ndiffractometer._forward_solution = pick_closest_solution\ndiffractometer.forward(1, 1, 1)"
    ]
   }
  ],

--- a/docs/source/guides/how_calc_ub.rst
+++ b/docs/source/guides/how_calc_ub.rst
@@ -168,7 +168,7 @@ angles recovers the expected :math:`(h, k, l)`, and that
 :math:`(h, k, l)` returns angles close to the measured ones::
 
     >>> # inverse: angles → hkl
-    >>> fourc.inverse((-145.451, 0, 0, 69.0966))
+    >>> fourc.inverse(dict(omega=-145.451, chi=0, phi=0, tth=69.0966))
     Hklpy2DiffractometerPseudoPos(h=3.9999, k=0, l=0)   # ≈ (4, 0, 0) ✓
 
     >>> # forward: hkl → angles

--- a/docs/source/guides/how_calc_ub.rst
+++ b/docs/source/guides/how_calc_ub.rst
@@ -26,6 +26,12 @@ resetting it.
    :ref:`guide.design` — explanation of the :math:`B`, :math:`U`, and
    :math:`UB` matrices.
 
+   :doc:`/examples/hkl_soleil-ub_calc` — executable notebook: compute
+   :math:`UB` from two reflections using the ``hkl_soleil`` solver.
+
+   :doc:`/examples/hkl_soleil-ub_set` — executable notebook: set
+   :math:`UB` directly from a known matrix.
+
 Setup
 -----
 


### PR DESCRIPTION
- closes #353

## Summary

- `how_calc_ub.rst`: add `seealso` links to both UB notebooks.
- `hkl_soleil-ub_calc.ipynb`: add seealso note linking to `how_calc_ub.rst`; convert `add_reflection()` bare-float motor tuple to `dict(omega=…, chi=…, phi=…, tth=…)`; update descriptor markdown to explain the named-dict form.
- `hkl_soleil-ub_set.ipynb`: add seealso note linking to `how_calc_ub.rst` and `ub_calc.ipynb`; fix stale `from hklpy2.misc import` → `hklpy2.utils`; convert both `inverse()` bare-float args to `dict(omega=…, chi=…, phi=…, tth=…)`.
- `how_calc_ub.rst` line 171: convert bare-float `inverse()` call to named-dict form for consistency.

Named motor positions make examples solver-agnostic and robust as additional solvers (with different canonical axis orders) are added.

Agent: OpenCode (claudesonnet46)