### PR TITLE
feat #363 save/restore solver mode; rename creator_from_config to simulator_from_config

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,12 +35,19 @@ describe future plans.
 
     Release expected by 2026-H2.
 
+    Breaking Changes
+    ----------------
+
+    * Rename ``creator_from_config()`` to ``simulator_from_config()`` to
+      clarify that it always produces a simulator with no hardware connections.
+      (:issue:`363`)
+
     New Features
     ------------
 
     * Add analyzer how-to guide: crystal analyzer as additional positioners
       on the detector arm, including save/restore. (:issue:`222`)
-    * Save auxiliary axes in ``export()`` config; ``creator_from_config()``
+    * Save auxiliary axes in ``export()`` config; ``simulator_from_config()``
       restores them automatically. (:issue:`361`)
     * Add performance guide: factors affecting ``forward()``/``inverse()``
       throughput for diffractometer users. (:issue:`221`)
@@ -85,7 +92,7 @@ describe future plans.
       ``dict_device_factory``, ``dynamic_import``, ``make_component``,
       ``make_dynamic_instance``, ``parse_factory_axes``. (:issue:`342`)
     * Extract run-engine/databroker integration from ``misc.py`` into new
-      ``hklpy2/run_utils.py``: ``ConfigurationRunWrapper``, ``creator_from_config``,
+      ``hklpy2/run_utils.py``: ``ConfigurationRunWrapper``, ``simulator_from_config``,
       ``get_run_orientation``, ``list_orientation_runs``. (:issue:`344`)
     * Extract solver discovery machinery from ``misc.py`` into new
       ``hklpy2/solver_utils.py``: ``SOLVER_ENTRYPOINT_GROUP``, ``get_solver``,
@@ -354,7 +361,7 @@ Released 2026-04-03.
 New Features
 ------------
 
-* Add :func:`~hklpy2.misc.creator_from_config` to create a simulated
+* Add :func:`~hklpy2.misc.simulator_from_config` to create a simulated
   diffractometer (no hardware) from a saved configuration file or dict.
   (:issue:`210`)
 
@@ -403,7 +410,7 @@ Fixes
 * Fix ``LimitsConstraint.valid()`` rejecting solver solutions that land just
   outside a limit boundary due to floating-point arithmetic; increase
   ``ENDPOINT_TOLERANCE`` from ``1e-7`` to ``1e-4``. (:issue:`242`)
-* Fix :func:`~hklpy2.misc.creator_from_config` restoring reflections with
+* Fix :func:`~hklpy2.misc.simulator_from_config` restoring reflections with
   wrong axis values when YAML serialises ``reals`` dict keys alphabetically
   instead of in physical axis order. (:issue:`243`)
 * Fix error message bugs: missing f-string prefix in ``hkl_soleil.py``,

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -47,6 +47,9 @@ describe future plans.
 
     * Add analyzer how-to guide: crystal analyzer as additional positioners
       on the detector arm, including save/restore. (:issue:`222`)
+    * Save solver mode in ``export()`` config; ``simulator_from_config()``
+      restores it automatically; ``restore()`` warns when saved mode differs
+      from current mode, with opt-in ``restore_mode=True``. (:issue:`363`)
     * Save auxiliary axes in ``export()`` config; ``simulator_from_config()``
       restores them automatically. (:issue:`361`)
     * Add performance guide: factors affecting ``forward()``/``inverse()``

--- a/docs/source/guides.rst
+++ b/docs/source/guides.rst
@@ -95,7 +95,7 @@ Configuration and solvers
    * - :doc:`guides/configuration_save_restore`
      - Save a full diffractometer configuration (orientation, samples,
        reflections) and restore it later.
-   * - :ref:`how_creator_from_config`
+   * - :ref:`how_simulator_from_config`
      - Create a simulated diffractometer directly from a saved config file.
 
 Reference and background

--- a/docs/source/guides/how_analyzer.ipynb
+++ b/docs/source/guides/how_analyzer.ipynb
@@ -447,7 +447,7 @@
     }
    ],
    "source": [
-    "e4cv2 = hklpy2.creator_from_config(config_file)\n",
+    "e4cv2 = hklpy2.simulator_from_config(config_file)\n",
     "e4cv2.wh()"
    ]
   },

