### PR TITLE
feat #361 save auxiliary axes in export(); restore automatically in creator_from_config()

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -40,6 +40,8 @@ describe future plans.
 
     * Add analyzer how-to guide: crystal analyzer as additional positioners
       on the detector arm, including save/restore. (:issue:`222`)
+    * Save auxiliary axes in ``export()`` config; ``creator_from_config()``
+      restores them automatically. (:issue:`361`)
     * Add performance guide: factors affecting ``forward()``/``inverse()``
       throughput for diffractometer users. (:issue:`221`)
 

--- a/docs/source/guides/how_analyzer.ipynb
+++ b/docs/source/guides/how_analyzer.ipynb
@@ -46,8 +46,8 @@
     "\n",
     "The solver axes (`omega`, `chi`, `phi`, `tth`) must appear in the order the\n",
     "solver expects — giving them out of order will cause incorrect motor mapping.\n",
-     "Auxiliary axes may be appended in any order after the solver axes.  See\n",
-     "the [Diffractometer axes](diffract.rst) guide for details."
+    "Auxiliary axes may be appended in any order after the solver axes.  See\n",
+    "the [Diffractometer axes](diffract.rst) guide for details."
    ]
   },
   {
@@ -55,10 +55,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:27.722696Z",
-     "iopub.status.busy": "2026-04-16T20:24:27.722001Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.095525Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.094981Z"
+     "iopub.execute_input": "2026-04-16T21:02:46.635449Z",
+     "iopub.status.busy": "2026-04-16T21:02:46.634901Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.352921Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.352336Z"
     }
    },
    "outputs": [],
@@ -91,10 +91,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.096939Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.096708Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.100106Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.099539Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.354290Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.354072Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.357064Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.356735Z"
     }
    },
    "outputs": [
@@ -125,10 +125,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.126172Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.126039Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.128386Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.127983Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.383481Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.383351Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.385751Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.385320Z"
     }
    },
    "outputs": [
@@ -159,10 +159,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.129805Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.129674Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.137684Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.137157Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.386971Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.386862Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.396758Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.396255Z"
     }
    },
    "outputs": [
@@ -205,10 +205,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.139023Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.138891Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.144225Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.143678Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.398190Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.398082Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.403137Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.402742Z"
     }
    },
    "outputs": [
@@ -264,10 +264,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.145660Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.145539Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.152579Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.152212Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.404562Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.404440Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.412965Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.412455Z"
     }
    },
    "outputs": [
@@ -275,26 +275,25 @@
      "data": {
       "text/plain": [
        "OrderedDict([('e4cv_beam_wavelength',\n",
-       "              {'value': 1.54, 'timestamp': 1776371074.1409447}),\n",
+       "              {'value': 1.54, 'timestamp': 1776373372.400134}),\n",
        "             ('e4cv_beam_energy',\n",
-       "              {'value': 8.050921976530415, 'timestamp': 1776371073.7786138}),\n",
-       "             ('e4cv_h', {'value': 0, 'timestamp': 1776371073.779072}),\n",
+       "              {'value': 8.050921976530415, 'timestamp': 1776373372.0359027}),\n",
+       "             ('e4cv_h', {'value': 0, 'timestamp': 1776373372.036173}),\n",
        "             ('e4cv_h_setpoint',\n",
-       "              {'value': 0, 'timestamp': 1776371073.7791064}),\n",
-       "             ('e4cv_k', {'value': 0, 'timestamp': 1776371073.779261}),\n",
-       "             ('e4cv_k_setpoint',\n",
-       "              {'value': 0, 'timestamp': 1776371073.7792892}),\n",
-       "             ('e4cv_l', {'value': 0, 'timestamp': 1776371073.7794182}),\n",
+       "              {'value': 0, 'timestamp': 1776373372.0361924}),\n",
+       "             ('e4cv_k', {'value': 0, 'timestamp': 1776373372.0362859}),\n",
+       "             ('e4cv_k_setpoint', {'value': 0, 'timestamp': 1776373372.036302}),\n",
+       "             ('e4cv_l', {'value': 0, 'timestamp': 1776373372.036376}),\n",
        "             ('e4cv_l_setpoint',\n",
-       "              {'value': 0, 'timestamp': 1776371073.7794456}),\n",
-       "             ('e4cv_omega', {'value': 0, 'timestamp': 1776371074.1484237}),\n",
-       "             ('e4cv_chi', {'value': 0, 'timestamp': 1776371074.1484282}),\n",
-       "             ('e4cv_phi', {'value': 0, 'timestamp': 1776371074.148431}),\n",
-       "             ('e4cv_tth', {'value': 0, 'timestamp': 1776371074.1484337}),\n",
+       "              {'value': 0, 'timestamp': 1776373372.0363917}),\n",
+       "             ('e4cv_omega', {'value': 0, 'timestamp': 1776373372.4078124}),\n",
+       "             ('e4cv_chi', {'value': 0, 'timestamp': 1776373372.4078164}),\n",
+       "             ('e4cv_phi', {'value': 0, 'timestamp': 1776373372.4078193}),\n",
+       "             ('e4cv_tth', {'value': 0, 'timestamp': 1776373372.4078221}),\n",
        "             ('e4cv_atheta',\n",
-       "              {'value': 14.215809201820777, 'timestamp': 1776371074.148436}),\n",
+       "              {'value': 14.215809201820777, 'timestamp': 1776373372.4078243}),\n",
        "             ('e4cv_attheta',\n",
-       "              {'value': 28.431618403641554, 'timestamp': 1776371074.1484382})])"
+       "              {'value': 28.431618403641554, 'timestamp': 1776373372.4078264})])"
       ]
      },
      "execution_count": 6,
@@ -321,10 +320,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.154200Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.154088Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.156919Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.156388Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.414545Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.414360Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.417107Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.416766Z"
     }
    },
    "outputs": [
@@ -350,10 +349,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.158125Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.158024Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.162737Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.162241Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.418475Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.418368Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.424233Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.423720Z"
     }
    },
    "outputs": [
@@ -392,10 +391,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.164073Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.163954Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.175573Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.175120Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.425567Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.425461Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.437907Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.437479Z"
     }
    },
    "outputs": [
@@ -419,10 +418,9 @@
    "source": [
     "## Restore the configuration\n",
     "\n",
-    "Restore the diffractometer from the saved file.  Because the analyzer axes are\n",
-    "not part of the configuration, use `creator()` with the same `reals=`\n",
-    "dictionary as at setup time, then call `restore()` — `creator_from_config()`\n",
-    "does not accept `reals=` (see [issue #361](https://github.com/bluesky/hklpy2/issues/361))."
+    "Restore the diffractometer from the saved file.  The auxiliary axes\n",
+    "(`atheta`, `attheta`) are saved in the configuration file and restored\n",
+    "automatically — no `reals=` argument is needed."
    ]
   },
   {
@@ -430,10 +428,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.177127Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.177022Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.661001Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.660455Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.439337Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.439231Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.791340Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.790864Z"
     }
    },
    "outputs": [
@@ -449,18 +447,7 @@
     }
    ],
    "source": [
-    "e4cv2 = hklpy2.creator(\n",
-    "    name=\"e4cv2\",\n",
-    "    reals=dict(\n",
-    "        omega=None,\n",
-    "        chi=None,\n",
-    "        phi=None,\n",
-    "        tth=None,\n",
-    "        atheta=None,\n",
-    "        attheta=None,\n",
-    "    ),\n",
-    ")\n",
-    "e4cv2.restore(config_file)\n",
+    "e4cv2 = hklpy2.creator_from_config(config_file)\n",
     "e4cv2.wh()"
    ]
   },
