### PR TITLE
feat #372 add Solver.default_geometry() and default_mode()

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -41,6 +41,9 @@ Enhancements
 * ``benchmark()``: add ``snapshot=True`` (default) to time on a simulator
   built from the diffractometer's configuration, and report ``fwd/inv``
   ratio. (:issue:`369`, :issue:`373`)
+* ``Solver.default_geometry()`` and ``Solver.default_mode(geometry)``;
+  remove hardcoded ``"E4CV"`` fallback in ``simulator_from_config()``.
+  (:issue:`372`)
 
 0.6.0
 #####

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -19,6 +19,7 @@ from deprecated.sphinx import versionadded
 
 from pyRestTable import Table
 
+from ..exceptions import SolverError
 from ..utils import IDENTITY_MATRIX_3X3
 from ..utils import INTERNAL_ANGLE_UNITS
 from ..utils import INTERNAL_LENGTH_UNITS
@@ -102,6 +103,8 @@ class SolverBase(ABC):
     .. autosummary::
 
         ~_geometry_registry
+        ~default_geometry
+        ~default_mode
         ~register_geometry
 
     .. rubric:: Python Properties
@@ -201,14 +204,82 @@ class SolverBase(ABC):
         cls._geometry_registry[descriptor.name] = descriptor
         logger.debug("Registered geometry %r on %s", descriptor.name, cls.__name__)
 
+    @versionadded(version="0.6.1", reason="Solver default geometry/mode contract.")
+    @classmethod
+    def default_geometry(cls) -> str:
+        """
+        Return this solver's default geometry name.
+
+        The default is the **first** entry in :meth:`geometries`.  Subclasses
+        that do not use :attr:`_geometry_registry` (e.g.
+        :class:`~hklpy2.backends.hkl_soleil.HklSolver`) should override this
+        method.
+
+        Raises
+        ------
+        SolverError
+            If the solver has no registered geometries.
+        """
+        names = cls.geometries()
+        if not names:
+            raise SolverError(
+                f"{cls.__name__} has no registered geometries; cannot pick a default."
+            )
+        return names[0]
+
+    @versionadded(version="0.6.1", reason="Solver default geometry/mode contract.")
+    @classmethod
+    def default_mode(cls, geometry: str) -> str:
+        """
+        Return the default mode for *geometry*.
+
+        Resolution order:
+
+        1. If a :class:`~hklpy2.backends.typing.GeometryDescriptor` is
+           registered for *geometry* and its
+           :attr:`~GeometryDescriptor.default_mode` is non-empty, return that.
+        2. Otherwise return the first entry in the descriptor's
+           :attr:`~GeometryDescriptor.modes`.
+
+        Subclasses that do not use :attr:`_geometry_registry` should override
+        this method to query their underlying library directly.
+
+        Raises
+        ------
+        SolverError
+            If *geometry* is not registered, or has no modes defined.
+        """
+        descriptor = cls._geometry_registry.get(geometry)
+        if descriptor is None:
+            raise SolverError(
+                f"{cls.__name__} has no registered geometry {geometry!r};"
+                f" cannot pick a default mode."
+            )
+        if descriptor.default_mode:
+            return descriptor.default_mode
+        if descriptor.modes:
+            return descriptor.modes[0]
+        raise SolverError(
+            f"Geometry {geometry!r} on {cls.__name__} defines no modes;"
+            f" cannot pick a default mode."
+        )
+
     def __init__(
         self,
         geometry: str,
         *,
         mode: str = "",  # "": accept solver's default mode
+        _resolve_default_mode: bool = True,
         **kwargs: Any,
     ) -> None:
         self._gname: str = geometry
+        if mode == "" and _resolve_default_mode:
+            try:
+                mode = type(self).default_mode(geometry)
+            except SolverError:
+                # Solver has no default for this geometry (e.g. NoOpSolver);
+                # leave mode blank as before.
+                mode = ""
         self.mode = mode
         self._all_extra_axis_names: Optional[List[str]] = None
         self._sample: Optional[SampleDict] = None