--- a/docs/source/guides/how_analyzer.ipynb
+++ b/docs/source/guides/how_analyzer.ipynb
@@ -55,10 +55,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:46.635449Z",
-     "iopub.status.busy": "2026-04-16T21:02:46.634901Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.352921Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.352336Z"
+     "iopub.execute_input": "2026-04-16T22:06:17.113988Z",
+     "iopub.status.busy": "2026-04-16T22:06:17.113444Z",
+     "iopub.status.idle": "2026-04-16T22:06:22.985520Z",
+     "shell.execute_reply": "2026-04-16T22:06:22.984581Z"
     }
    },
    "outputs": [],
@@ -91,10 +91,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.354290Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.354072Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.357064Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.356735Z"
+     "iopub.execute_input": "2026-04-16T22:06:22.987990Z",
+     "iopub.status.busy": "2026-04-16T22:06:22.987577Z",
+     "iopub.status.idle": "2026-04-16T22:06:22.993260Z",
+     "shell.execute_reply": "2026-04-16T22:06:22.992321Z"
     }
    },
    "outputs": [
@@ -125,10 +125,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.383481Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.383351Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.385751Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.385320Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.033918Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.033757Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.036467Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.035891Z"
     }
    },
    "outputs": [
@@ -159,10 +159,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.386971Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.386862Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.396758Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.396255Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.038055Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.037894Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.046342Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.045782Z"
     }
    },
    "outputs": [
@@ -205,10 +205,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.398190Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.398082Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.403137Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.402742Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.047505Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.047397Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.058170Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.057817Z"
     }
    },
    "outputs": [
@@ -264,10 +264,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.404562Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.404440Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.412965Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.412455Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.059626Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.059462Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.067138Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.066593Z"
     }
    },
    "outputs": [
@@ -275,25 +275,25 @@
      "data": {
       "text/plain": [
        "OrderedDict([('e4cv_beam_wavelength',\n",
-       "              {'value': 1.54, 'timestamp': 1776373372.400134}),\n",
+       "              {'value': 1.54, 'timestamp': 1776377183.0549195}),\n",
        "             ('e4cv_beam_energy',\n",
-       "              {'value': 8.050921976530415, 'timestamp': 1776373372.0359027}),\n",
-       "             ('e4cv_h', {'value': 0, 'timestamp': 1776373372.036173}),\n",
+       "              {'value': 8.050921976530415, 'timestamp': 1776377182.6812484}),\n",
+       "             ('e4cv_h', {'value': 0, 'timestamp': 1776377182.681517}),\n",
        "             ('e4cv_h_setpoint',\n",
-       "              {'value': 0, 'timestamp': 1776373372.0361924}),\n",
-       "             ('e4cv_k', {'value': 0, 'timestamp': 1776373372.0362859}),\n",
-       "             ('e4cv_k_setpoint', {'value': 0, 'timestamp': 1776373372.036302}),\n",
-       "             ('e4cv_l', {'value': 0, 'timestamp': 1776373372.036376}),\n",
+       "              {'value': 0, 'timestamp': 1776377182.6815362}),\n",
+       "             ('e4cv_k', {'value': 0, 'timestamp': 1776377182.6816278}),\n",
+       "             ('e4cv_k_setpoint', {'value': 0, 'timestamp': 1776377182.681644}),\n",
+       "             ('e4cv_l', {'value': 0, 'timestamp': 1776377182.6817188}),\n",
        "             ('e4cv_l_setpoint',\n",
-       "              {'value': 0, 'timestamp': 1776373372.0363917}),\n",
-       "             ('e4cv_omega', {'value': 0, 'timestamp': 1776373372.4078124}),\n",
-       "             ('e4cv_chi', {'value': 0, 'timestamp': 1776373372.4078164}),\n",
-       "             ('e4cv_phi', {'value': 0, 'timestamp': 1776373372.4078193}),\n",
-       "             ('e4cv_tth', {'value': 0, 'timestamp': 1776373372.4078221}),\n",
+       "              {'value': 0, 'timestamp': 1776377182.6817346}),\n",
+       "             ('e4cv_omega', {'value': 0, 'timestamp': 1776377183.0630844}),\n",
+       "             ('e4cv_chi', {'value': 0, 'timestamp': 1776377183.0630896}),\n",
+       "             ('e4cv_phi', {'value': 0, 'timestamp': 1776377183.0630927}),\n",
+       "             ('e4cv_tth', {'value': 0, 'timestamp': 1776377183.0630956}),\n",
        "             ('e4cv_atheta',\n",
-       "              {'value': 14.215809201820777, 'timestamp': 1776373372.4078243}),\n",
+       "              {'value': 14.215809201820777, 'timestamp': 1776377183.0630977}),\n",
        "             ('e4cv_attheta',\n",
-       "              {'value': 28.431618403641554, 'timestamp': 1776373372.4078264})])"
+       "              {'value': 28.431618403641554, 'timestamp': 1776377183.0630999})])"
       ]
      },
      "execution_count": 6,
@@ -320,10 +320,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.414545Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.414360Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.417107Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.416766Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.068280Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.068172Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.071518Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.071023Z"
     }
    },
    "outputs": [
@@ -349,10 +349,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.418475Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.418368Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.424233Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.423720Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.072656Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.072549Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.077640Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.077261Z"
     }
    },
    "outputs": [
@@ -391,10 +391,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.425567Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.425461Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.437907Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.437479Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.078994Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.078874Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.093540Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.092988Z"
     }
    },
    "outputs": [
@@ -428,10 +428,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.439337Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.439231Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.791340Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.790864Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.094697Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.094586Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.442967Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.442442Z"
     }
    },
    "outputs": [
@@ -479,10 +479,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.792672Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.792566Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.804483Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.803973Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.444227Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.444117Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.456769Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.456211Z"
     }
    },
    "outputs": [
@@ -513,10 +513,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:02:52.805687Z",
-     "iopub.status.busy": "2026-04-16T21:02:52.805585Z",
-     "iopub.status.idle": "2026-04-16T21:02:52.807824Z",
-     "shell.execute_reply": "2026-04-16T21:02:52.807342Z"
+     "iopub.execute_input": "2026-04-16T22:06:23.458057Z",
+     "iopub.status.busy": "2026-04-16T22:06:23.457951Z",
+     "iopub.status.idle": "2026-04-16T22:06:23.460125Z",
+     "shell.execute_reply": "2026-04-16T22:06:23.459763Z"
     }
    },
    "outputs": [],

