### PR TITLE
feat #369 benchmark() snapshots config; report fwd/inv ratio

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -30,10 +30,17 @@ describe future plans.
 
     Release expected 2026-Q3.
 
-    0.6.1
-    #####
+0.6.1
+#####
 
-    Release expected by 2026-H2.
+Release expected by 2026-H2.
+
+Enhancements
+------------
+
+* ``benchmark()``: add ``snapshot=True`` (default) to time on a simulator
+  built from the diffractometer's configuration, and report ``fwd/inv``
+  ratio. (:issue:`369`, :issue:`373`)
 
 0.6.0
 #####

--- a/src/hklpy2/tests/test_utils.py
+++ b/src/hklpy2/tests/test_utils.py
@@ -1120,14 +1120,24 @@ def test_make_dynamic_instance_raises():
     "parms, context",
     [
         pytest.param(
-            dict(config="e4cv_orient.yml", print=False),
+            dict(config="e4cv_orient.yml", print=False, snapshot=True),
             does_not_raise(),
-            id="benchmark returns dict when print=False",
+            id="benchmark returns dict when print=False (snapshot=True)",
         ),
         pytest.param(
-            dict(config="e4cv_orient.yml", print=True),
+            dict(config="e4cv_orient.yml", print=True, snapshot=True),
             does_not_raise(),
-            id="benchmark returns None when print=True",
+            id="benchmark returns None when print=True (snapshot=True)",
+        ),
+        pytest.param(
+            dict(config="e4cv_orient.yml", print=False, snapshot=False),
+            does_not_raise(),
+            id="benchmark returns dict when print=False (snapshot=False)",
+        ),
+        pytest.param(
+            dict(config="e4cv_orient.yml", print=True, snapshot=False),
+            does_not_raise(),
+            id="benchmark returns None when print=True (snapshot=False)",
         ),
     ],
 )
@@ -1141,7 +1151,12 @@ def test_benchmark(capsys, parms, context):
     """
     with context:
         sim = simulator_from_config(TESTS_DIR / parms["config"])
-        result = benchmark(sim, n=10, print=parms["print"])
+        result = benchmark(
+            sim,
+            n=10,
+            print=parms["print"],
+            snapshot=parms["snapshot"],
+        )
 
         if parms["print"]:
             assert result is None
@@ -1150,6 +1165,8 @@ def test_benchmark(capsys, parms, context):
             assert "forward()" in captured.out
             assert "inverse()" in captured.out
             assert "ops/sec" in captured.out
+            assert "fwd/inv" in captured.out
+            assert f"snapshot:   {parms['snapshot']}" in captured.out
         else:
             assert result is not None
             assert isinstance(result, dict)
@@ -1163,6 +1180,7 @@ def test_benchmark(capsys, parms, context):
                 "forward_ms_per_call",
                 "inverse_ops_per_sec",
                 "inverse_ms_per_call",
+                "fwd_inv_ratio",
                 "target_ops_per_sec",
             }
             assert set(result.keys()) == expected_keys
@@ -1170,6 +1188,27 @@ def test_benchmark(capsys, parms, context):
             assert result["forward_ops_per_sec"] > 0
             assert result["inverse_ops_per_sec"] > 0
             assert result["target_ops_per_sec"] == 2_000
+            # fwd_inv_ratio matches the reported per-operation throughputs.
+            assert result["fwd_inv_ratio"] == pytest.approx(
+                result["forward_ops_per_sec"] / result["inverse_ops_per_sec"]
+            )
+
+
+def test_benchmark_snapshot_does_not_mutate_diffractometer():
+    """
+    Per #369: ``benchmark(snapshot=True)`` must not alter the supplied
+    diffractometer's solver state, sample, or position.
+    """
+    sim = simulator_from_config(TESTS_DIR / "e4cv_orient.yml")
+    before_mode = sim.core.solver.mode
+    before_sample = sim.sample.name
+    before_position = sim.real_position
+
+    benchmark(sim, n=5, print=False, snapshot=True)
+
+    assert sim.core.solver.mode == before_mode
+    assert sim.sample.name == before_sample
+    assert sim.real_position == before_position
 
 
 def test_benchmark_no_reflections():
@@ -1181,6 +1220,9 @@ def test_benchmark_no_reflections():
     assert len(sim.sample.reflections) == 0
     # Move to a non-trivial position so forward() has a solution.
     sim.move(1, 0, 0)
-    result = benchmark(sim, n=5, print=False)
+    # snapshot=False so the (mutated) sim is the actual benchmark target;
+    # otherwise the snapshot is rebuilt from configuration() and may not
+    # reflect the in-memory removal of reflections.
+    result = benchmark(sim, n=5, print=False, snapshot=False)
     assert result["forward_ops_per_sec"] > 0
     assert result["inverse_ops_per_sec"] > 0

--- a/src/hklpy2/utils.py
+++ b/src/hklpy2/utils.py
@@ -435,7 +435,12 @@ def validate_and_canonical_unit(value: str, target_units: str) -> str:
     return value
 
 
-def benchmark(diffractometer, n: int = 500, print: bool = True):
+def benchmark(
+    diffractometer,
+    n: int = 500,
+    print: bool = True,
+    snapshot: bool = True,
+):
     """
     Assess ``forward()`` and ``inverse()`` throughput for a diffractometer.
 