--- a/src/hklpy2/backends/hkl_soleil.py
+++ b/src/hklpy2/backends/hkl_soleil.py
@@ -262,7 +262,7 @@ class HklSolver(SolverBase):
         if mode == "":
             try:
                 mode = type(self).default_mode(geometry, engine=engine)
-            except SolverError:
+            except SolverError:  # pragma: no cover - defensive; libhkl raises first
                 mode = ""
         self.mode = mode
 
@@ -540,7 +540,9 @@ class HklSolver(SolverBase):
             )
         engine_list = factories[geometry].create_new_engine_list()
         engines = engine_list.engines_get()
-        if not engines:
+        if (
+            not engines
+        ):  # pragma: no cover - libhkl-listed geometries always have engines
             raise SolverError(
                 f"{cls.__name__}: geometry {geometry!r} has no engines;"
                 f" cannot pick a default mode."
@@ -553,7 +555,9 @@ class HklSolver(SolverBase):
         if chosen is None:
             chosen = engines[0]
         modes = chosen.modes_names_get()
-        if not modes:
+        if (
+            not modes
+        ):  # pragma: no cover - libhkl engines always declare at least one mode
             raise SolverError(
                 f"{cls.__name__}: geometry {geometry!r} engine"
                 f" {chosen.name_get()!r} has no modes;"

--- a/src/hklpy2/backends/hkl_soleil.py
+++ b/src/hklpy2/backends/hkl_soleil.py
@@ -48,6 +48,7 @@ from numpy import typing as npt
 from pyRestTable import Table
 
 from ..exceptions import NoForwardSolutions
+from ..exceptions import SolverError
 from ..utils import IDENTITY_MATRIX_3X3
 from ..utils import check_value_in_list
 from ..utils import istype
@@ -241,7 +242,11 @@ class HklSolver(SolverBase):
         self._hkl_engine = None
         self._sample = None
 
-        super().__init__(geometry, **kwargs)
+        # Suppress base-class default-mode resolution: libhkl objects are
+        # not yet built, so self.modes would return [] at this point.  We
+        # resolve and apply the default mode ourselves below, after engine
+        # setup, so mode validation in self.mode = ... can succeed.
+        super().__init__(geometry, _resolve_default_mode=False, **kwargs)
 
         # Preface libhkl object names with "_hkl".
         # Note: must keep the '_hkl_engine_list' object as class attribute or
@@ -254,6 +259,11 @@ class HklSolver(SolverBase):
         self._hkl_engine = self._hkl_engine_list.engine_get_by_name(engine)
         self._hkl_geometry = self._hkl_factory.create_new_geometry()
 
+        if mode == "":
+            try:
+                mode = type(self).default_mode(geometry, engine=engine)
+            except SolverError:
+                mode = ""
         self.mode = mode
 
     def __repr__(self) -> str:
@@ -499,6 +509,57 @@ class HklSolver(SolverBase):
                 if num_engines(geometry) > 0
             ]
         )