--- a/docs/source/guides/how_creator_from_config.rst
+++ b/docs/source/guides/how_creator_from_config.rst
@@ -1,15 +1,15 @@
-.. _how_creator_from_config:
+.. _how_simulator_from_config:
 
 ==========================================
 How to Create a Simulator from a Config
 ==========================================
 
 .. index::
-    !creator_from_config
+    !simulator_from_config
     simulator; from configuration
     configuration; restore as simulator
 
-:func:`~hklpy2.misc.creator_from_config` creates a fully configured
+:func:`~hklpy2.misc.simulator_from_config` creates a fully configured
 simulated diffractometer — with no hardware connections — from a previously
 saved configuration file or dictionary.  All real-axis positioners are soft
 (simulated) positioners regardless of how they were defined in the original
@@ -37,18 +37,18 @@ Create a simulator from that file
 Pass the path to the YAML file::
 
     >>> import hklpy2
-    >>> sim = hklpy2.creator_from_config("e4cv-config.yml")
+    >>> sim = hklpy2.simulator_from_config("e4cv-config.yml")
     >>> sim.wh()
 
 Or pass a configuration dictionary directly::
 
     >>> config = hklpy2.misc.load_yaml_file("e4cv-config.yml")
-    >>> sim = hklpy2.creator_from_config(config)
+    >>> sim = hklpy2.simulator_from_config(config)
 
 Or pass the ``configuration`` property of an existing diffractometer to
 create a simulator with the same orientation — no file needed::
 
-    >>> sim = hklpy2.creator_from_config(k6c.configuration)
+    >>> sim = hklpy2.simulator_from_config(k6c.configuration)
 
 The simulator preserves
 ------------------------
@@ -78,7 +78,7 @@ Custom-named axes are preserved
 If the original diffractometer used custom axis names (e.g. ``theta`` instead
 of ``omega``), those names are preserved in the simulator::
 
-    >>> sim = hklpy2.creator_from_config("fourc-config.yml")
+    >>> sim = hklpy2.simulator_from_config("fourc-config.yml")
     >>> sim.real_axis_names     # e.g. ['theta', 'chi', 'phi', 'ttheta']
     ['theta', 'chi', 'phi', 'ttheta']
 