@@ -455,6 +460,12 @@ def benchmark(diffractometer, n: int = 500, print: bool = True):
         When ``True`` (default), print a human-readable report to stdout and
         return ``None``.  When ``False``, suppress all output and return a
         ``dict`` of results.
+    snapshot : bool, optional
+        When ``True`` (default), snapshot the diffractometer configuration
+        and run all timing loops on a simulator built from that snapshot,
+        leaving the original diffractometer (and its solver state)
+        completely untouched.  When ``False``, run the timing loops directly
+        on the supplied diffractometer (legacy behaviour).
 
     Returns
     -------
@@ -471,6 +482,7 @@ def benchmark(diffractometer, n: int = 500, print: bool = True):
         - ``"forward_ms_per_call"`` — ``forward()`` latency in ms
         - ``"inverse_ops_per_sec"`` — ``inverse()`` throughput
         - ``"inverse_ms_per_call"`` — ``inverse()`` latency in ms
+        - ``"fwd_inv_ratio"`` — ratio of forward to inverse ops/sec
         - ``"target_ops_per_sec"`` — minimum target (2,000)
 
     Example
@@ -488,25 +500,37 @@ def benchmark(diffractometer, n: int = 500, print: bool = True):
     """
     TARGET = 2_000
 
+    # Per #369: by default, snapshot the diffractometer configuration and
+    # run all timing loops on a simulator built from that snapshot.  This
+    # eliminates any risk of side effects on motor positions, sample state,
+    # or solver state during the benchmark — especially important when
+    # called on a live instrument.
+    if snapshot:
+        from .run_utils import simulator_from_config
+
+        target = simulator_from_config(diffractometer.configuration)
+    else:
+        target = diffractometer
+
     # Use the first reflection's positions if available, as the origin (0,0,0)
     # has no forward() solution. Fall back to current position otherwise.
-    reflections = list(diffractometer.sample.reflections.values())
+    reflections = list(target.sample.reflections.values())
     if reflections:
         pseudos = reflections[0].pseudos
         reals = reflections[0].reals
     else:
-        pseudos = diffractometer.position._asdict()
-        reals = diffractometer.real_position._asdict()
-    solver = diffractometer.core.solver
+        pseudos = target.position._asdict()
+        reals = target.real_position._asdict()
+    solver = target.core.solver
     mode = solver.mode
     geometry = solver.geometry
     solver_name = solver.name
-    wavelength = diffractometer.beam.wavelength.get()
+    wavelength = target.beam.wavelength.get()
 
     # forward() benchmark
     t0 = time.perf_counter()
     for _ in range(n):
-        diffractometer.forward(**pseudos)
+        target.forward(**pseudos)
     fwd_elapsed = time.perf_counter() - t0
     fwd_ops = n / fwd_elapsed
     fwd_ms = fwd_elapsed * 1000 / n
@@ -514,10 +538,12 @@ def benchmark(diffractometer, n: int = 500, print: bool = True):
     # inverse() benchmark
     t0 = time.perf_counter()
     for _ in range(n):
-        diffractometer.inverse(**reals)
+        target.inverse(**reals)
     inv_elapsed = time.perf_counter() - t0
     inv_ops = n / inv_elapsed
     inv_ms = inv_elapsed * 1000 / n
+
+    fwd_inv_ratio = fwd_ops / inv_ops if inv_ops > 0 else float("inf")
 
     results = {
         "solver": solver_name,
@@ -529,6 +555,7 @@ def benchmark(diffractometer, n: int = 500, print: bool = True):
         "forward_ms_per_call": fwd_ms,
         "inverse_ops_per_sec": inv_ops,
         "inverse_ms_per_call": inv_ms,
+        "fwd_inv_ratio": fwd_inv_ratio,
         "target_ops_per_sec": TARGET,
     }
 
@@ -550,11 +577,12 @@ def benchmark(diffractometer, n: int = 500, print: bool = True):
         f"\n  mode:       {mode}"
         f"\n  wavelength: {wavelength}"
         f"\n  calls:      {n}"
+        f"\n  snapshot:   {snapshot}"
         f"\n"
-        f"\n  {'operation':<12} {'ops/sec':>10} {'ms/call':>11} {'status':>6}"
-        f"\n  {'-' * 12} {'-' * 10} {'-' * 11} {'-' * 6}"
-        f"\n  {'forward()':<12} {fwd_ops:>10.0f} {fwd_ms:>11.3f} {_status(fwd_ops):>6}"
-        f"\n  {'inverse()':<12} {inv_ops:>10.0f} {inv_ms:>11.3f} {_status(inv_ops):>6}"
+        f"\n  {'operation':<12} {'ops/sec':>10} {'ms/call':>11} {'fwd/inv':>9} {'status':>6}"  # noqa: E501
+        f"\n  {'-' * 12} {'-' * 10} {'-' * 11} {'-' * 9} {'-' * 6}"
+        f"\n  {'forward()':<12} {fwd_ops:>10.0f} {fwd_ms:>11.3f} {fwd_inv_ratio:>9.3f} {_status(fwd_ops):>6}"  # noqa: E501
+        f"\n  {'inverse()':<12} {inv_ops:>10.0f} {inv_ms:>11.3f} {'':>9} {_status(inv_ops):>6}"  # noqa: E501
         f"\n"
         f"\n  target: {TARGET:,} ops/sec (+/-{tolerance:.0%})"
     )


### PR DESCRIPTION
- closes #369
- closes #373

## Summary

- ``benchmark()`` gains ``snapshot=True`` (default).  When set, it builds
  a simulator from ``diffractometer.configuration`` and runs all timing
  loops against the simulator, leaving the supplied diffractometer
  (motors, sample state, solver state) completely untouched.  This makes
  it safe to call on a live instrument.  ``snapshot=False`` retains the
  legacy in-place behaviour.
- Adds an ``fwd_inv_ratio`` key to the result ``dict`` and a
  ``fwd/inv`` column to the printed table (#373).

## Test changes

- Parametrized the existing ``test_benchmark`` over
  ``snapshot=True/False`` and added an assertion that the new
  ``fwd_inv_ratio`` matches ``forward_ops_per_sec / inverse_ops_per_sec``.
- Added ``test_benchmark_snapshot_does_not_mutate_diffractometer`` to
  guard the #369 invariant (mode/sample/position unchanged after
  ``benchmark(..., snapshot=True)``).
- ``test_benchmark_no_reflections`` now runs with ``snapshot=False``
  because that test deliberately mutates the in-memory simulator's
  reflections (the exported configuration would re-include them).

## Release notes

- Opened the ``0.6.1`` development section with a single combined
  Enhancements entry.

Agent: OpenCode (claudeopus47)