+
+    @classmethod
+    def default_mode(cls, geometry: str, *, engine: str = "hkl") -> str:
+        """
+        Return the first mode of *geometry*'s *engine*.
+
+        Queries |libhkl| directly via :func:`libhkl.factories` rather than the
+        :attr:`_geometry_registry` (which ``HklSolver`` does not populate).
+
+        Parameters
+        ----------
+        geometry : str
+            Geometry name as known to |libhkl| (e.g. ``"E4CV"``).
+        engine : str, optional
+            Engine name (default: ``"hkl"``).  When the named engine is not
+            available for *geometry*, falls back to the first available
+            engine.
+
+        Raises
+        ------
+        SolverError
+            If *geometry* is not known to |libhkl| or has no modes defined.
+        """
+        factories = libhkl.factories()
+        if geometry not in factories:
+            raise SolverError(
+                f"{cls.__name__}: geometry {geometry!r} is not known to libhkl;"
+                f" cannot pick a default mode."
+            )
+        engine_list = factories[geometry].create_new_engine_list()
+        engines = engine_list.engines_get()
+        if not engines:
+            raise SolverError(
+                f"{cls.__name__}: geometry {geometry!r} has no engines;"
+                f" cannot pick a default mode."
+            )
+        chosen = None
+        for eng in engines:
+            if eng.name_get() == engine:
+                chosen = eng
+                break
+        if chosen is None:
+            chosen = engines[0]
+        modes = chosen.modes_names_get()
+        if not modes:
+            raise SolverError(
+                f"{cls.__name__}: geometry {geometry!r} engine"
+                f" {chosen.name_get()!r} has no modes;"
+                f" cannot pick a default mode."
+            )
+        return modes[0]
 
     def inverse(self, reals: NamedFloatDict) -> NamedFloatDict:
         """Compute tuple of pseudos from reals (angles -> hkl)."""

--- a/src/hklpy2/backends/tests/test_base.py
+++ b/src/hklpy2/backends/tests/test_base.py
@@ -369,6 +369,11 @@ def test_init_applies_default_mode(parms, context):
             does_not_raise(),
             id="blank default_mode falls back to modes[0]",
         ),
+        pytest.param(
+            dict(modes=[], default_mode="", expected=None),
+            pytest.raises(SolverError, match=re.escape("defines no modes")),
+            id="empty modes -> SolverError",
+        ),
     ],
 )
 def test_descriptor_default_mode_resolution(parms, context):

--- a/src/hklpy2/backends/tests/test_base.py
+++ b/src/hklpy2/backends/tests/test_base.py
@@ -10,10 +10,14 @@ import pytest
 
 from ...blocks.lattice import Lattice
 from ...blocks.reflection import Reflection
+from ...exceptions import SolverError
 from ...utils import IDENTITY_MATRIX_3X3
 from ..base import SolverBase
+from ..no_op import NoOpSolver
+from ..th_tth_q import BISECTOR_MODE
 from ..th_tth_q import TH_TTH_Q_GEOMETRY
 from ..th_tth_q import ThTthSolver
+from ..typing import GeometryDescriptor
 
 
 class TrivialSolver(SolverBase):
@@ -265,3 +269,124 @@ def test_SolverBase_U_UB_inherited(parms, context):
         assert solver.U == _SAMPLE_MATRIX
         solver.UB = _SAMPLE_MATRIX
         assert solver.UB == _SAMPLE_MATRIX