@@ -87,8 +87,8 @@ Round-trip: simulator to simulator
 
 A simulator's configuration can itself be used to create another simulator::
 
-    >>> sim1 = hklpy2.creator_from_config("e4cv-config.yml")
-    >>> sim2 = hklpy2.creator_from_config(sim1.configuration)
+    >>> sim1 = hklpy2.simulator_from_config("e4cv-config.yml")
+    >>> sim2 = hklpy2.simulator_from_config(sim1.configuration)
 
 .. seealso::
 

--- a/docs/source/guides/how_performance.rst
+++ b/docs/source/guides/how_performance.rst
@@ -82,7 +82,7 @@ Performance target
 -------------------
 
 The project benchmark (``test_i221.py``) measures throughput using
-:func:`~hklpy2.run_utils.creator_from_config` with representative
+:func:`~hklpy2.run_utils.simulator_from_config` with representative
 configuration files and reports operations per second for both
 ``forward()`` and ``inverse()``.  The target is met when **all** parameter
 sets in that test pass.

--- a/src/hklpy2/__init__.py
+++ b/src/hklpy2/__init__.py
@@ -65,7 +65,7 @@ from .diffract import diffractometer_class_factory  # noqa: E402, F401, F403
 from .incident import A_KEV  # noqa: E402, F401
 from .exceptions import SolverError  # noqa: E402, F401
 from .run_utils import ConfigurationRunWrapper  # noqa: E402, F401
-from .run_utils import creator_from_config  # noqa: E402, F401
+from .run_utils import simulator_from_config  # noqa: E402, F401
 from .run_utils import get_run_orientation  # noqa: E402, F401
 from .run_utils import list_orientation_runs  # noqa: E402, F401
 from .solver_utils import SOLVER_ENTRYPOINT_GROUP  # noqa: E402, F401

--- a/src/hklpy2/backends/hkl_soleil.py
+++ b/src/hklpy2/backends/hkl_soleil.py
@@ -274,6 +274,7 @@ class HklSolver(SolverBase):
             "real_axes": self.real_axis_names,
             "version": self.version,
             "engine": self.engine_name,
+            "mode": self.mode,
         }
         return meta
 

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -407,9 +407,9 @@ class DiffractometerBase(PseudoPositioner):
 
         saved_mode = config.get("solver", {}).get("mode")
         if saved_mode is not None:
-            current_mode = self.core.solver.mode
+            current_mode = self.core.mode  # use core.mode (authoritative)
             if restore_mode:
-                self.core.solver.mode = saved_mode
+                self.core.mode = saved_mode
             elif saved_mode != current_mode:
                 import warnings
 

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -339,6 +339,7 @@ class DiffractometerBase(PseudoPositioner):
         clear=True,
         restore_constraints=True,
         restore_wavelength=True,
+        restore_mode=False,
     ) -> None:
         """
         Restore diffractometer configuration.
@@ -368,6 +369,14 @@ class DiffractometerBase(PseudoPositioner):
             If ``True`` (default), restore any constraints provided.
         restore_wavelength : bool
             If ``True`` (default), restore wavelength.
+        restore_mode : bool
+            If ``False`` (default), the solver mode is not changed.  If the
+            saved mode differs from the current mode, a warning is issued so
+            the user can decide whether to apply it.
+
+            If ``True``, the saved mode is applied.  Use with caution on
+            hardware-connected diffractometers — changing mode can cause
+            ``forward()`` to move axes that were previously held fixed.
 
         Note: Can't name this method "import", it's a reserved Python word.
         """
@@ -395,6 +404,22 @@ class DiffractometerBase(PseudoPositioner):
             clear=clear,
             restore_constraints=restore_constraints,
         )
