### PR TITLE
fix #375 add benchmark to utils.__all__

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -45,6 +45,12 @@ Enhancements
   remove hardcoded ``"E4CV"`` fallback in ``simulator_from_config()``.
   (:issue:`372`)
 
+Fixes
+-----
+
+* Add ``benchmark`` to ``hklpy2.utils.__all__`` so its API page renders.
+  (:issue:`375`)
+
 0.6.0
 #####
 

--- a/src/hklpy2/tests/test_utils.py
+++ b/src/hklpy2/tests/test_utils.py
@@ -1258,7 +1258,8 @@ def test_module_all_covers_public_defs(parms, context):
     with context:
         module = importlib.import_module(parms["module_name"])
         source_path = module.__file__
-        tree = ast.parse(open(source_path).read())
+        with open(source_path) as stream:
+            tree = ast.parse(stream.read())
         # Collect __all__
         all_list = None
         for node in tree.body:

--- a/src/hklpy2/tests/test_utils.py
+++ b/src/hklpy2/tests/test_utils.py
@@ -1226,3 +1226,65 @@ def test_benchmark_no_reflections():
     result = benchmark(sim, n=5, print=False, snapshot=False)
     assert result["forward_ops_per_sec"] > 0
     assert result["inverse_ops_per_sec"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #375: every public function/class defined in utils.py must appear in
+# __all__ so that sphinx-autoapi renders a detail page (not just a row in
+# the summary table).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(module_name="hklpy2.utils"),
+            does_not_raise(),
+            id="hklpy2.utils: every public def is in __all__",
+        ),
+    ],
+)
+def test_module_all_covers_public_defs(parms, context):
+    """
+    Guard against the #375 regression: a public function defined in a
+    module that exposes ``__all__`` must be listed in ``__all__``,
+    otherwise sphinx-autoapi renders a row in the summary table with no
+    body / hyperlink.
+    """
+    import ast
+    import importlib
+
+    with context:
+        module = importlib.import_module(parms["module_name"])
+        source_path = module.__file__
+        tree = ast.parse(open(source_path).read())
+        # Collect __all__
+        all_list = None
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                for tgt in node.targets:
+                    if (
+                        isinstance(tgt, ast.Name)
+                        and tgt.id == "__all__"
+                        and isinstance(node.value, ast.List)
+                    ):
+                        all_list = [
+                            e.value
+                            for e in node.value.elts
+                            if isinstance(e, ast.Constant)
+                        ]
+        assert all_list is not None, (
+            f"{parms['module_name']} has no __all__ to validate"
+        )
+        # Collect public top-level defs (functions and classes).
+        public_defs = [
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+            and not node.name.startswith("_")
+        ]
+        missing = [n for n in public_defs if n not in all_list]
+        assert not missing, (
+            f"{parms['module_name']}.__all__ is missing public defs: {missing!r}"
+        )

--- a/src/hklpy2/utils.py
+++ b/src/hklpy2/utils.py
@@ -1,7 +1,7 @@
 """
 General-purpose utilities for |hklpy2|.
 
-.. rubric: Functions
+.. rubric:: Functions
 .. autosummary::
 
     ~axes_to_dict
@@ -21,7 +21,7 @@ General-purpose utilities for |hklpy2|.
     ~validate_and_canonical_unit
     ~validate_not_parallel
 
-.. rubric: Symbols
+.. rubric:: Symbols
 .. autosummary::
 
     ~DEFAULT_DIGITS
@@ -85,6 +85,7 @@ __all__ = [
     "UREG",
     # Functions
     "axes_to_dict",
+    "benchmark",
     "check_value_in_list",
     "compare_float_dicts",
     "convert_units",


### PR DESCRIPTION
- closes #375

## Summary

Root cause: ``hklpy2.utils.__all__`` listed every public symbol in the
module *except* ``benchmark``.  ``sphinx-autoapi`` honours ``__all__``
when present and skips emitting a detail page for any name not in it,
so ``benchmark`` rendered as a row in the summary table with no
hyperlink and no body section (the exact symptom in the issue).

## Fix

- Add ``benchmark`` to ``hklpy2.utils.__all__`` (alphabetically, between
  ``axes_to_dict`` and ``check_value_in_list``).
- Drive-by: fix two malformed ``.. rubric: Functions`` / ``.. rubric: Symbols``
  directives in the same module docstring (single colon → double colon).

## Audit

I audited every module in the package for the same root cause: a public
top-level def missing from ``__all__``.  ``benchmark`` was the only
case across the codebase.

## Regression guard

Added ``test_module_all_covers_public_defs`` (parametrized,
agent-style): asserts every public top-level def in ``hklpy2.utils`` is
listed in ``__all__``.  Future additions to the module that forget
``__all__`` will fail this test.

## Verification

Rebuilt the docs locally with ``sphinx-build`` and confirmed:

- ``hklpy2.utils.benchmark`` anchor is now present (1 occurrence,
  previously 0).
- The summary-table row is hyperlinked.
- The ``[source]`` link, function signature, and TOC entry all render.

## Release notes

Added a Fixes entry under 0.6.1.

Agent: OpenCode (claudeopus47)