+
+
+# ---------------------------------------------------------------------------
+# Issue #372: Solver default geometry & default mode contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(cls=ThTthSolver, expected=TH_TTH_Q_GEOMETRY),
+            does_not_raise(),
+            id="ThTthSolver: first registered geometry",
+        ),
+        pytest.param(
+            dict(cls=NoOpSolver, expected=None),
+            pytest.raises(
+                SolverError,
+                match=re.escape("NoOpSolver has no registered geometries"),
+            ),
+            id="NoOpSolver: no geometries -> SolverError",
+        ),
+    ],
+)
+def test_default_geometry(parms, context):
+    """Solver.default_geometry() returns geometries()[0] or raises."""
+    with context:
+        result = parms["cls"].default_geometry()
+        assert result == parms["expected"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(cls=ThTthSolver, geometry=TH_TTH_Q_GEOMETRY, expected=BISECTOR_MODE),
+            does_not_raise(),
+            id="ThTthSolver: descriptor.default_mode wins",
+        ),
+        pytest.param(
+            dict(cls=ThTthSolver, geometry="UNKNOWN", expected=None),
+            pytest.raises(
+                SolverError,
+                match=re.escape("ThTthSolver has no registered geometry 'UNKNOWN'"),
+            ),
+            id="ThTthSolver: unregistered geometry -> SolverError",
+        ),
+        pytest.param(
+            dict(cls=NoOpSolver, geometry="anything", expected=None),
+            pytest.raises(
+                SolverError,
+                match=re.escape("NoOpSolver has no registered geometry 'anything'"),
+            ),
+            id="NoOpSolver: any geometry -> SolverError",
+        ),
+    ],
+)
+def test_default_mode(parms, context):
+    """Solver.default_mode(geometry) honours descriptor.default_mode or raises."""
+    with context:
+        result = parms["cls"].default_mode(parms["geometry"])
+        assert result == parms["expected"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(cls=ThTthSolver, geometry=TH_TTH_Q_GEOMETRY, expected=BISECTOR_MODE),
+            does_not_raise(),
+            id="ThTthSolver: __init__ applies default_mode",
+        ),
+        pytest.param(
+            dict(cls=NoOpSolver, geometry="anything", expected=""),
+            does_not_raise(),
+            id="NoOpSolver: __init__ leaves mode blank when no default exists",
+        ),
+    ],
+)
+def test_init_applies_default_mode(parms, context):
+    """Solver(geometry, mode='') resolves to default_mode when available."""
+    with context:
+        solver = parms["cls"](parms["geometry"])
+        assert solver.mode == parms["expected"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(modes=["a", "b", "c"], default_mode="b", expected="b"),
+            does_not_raise(),
+            id="explicit default_mode wins over modes[0]",
+        ),
+        pytest.param(
+            dict(modes=["a", "b", "c"], default_mode="", expected="a"),
+            does_not_raise(),
+            id="blank default_mode falls back to modes[0]",
+        ),
+    ],
+)
+def test_descriptor_default_mode_resolution(parms, context):
+    """Verify descriptor's default_mode field takes precedence over modes[0]."""
+
+    class _IsolatedSolver(ThTthSolver):
+        _geometry_registry = {}
+
+    with context:
+        desc = GeometryDescriptor(
+            name="ISOLATED",
+            pseudo_axis_names=["q"],
+            real_axis_names=["th", "tth"],
+            modes=parms["modes"],
+            default_mode=parms["default_mode"],
+        )
+        _IsolatedSolver.register_geometry(desc)
+        assert _IsolatedSolver.default_mode("ISOLATED") == parms["expected"]
+        # __init__ should also apply this default.
+        solver = _IsolatedSolver("ISOLATED")
+        assert solver.mode == parms["expected"]

--- a/src/hklpy2/backends/tests/test_hkl_soleil.py
+++ b/src/hklpy2/backends/tests/test_hkl_soleil.py
@@ -674,3 +674,73 @@ def test_hkl_solver_metadata_live(parms, context):
         assert meta["engine"] == parms["engine"]
         assert isinstance(meta["real_axes"], list)
         assert len(meta["real_axes"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #372: HklSolver default geometry & default mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(geometry="E4CV", engine="hkl", expected="bissector"),
+            does_not_raise(),
+            id="E4CV/hkl -> bissector",
+        ),
+        pytest.param(
+            dict(geometry="E4CV", engine="psi", expected="psi"),
+            does_not_raise(),
+            id="E4CV/psi -> psi",
+        ),
+        pytest.param(
+            dict(geometry="E4CV", engine="MISSING", expected="bissector"),
+            does_not_raise(),
+            id="missing engine falls back to first engine",
+        ),
+        pytest.param(
+            dict(geometry="UNKNOWN GEO", engine="hkl", expected=None),
+            pytest.raises(
+                __import__("hklpy2.exceptions", fromlist=["SolverError"]).SolverError,
+                match=re.escape("'UNKNOWN GEO' is not known to libhkl"),
+            ),
+            id="unknown geometry -> SolverError",
+        ),
+    ],
+)
+def test_hkl_default_mode(parms, context):
+    """HklSolver.default_mode(geometry, engine=...) queries libhkl directly."""
+    with context:
+        result = hkl_soleil.HklSolver.default_mode(
+            parms["geometry"], engine=parms["engine"]
+        )
+        assert result == parms["expected"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(geometry="E4CV", engine="hkl", expected_mode="bissector"),
+            does_not_raise(),
+            id="E4CV/hkl applies bissector at construction",
+        ),
+        pytest.param(
+            dict(geometry="E4CV", engine="psi", expected_mode="psi"),
+            does_not_raise(),
+            id="E4CV/psi applies psi at construction",
+        ),
+    ],
+)
+def test_hkl_init_applies_default_mode(parms, context):
+    """HklSolver(geometry, engine=...) with mode='' resolves the engine's first mode."""
+    with context:
+        solver = hkl_soleil.HklSolver(parms["geometry"], engine=parms["engine"])
+        assert solver.mode == parms["expected_mode"]
+
+
+def test_hkl_default_geometry_is_first_alphabetical():
+    """HklSolver.default_geometry() returns geometries()[0] (alphabetical)."""
+    geometries = hkl_soleil.HklSolver.geometries()
+    assert hkl_soleil.HklSolver.default_geometry() == geometries[0]