+
+        saved_mode = config.get("solver", {}).get("mode")
+        if saved_mode is not None:
+            current_mode = self.core.solver.mode
+            if restore_mode:
+                self.core.solver.mode = saved_mode
+            elif saved_mode != current_mode:
+                import warnings
+
+                warnings.warn(
+                    f"Saved mode {saved_mode!r} differs from current mode"
+                    f" {current_mode!r}. To apply the saved mode, use"
+                    f" restore(restore_mode=True).",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
     @pseudo_position_argument
     def forward(self, pseudos: dict, wavelength: Optional[float] = None) -> NamedTuple:

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -345,8 +345,9 @@ def simulator_from_config(config: Union[dict, str, pathlib.Path]):
     Create a simulated diffractometer from a saved configuration.
 
     All axes are soft positioners — no hardware connections are made.
-    Auxiliary axes saved by :meth:`~hklpy2.diffract.DiffractometerBase.export`
-    are restored automatically.
+    Auxiliary axes and solver mode saved by
+    :meth:`~hklpy2.diffract.DiffractometerBase.export` are restored
+    automatically.
 
     If the diffractometer requires auxiliary axes that are not in the
     configuration file, use :func:`~hklpy2.diffract.creator` with
@@ -457,5 +458,8 @@ def simulator_from_config(config: Union[dict, str, pathlib.Path]):
         _pseudo=pseudo_axes_ordered if pseudo_axes_ordered else None,
     )
 
-    sim.restore(config)
+    # restore_mode=True is safe here: simulator_from_config() always produces
+    # a simulator with no hardware connections, so mode changes cannot cause
+    # unexpected motion.
+    sim.restore(config, restore_mode=True)
     return sim

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -7,7 +7,7 @@ and retrieve orientation information from previously recorded runs.
 .. autosummary::
 
     ~ConfigurationRunWrapper
-    ~creator_from_config
+    ~simulator_from_config
     ~get_run_orientation
     ~list_orientation_runs
 """
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "ConfigurationRunWrapper",
-    "creator_from_config",
+    "simulator_from_config",
     "get_run_orientation",
     "list_orientation_runs",
 ]
@@ -340,16 +340,13 @@ def list_orientation_runs(
     version="0.4.0",
     reason="Create a simulated diffractometer from a saved configuration.",
 )
-def creator_from_config(config: Union[dict, str, pathlib.Path]):
+def simulator_from_config(config: Union[dict, str, pathlib.Path]):
     """
     Create a simulated diffractometer from a saved configuration.
 
-    Parses the configuration for the solver, geometry, and axis names, then
-    constructs a simulator (all axes are soft positioners — no hardware
-    connection) and restores the full orientation (samples, reflections, UB
-    matrix, wavelength, constraints) from the configuration.  Auxiliary axes
-    saved by :meth:`~hklpy2.diffract.DiffractometerBase.export` are restored
-    automatically.
+    All axes are soft positioners — no hardware connections are made.
+    Auxiliary axes saved by :meth:`~hklpy2.diffract.DiffractometerBase.export`
+    are restored automatically.
 
     If the diffractometer requires auxiliary axes that are not in the
     configuration file, use :func:`~hklpy2.diffract.creator` with
@@ -372,7 +369,7 @@ def creator_from_config(config: Union[dict, str, pathlib.Path]):
     EXAMPLE::
 
         >>> import hklpy2
-        >>> sim = hklpy2.creator_from_config("e4cv-config.yml")
+        >>> sim = hklpy2.simulator_from_config("e4cv-config.yml")
         >>> sim.wh()
 
     SEE ALSO
@@ -382,7 +379,7 @@ def creator_from_config(config: Union[dict, str, pathlib.Path]):
     from .diffract import creator
 
     if isinstance(config, (str, pathlib.Path)):
-        logger.debug("creator_from_config: loading from file %r", str(config))
+        logger.debug("simulator_from_config: loading from file %r", str(config))
         config = load_yaml_file(config)
     if not isinstance(config, dict):
         raise TypeError(
@@ -445,7 +442,7 @@ def creator_from_config(config: Union[dict, str, pathlib.Path]):
     diffractometer_name = config.get("name", geometry.lower())
 
     logger.debug(
-        "creator_from_config: creating %r solver=%r geometry=%r",
+        "simulator_from_config: creating %r solver=%r geometry=%r",
         diffractometer_name,
         solver_name,
         geometry,

--- a/src/hklpy2/tests/test_i210.py
+++ b/src/hklpy2/tests/test_i210.py
@@ -384,3 +384,42 @@ def test_simulator_from_config_auxiliary_axes_roundtrip(tmp_path):
         sim.forward(h=1, k=0, l=0)[0],
         sim2.forward(h=1, k=0, l=0)[0],
     )
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                config="e4cv_orient.yml", restore_mode=True, expected_mode="bissector"
+            ),
+            does_not_raise(),
+            id="restore_mode=True applies saved mode",
+        ),
+        pytest.param(
+            dict(
+                config="e4cv_orient.yml",
+                restore_mode=False,
+                expected_mode="constant_phi",
+            ),
+            pytest.warns(UserWarning, match="differs from current mode"),
+            id="restore_mode=False warns when saved mode differs from current",
+        ),
+    ],
+)
+def test_restore_mode(parms, context):
+    """
+    Test restore() mode handling (issue #363).
+
+    restore_mode=True applies the saved mode; restore_mode=False (default)
+    warns when saved mode differs from current mode.
+    """
+    with context:
+        sim = hklpy2.creator(name="e4cv")
+        # Set a mode that differs from the saved mode (bissector).
+        sim.core.mode = "constant_phi"
+        sim.restore(
+            TESTS_DIR / parms["config"],
+            restore_mode=parms["restore_mode"],
+        )
+        assert sim.core.mode == parms["expected_mode"]