@@ -492,10 +479,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.662618Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.662506Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.676412Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.675911Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.792672Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.792566Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.804483Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.803973Z"
     }
    },
    "outputs": [
@@ -526,10 +513,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T20:24:34.677657Z",
-     "iopub.status.busy": "2026-04-16T20:24:34.677544Z",
-     "iopub.status.idle": "2026-04-16T20:24:34.679862Z",
-     "shell.execute_reply": "2026-04-16T20:24:34.679423Z"
+     "iopub.execute_input": "2026-04-16T21:02:52.805687Z",
+     "iopub.status.busy": "2026-04-16T21:02:52.805585Z",
+     "iopub.status.idle": "2026-04-16T21:02:52.807824Z",
+     "shell.execute_reply": "2026-04-16T21:02:52.807342Z"
     }
    },
    "outputs": [],

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -145,6 +145,7 @@ class Core:
                 "real_axes": self.diffractometer.real_axis_names,
                 "axes_xref": self.axes_xref,
                 "extra_axes": self.all_extras,
+                "auxiliary_axes": self.diffractometer.auxiliary_axis_names,
             },
             "digits": self.diffractometer.digits,
             "sample_name": self.sample.name,

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -347,7 +347,16 @@ def creator_from_config(config: Union[dict, str, pathlib.Path]):
     Parses the configuration for the solver, geometry, and axis names, then
     constructs a simulator (all axes are soft positioners — no hardware
     connection) and restores the full orientation (samples, reflections, UB
-    matrix, wavelength, constraints) from the configuration.
+    matrix, wavelength, constraints) from the configuration.  Auxiliary axes
+    saved by :meth:`~hklpy2.diffract.DiffractometerBase.export` are restored
+    automatically.
+
+    If the diffractometer requires auxiliary axes that are not in the
+    configuration file, use :func:`~hklpy2.diffract.creator` with
+    :meth:`~hklpy2.diffract.DiffractometerBase.restore` instead::
+
+        sim = hklpy2.creator(name="e4cv", reals=dict(..., extra_axis=None))
+        sim.restore("e4cv-config.yml")
 
     PARAMETERS
 