--- a/src/hklpy2/backends/tests/test_th_tth_q.py
+++ b/src/hklpy2/backends/tests/test_th_tth_q.py
@@ -31,7 +31,8 @@ def test_solver():
     assert solver.refineLattice([]) is None
     assert solver.calculate_UB(None, None) == IDENTITY_MATRIX_3X3
 
-    assert solver.mode == "", f"{solver.mode=!r}"
+    # Issue #372: solver picks the geometry's default mode at construction.
+    assert solver.mode == BISECTOR_MODE, f"{solver.mode=!r}"
     solver.mode = BISECTOR_MODE
     assert solver.mode == BISECTOR_MODE
 

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -390,8 +390,14 @@ def simulator_from_config(config: Union[dict, str, pathlib.Path]):
         raise KeyError(MISSING_HEADER_KEY_MSG)
 
     solver_cfg = config.get("solver", {})
-    solver_name = solver_cfg.get("name", "hkl_soleil")
-    geometry = solver_cfg.get("geometry", "E4CV")
+    # Default solver name remains "hkl_soleil" because the config
+    # does not include a way to discover a system-wide default solver
+    # (see #372 discussion); the geometry default now flows from the
+    # solver's own default_geometry() classmethod.
+    solver_name = solver_cfg.get("name") or "hkl_soleil"
+    from .solver_utils import get_solver
+
+    geometry = solver_cfg.get("geometry") or get_solver(solver_name).default_geometry()
 
     solver_kwargs: dict = {}
     engine = solver_cfg.get("engine")

--- a/src/hklpy2/tests/test_i210.py
+++ b/src/hklpy2/tests/test_i210.py
@@ -423,3 +423,55 @@ def test_restore_mode(parms, context):
             restore_mode=parms["restore_mode"],
         )
         assert sim.core.mode == parms["expected_mode"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #372: simulator_from_config() falls back to Solver.default_geometry()
+# when the config omits solver.geometry.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(strip_geometry=True),
+            does_not_raise(),
+            id="missing solver.geometry resolved via default_geometry()",
+        ),
+    ],
+)
+def test_simulator_from_config_default_geometry(parms, context):
+    """
+    Per #372: simulator_from_config() resolves a missing solver.geometry
+    via the solver's default_geometry() classmethod.
+
+    We exercise the resolution path by patching a minimal in-memory config
+    that exposes only the fields needed to reach the fallback; verifying
+    that the geometry passed to ``creator()`` equals
+    ``HklSolver.default_geometry()`` is sufficient evidence that the
+    fallback runs.  (A real ``export()`` always writes solver.geometry, so
+    this fallback only matters for malformed/hand-edited configs.)
+    """
+    from unittest import mock
+
+    from hklpy2.backends.hkl_soleil import HklSolver
+
+    with context:
+        # Minimal valid config that reaches the fallback (no solver.geometry).
+        cfg = {
+            "_header": {},
+            "solver": {"name": "hkl_soleil"},
+            "axes": {"axes_xref": {}, "pseudo_axes": [], "real_axes": []},
+        }
+        with mock.patch(
+            "hklpy2.diffract.creator",
+            side_effect=RuntimeError("stop here"),
+        ) as mock_creator:
+            with pytest.raises(RuntimeError, match="stop here"):
+                simulator_from_config(cfg)
+        # The resolved geometry passed to creator() must equal
+        # HklSolver.default_geometry() (i.e. the fallback ran).
+        assert mock_creator.called
+        call_kwargs = mock_creator.call_args.kwargs
+        assert call_kwargs["geometry"] == HklSolver.default_geometry()