--- a/src/hklpy2/tests/test_i210.py
+++ b/src/hklpy2/tests/test_i210.py
@@ -1,7 +1,7 @@
 """
 Regression test for issue #210.
 
-Test creator_from_config(): create a simulated diffractometer from a
+Test simulator_from_config(): create a simulated diffractometer from a
 saved configuration file or dict, with no hardware connections.
 """
 
@@ -15,7 +15,7 @@ import pytest
 import yaml
 
 import hklpy2
-from hklpy2.run_utils import creator_from_config
+from hklpy2.run_utils import simulator_from_config
 
 TESTS_DIR = pathlib.Path(__file__).parent
 
@@ -59,10 +59,10 @@ TESTS_DIR = pathlib.Path(__file__).parent
         ),
     ],
 )
-def test_creator_from_config(parms, context):
-    """Test that creator_from_config() returns a working diffractometer."""
+def test_simulator_from_config(parms, context):
+    """Test that simulator_from_config() returns a working diffractometer."""
     with context:
-        sim = creator_from_config(parms["config"])
+        sim = simulator_from_config(parms["config"])
         assert sim is not None
         assert hasattr(sim, "core")
         assert hasattr(sim, "forward")
@@ -105,10 +105,10 @@ def test_creator_from_config(parms, context):
         ),
     ],
 )
-def test_creator_from_config_orientation(parms, context):
+def test_simulator_from_config_orientation(parms, context):
     """Test that orientation data is restored correctly."""
     with context:
-        sim = creator_from_config(parms["config"])
+        sim = simulator_from_config(parms["config"])
 
         assert sim.core.solver.name == parms["expected_solver"]
         assert sim.core.solver.geometry == parms["expected_geometry"]
@@ -131,7 +131,7 @@ def test_creator_from_config_orientation(parms, context):
 def test_simulator_is_simulated(parms, context):
     """Test that the simulator uses soft positioners, not EPICS."""
     with context:
-        sim = creator_from_config(parms["config"])
+        sim = simulator_from_config(parms["config"])
         # Soft positioners are connected immediately without an IOC
         assert sim.connected
 
@@ -142,14 +142,14 @@ def test_simulator_is_simulated(parms, context):
         pytest.param(
             dict(config=TESTS_DIR / "e4cv-silicon-example.yml"),
             does_not_raise(),
-            id="creator_from_config accessible from hklpy2 namespace",
+            id="simulator_from_config accessible from hklpy2 namespace",
         ),
     ],
 )
-def test_creator_from_config_in_namespace(parms, context):
-    """Test that creator_from_config is accessible from hklpy2 namespace."""
+def test_simulator_from_config_in_namespace(parms, context):
+    """Test that simulator_from_config is accessible from hklpy2 namespace."""
     with context:
-        sim = hklpy2.creator_from_config(parms["config"])
+        sim = hklpy2.simulator_from_config(parms["config"])
         assert sim is not None
 
 
@@ -166,10 +166,10 @@ def test_creator_from_config_in_namespace(parms, context):
 def test_simulator_roundtrip(parms, context):
     """Test that a simulator's exported config can recreate another simulator."""
     with context:
-        sim1 = creator_from_config(parms["config"])
+        sim1 = simulator_from_config(parms["config"])
         config1 = sim1.configuration
 