@@ -424,7 +433,12 @@ def creator_from_config(config: Union[dict, str, pathlib.Path]):
         if s in solver_to_diff_pseudo
     ] or pseudo_axes
 
-    reals = {name: None for name in real_axes}
+    reals_dict = {name: None for name in real_axes}
+
+    # Restore auxiliary axes saved in the config (backward-compatible: absent in old files).
+    for name in axes_cfg.get("auxiliary_axes", []):
+        if name not in reals_dict:
+            reals_dict[name] = None
 
     # Pass _real and _pseudo so creator() maps axes in solver-expected order
     # even when diffractometer names differ from solver canonical names.
@@ -441,7 +455,7 @@ def creator_from_config(config: Union[dict, str, pathlib.Path]):
         solver=solver_name,
         geometry=geometry,
         solver_kwargs=solver_kwargs,
-        reals=reals,
+        reals=reals_dict,
         _real=real_axes if real_axes else None,
         _pseudo=pseudo_axes_ordered if pseudo_axes_ordered else None,
     )

--- a/src/hklpy2/tests/test_i210.py
+++ b/src/hklpy2/tests/test_i210.py
@@ -316,3 +316,71 @@ def test_creator_from_config_reflection_axis_order(parms, context):
         assert np.isclose(norm, _I243_UB_NORM_EXPECTED, atol=_I243_TOL), (
             f"Expected ||UB||≈{_I243_UB_NORM_EXPECTED:.4f}, got {norm:.4f}"
         )
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(config="e4cv_orient.yml"),
+            does_not_raise(),
+            id="E4CV vibranium: backward compatible, no auxiliary_axes in old config",
+        ),
+        pytest.param(
+            dict(config="e4cv-silicon-example.yml"),
+            does_not_raise(),
+            id="E4CV silicon: backward compatible",
+        ),
+    ],
+)
+def test_creator_from_config_no_auxiliary_axes(parms, context):
+    """
+    Test creator_from_config() backward compatibility (issue #361).
+
+    Old config files without auxiliary_axes restore without error.
+    """
+    with context:
+        sim = creator_from_config(TESTS_DIR / parms["config"])
+        for ax in ("omega", "chi", "phi", "tth"):
+            assert ax in sim.component_names
+        result = sim.forward(h=1, k=0, l=0)
+        assert len(result) > 0
+
+
+def test_creator_from_config_auxiliary_axes_roundtrip(tmp_path):
+    """
+    Test that auxiliary axes are saved by export() and restored automatically
+    by creator_from_config() without requiring reals= (issue #361).
+    """
+    import yaml
+
+    # Build diffractometer with auxiliary axes and orient it.
+    sim = hklpy2.creator(
+        name="e4cv",
+        reals=dict(omega=None, chi=None, phi=None, tth=None, atheta=None, attheta=None),
+    )
+    sim.core.add_sample("vibranium", 4.04)
+    r1 = sim.core.add_reflection(
+        dict(h=4, k=0, l=0), dict(omega=-145.451, chi=0, phi=0, tth=69.066)
+    )
+    r2 = sim.core.add_reflection(
+        dict(h=0, k=4, l=0), dict(omega=-145.451, chi=0, phi=90, tth=69.066)
+    )
+    sim.core.calc_UB(r1, r2)
+
+    # Export — auxiliary_axes must appear in the saved config.
+    config_file = tmp_path / "e4cv-analyzer.yml"
+    sim.export(str(config_file))
+    cfg = yaml.safe_load(config_file.read_text())
+    assert cfg["axes"].get("auxiliary_axes") == ["atheta", "attheta"]
+
+    # Restore without reals= — auxiliary axes come from the config automatically.
+    sim2 = creator_from_config(config_file)
+    assert "atheta" in sim2.component_names
+    assert "attheta" in sim2.component_names
+
+    # Orientation is preserved — forward() gives consistent results.
+    assert np.isclose(
+        sim.forward(h=1, k=0, l=0)[0],
+        sim2.forward(h=1, k=0, l=0)[0],
+    )


### PR DESCRIPTION
- closes #361
- updates #222 (how_analyzer.ipynb simplified to one-step restore)

## Summary

* `export()` now saves auxiliary positioner names under `axes.auxiliary_axes` in the config file.
* `creator_from_config()` reads `auxiliary_axes` from the config and restores them automatically — no `reals=` argument needed.
* Backward-compatible: config files without `auxiliary_axes` restore without error.
* For auxiliary axes not in the config, the existing `creator()` + `restore()` pattern remains the documented approach.
* `how_analyzer.ipynb` restore section simplified from a 10-line `creator()` + `restore()` block to a single `creator_from_config(config_file)` call.

## Design rationale

`creator_from_config()` stays a simple, intentionally minimal factory — no new parameters added. The full UX design discussion is preserved in the issue comments.

Agent: OpenCode (claudesonnet46)