### PR DESCRIPTION
- closes #372

## Summary

Establishes a uniform contract on ``SolverBase`` so every solver can answer
"what is the default geometry?" and "what is the default mode for a given
geometry?" — and replaces the hardcoded ``"E4CV"`` fallback in
``simulator_from_config()`` with a call to that contract.

## Changes

- **``SolverBase``** — new ``default_geometry()`` and
  ``default_mode(geometry)`` classmethods.  Default implementation
  reads the ``_geometry_registry``: prefers ``descriptor.default_mode``,
  else ``descriptor.modes[0]``.  ``__init__`` now resolves ``mode=""``
  via ``default_mode()`` so a freshly constructed solver starts in a
  known mode (gated by a private ``_resolve_default_mode`` flag so
  subclasses can defer when their backend isn't ready yet).
- **``HklSolver``** — overrides ``default_mode(geometry, engine="hkl")``
  to query ``libhkl.factories()`` directly (no full-solver allocation).
  Resolves ``mode=""`` itself after engine setup since the libhkl
  objects don't exist when ``super().__init__`` runs.
  ``default_geometry()`` is inherited.
- **``ThTthSolver``** — no code change; the existing
  ``default_mode="bissector"`` on its descriptor now flows automatically
  to ``solver.mode`` at construction.
- **``NoOpSolver``** — no code change; ``default_geometry()`` raises
  ``SolverError`` (intentional), ``__init__`` swallows it and leaves
  ``mode = ""`` as before.
- **``run_utils.simulator_from_config()``** — dropped the hardcoded
  ``"E4CV"`` fallback; missing ``solver.geometry`` now resolves via
  ``Solver.default_geometry()``.
- **``creator()`` / ``diffractometer_class_factory()``** — kept the
  literal ``geometry="E4CV"`` default deliberately.  Switching to
  ``default_geometry()`` would silently change ``creator(name="x")``
  from E4CV to ``"APS POLAR"`` (libhkl's first geometry alphabetically),
  breaking the documented user-facing convention.  The new contract is
  still available to callers that explicitly want it.

## Tests

- Parametrized ``test_default_geometry`` / ``test_default_mode`` /
  ``test_init_applies_default_mode`` /
  ``test_descriptor_default_mode_resolution`` in
  ``test_base.py`` — exercise descriptor precedence (``default_mode``
  beats ``modes[0]``), the ``NoOpSolver`` no-default path, and
  ``__init__`` application.
- Parametrized ``test_hkl_default_mode`` /
  ``test_hkl_init_applies_default_mode`` plus
  ``test_hkl_default_geometry_is_first_alphabetical`` in
  ``test_hkl_soleil.py`` — covers engine-name fallback and
  unknown-geometry ``SolverError``.
- ``test_th_tth_q.test_solver`` — updated to assert the new default
  (``solver.mode == "bissector"``) at construction.
- ``test_simulator_from_config_default_geometry`` (in ``test_i210.py``)
  — mocks ``creator`` to verify the fallback path resolves the geometry
  via ``HklSolver.default_geometry()``.

## Release notes

Added a 0.6.1 Enhancements entry.

Agent: OpenCode (claudeopus47)