-        sim2 = creator_from_config(config1)
+        sim2 = simulator_from_config(config1)
 
         assert sim2.core.solver.geometry == sim1.core.solver.geometry
         assert set(sim2.core.samples.keys()) == set(sim1.core.samples.keys())
@@ -206,7 +206,7 @@ def test_simulator_roundtrip(parms, context):
 def test_simulator_axis_order(parms, context):
     """Test that real axes are in solver-expected order even with custom names."""
     with context:
-        sim = creator_from_config(parms["config"])
+        sim = simulator_from_config(parms["config"])
         assert sim.real_axis_names == parms["expected_real_axes"]
 
 
@@ -234,12 +234,12 @@ def test_simulator_axis_order(parms, context):
 def test_simulator_pseudo_order(parms, context):
     """Test that pseudo axes are in solver-expected order."""
     with context:
-        sim = creator_from_config(parms["config"])
+        sim = simulator_from_config(parms["config"])
         assert sim.pseudo_axis_names == parms["expected_pseudo_axes"]
 
 
 # ---------------------------------------------------------------------------
-# Issue #243: creator_from_config restores reflections with wrong axis values
+# Issue #243: simulator_from_config restores reflections with wrong axis values
 # when YAML serialises reals dict keys in alphabetical order.
 # ---------------------------------------------------------------------------
 
@@ -298,7 +298,7 @@ def _config_with_positionally_wrong_reals():
         ),
     ],
 )
-def test_creator_from_config_reflection_axis_order(parms, context):
+def test_simulator_from_config_reflection_axis_order(parms, context):
     """Regression test for #243: reals must be assigned by key, not position.
 
     YAML serialises dict keys alphabetically.  Before the fix, restoring a
@@ -309,7 +309,7 @@ def test_creator_from_config_reflection_axis_order(parms, context):
     internal implementation path.
     """
     with context:
-        sim = creator_from_config(parms["config"])
+        sim = simulator_from_config(parms["config"])
         r1, r2 = list(sim.core.sample.reflections)[:2]
         ub = sim.core.calc_UB(r1, r2)
         norm = np.linalg.norm(ub)
@@ -333,24 +333,24 @@ def test_creator_from_config_reflection_axis_order(parms, context):
         ),
     ],
 )
-def test_creator_from_config_no_auxiliary_axes(parms, context):
+def test_simulator_from_config_no_auxiliary_axes(parms, context):
     """
-    Test creator_from_config() backward compatibility (issue #361).
+    Test simulator_from_config() backward compatibility (issue #361).
 
     Old config files without auxiliary_axes restore without error.
     """
     with context:
-        sim = creator_from_config(TESTS_DIR / parms["config"])
+        sim = simulator_from_config(TESTS_DIR / parms["config"])
         for ax in ("omega", "chi", "phi", "tth"):
             assert ax in sim.component_names
         result = sim.forward(h=1, k=0, l=0)
         assert len(result) > 0
 
 
-def test_creator_from_config_auxiliary_axes_roundtrip(tmp_path):
+def test_simulator_from_config_auxiliary_axes_roundtrip(tmp_path):
     """
     Test that auxiliary axes are saved by export() and restored automatically
-    by creator_from_config() without requiring reals= (issue #361).
+    by simulator_from_config() without requiring reals= (issue #361).
     """
     import yaml
 
@@ -375,7 +375,7 @@ def test_creator_from_config_auxiliary_axes_roundtrip(tmp_path):
     assert cfg["axes"].get("auxiliary_axes") == ["atheta", "attheta"]
 
     # Restore without reals= — auxiliary axes come from the config automatically.
-    sim2 = creator_from_config(config_file)
+    sim2 = simulator_from_config(config_file)
     assert "atheta" in sim2.component_names
     assert "attheta" in sim2.component_names
 

--- a/src/hklpy2/tests/test_i221.py
+++ b/src/hklpy2/tests/test_i221.py
@@ -13,7 +13,7 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from .. import creator_from_config
+from .. import simulator_from_config
 from .common import TESTS_DIR
 
 # Number of calls used to measure throughput.
@@ -73,7 +73,7 @@ def test_forward_throughput(parms, context):
     target required by issue #221.
     """
     with context:
-        sim = creator_from_config(TESTS_DIR / parms["config"])
+        sim = simulator_from_config(TESTS_DIR / parms["config"])
         sim.core.solver.mode = parms["mode"]
 
         t0 = time.perf_counter()
@@ -140,7 +140,7 @@ def test_inverse_throughput(parms, context):
     target required by issue #221 (and #223).
     """
     with context:
-        sim = creator_from_config(TESTS_DIR / parms["config"])
+        sim = simulator_from_config(TESTS_DIR / parms["config"])
         sim.core.solver.mode = parms["mode"]
 
         t0 = time.perf_counter()

--- a/src/hklpy2/tests/test_i240.py
+++ b/src/hklpy2/tests/test_i240.py
@@ -311,9 +311,9 @@ def test_i240_libhkl():
 
 def test_i240_from_config():
     """Test using configuration file."""
-    from .. import creator_from_config
+    from .. import simulator_from_config
 
-    polar = creator_from_config(I250_CONFIG_FILE)
+    polar = simulator_from_config(I250_CONFIG_FILE)
     # validate the input first
     assert polar.sample.name == "test"
     assert polar.sample.lattice.crystal_system == "cubic"

--- a/src/hklpy2/tests/test_plans.py
+++ b/src/hklpy2/tests/test_plans.py
@@ -10,7 +10,7 @@ import pytest
 from ophyd.sim import noisy_det
 
 from ..diffract import creator
-from ..run_utils import creator_from_config
+from ..run_utils import simulator_from_config
 from ..utils import validate_not_parallel
 from ..plans import _find_psi_axis
 from ..plans import _find_psi_mode
@@ -23,7 +23,7 @@ HKLPY2_DIR = Path(__file__).parent.parent
 
 def sim4c():
     """Oriented E4CV with silicon, ready for psi scans."""
-    return creator_from_config(HKLPY2_DIR / "tests" / "e4cv_orient.yml")
+    return simulator_from_config(HKLPY2_DIR / "tests" / "e4cv_orient.yml")
 
 
 # ---------------------------------------------------------------------------

--- a/src/hklpy2/tests/test_utils.py
+++ b/src/hklpy2/tests/test_utils.py
@@ -43,7 +43,7 @@ from ..utils import pick_closest_solution
 from ..utils import pick_first_solution
 from ..utils import roundoff
 from ..run_utils import ConfigurationRunWrapper
-from ..run_utils import creator_from_config
+from ..run_utils import simulator_from_config
 from ..run_utils import get_run_orientation
 from ..run_utils import list_orientation_runs
 from ..solver_utils import get_solver
@@ -1140,7 +1140,7 @@ def test_benchmark(capsys, parms, context):
     hardware connection.
     """
     with context:
-        sim = creator_from_config(TESTS_DIR / parms["config"])
+        sim = simulator_from_config(TESTS_DIR / parms["config"])
         result = benchmark(sim, n=10, print=parms["print"])
 
         if parms["print"]:
@@ -1174,7 +1174,7 @@ def test_benchmark(capsys, parms, context):
 
 def test_benchmark_no_reflections():
     """benchmark() falls back to current position when sample has no reflections."""
-    sim = creator_from_config(TESTS_DIR / "e4cv_orient.yml")
+    sim = simulator_from_config(TESTS_DIR / "e4cv_orient.yml")
     # Remove all reflections to exercise the else branch; UB matrix is retained.
     for name in list(sim.sample.reflections.keys()):
         sim.sample.remove_reflection(name)


### PR DESCRIPTION
- closes #363

## Summary

**Breaking change** (0.6.0): rename `creator_from_config()` → `simulator_from_config()` to make explicit that it always produces a simulator with no hardware connections.

**Mode save/restore** (the core of #363):
* `export()` now saves the solver mode under `solver.mode` in the config file.
* `restore()` gains `restore_mode=False` (default): warns when the saved mode differs from the current mode, so the user can decide whether to apply it. On hardware-connected diffractometers, silently changing mode could cause `forward()` to move axes that were previously held fixed.
* `restore(restore_mode=True)` applies the saved mode explicitly — opt-in only.
* `simulator_from_config()` calls `restore(restore_mode=True)` — safe because it always produces a simulator with no hardware connections.

## Safety rationale

Changing mode on a live diffractometer can cause unexpected motion. The default `restore_mode=False` ensures users are always in control of anything that could affect hardware.

Agent: OpenCode (claudesonnet46)