### PR TITLE
feat #371 simulator_from_config() accepts diffractometer instance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,62 @@ The `Makefile` `pre` target also exports this variable automatically.
   ``Add ``scan_psi()```  sorts as ``"Add scan_psi()"`` (after ``"Add s"``),
   placing it after entries that begin with ``"Add h"``.
 
+## Version Decorators
+
+The project uses Sphinx-style version decorators from the ``deprecated``
+package to record when public APIs were introduced or changed.  Keep these
+in sync with code changes — they appear in the rendered docs and are part
+of the public contract.
+
+- Imports::
+
+      from deprecated.sphinx import versionadded
+      from deprecated.sphinx import versionchanged
+      from deprecated.sphinx import deprecated
+
+- **New public function/class/method** → add ``@versionadded`` with the
+  upcoming release version and a one-line ``reason``::
+
+      @versionadded(version="0.6.1", reason="Brief description of the API.")
+      def new_function(...):
+          ...
+
+- **Behavioral or signature change to an existing public API** → add a
+  ``@versionchanged`` decorator (stacked **below** the original
+  ``@versionadded``) for the upcoming release.  Do not edit historical
+  entries::
+
+      @versionadded(version="0.4.0", reason="Original description.")
+      @versionchanged(
+          version="0.6.1",
+          reason="Accept a ``DiffractometerBase`` instance directly.",
+      )
+      def existing_function(...):
+          ...
+
+- **Decorator order**: ``@versionadded`` first (outermost), then any
+  ``@versionchanged`` entries in chronological order beneath it, then the
+  function definition.  This matches the existing convention (see
+  ``hklpy2.diffract.creator``).
+
+- **Version string**: use the upcoming release tag (the topmost unreleased
+  section in ``RELEASE_NOTES.rst``).  If you add a release-notes entry for
+  an API change, also add the matching ``@versionchanged``/``@versionadded``
+  decorator (and vice versa).
+
+- **Inline forms**: for module/class-level documentation that is not a
+  decorated callable, use the RST directive form inside the docstring::
+
+      """
+      .. versionadded:: 0.5.0
+      .. versionchanged:: 0.6.1
+         Description of the change.
+      """
+
+- **Deprecations**: use ``@deprecated`` (also from ``deprecated.sphinx``);
+  add a corresponding entry in the ``Deprecations`` subsection of
+  ``RELEASE_NOTES.rst``.
+
 ## Documentation: RST Style
 
 - RST title underlines (and overlines) must be **at least as long** as the

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -41,6 +41,8 @@ Enhancements
 * ``benchmark()``: add ``snapshot=True`` (default) to time on a simulator
   built from the diffractometer's configuration, and report ``fwd/inv``
   ratio. (:issue:`369`, :issue:`373`)
+* ``simulator_from_config()`` accepts a diffractometer instance directly,
+  using its current configuration snapshot. (:issue:`371`)
 * ``Solver.default_geometry()`` and ``Solver.default_mode(geometry)``;
   remove hardcoded ``"E4CV"`` fallback in ``simulator_from_config()``.
   (:issue:`372`)

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -19,7 +19,6 @@ from collections.abc import Iterator
 from typing import Any
 from typing import Mapping
 from typing import Sequence
-from typing import Union
 
 import pandas as pd
 import tqdm
@@ -340,7 +339,11 @@ def list_orientation_runs(
     version="0.4.0",
     reason="Create a simulated diffractometer from a saved configuration.",
 )
-def simulator_from_config(config: Union[dict, str, pathlib.Path]):
+@versionchanged(
+    version="0.6.1",
+    reason="Accept a ``DiffractometerBase`` instance directly.",
+)
+def simulator_from_config(config):
     """
     Create a simulated diffractometer from a saved configuration.
 
@@ -358,9 +361,14 @@ def simulator_from_config(config: Union[dict, str, pathlib.Path]):
 
     PARAMETERS
 
-    config : dict, str, or pathlib.Path
-        Configuration dictionary, or path to a YAML configuration file
-        previously saved with ``diffractometer.export()``.
+    config : dict, str, pathlib.Path, or DiffractometerBase
+        One of:
+
+        * a configuration dictionary,
+        * a path to a YAML configuration file previously saved with
+          ``diffractometer.export()``, or
+        * a :class:`~hklpy2.diffract.DiffractometerBase` instance (its
+          current configuration snapshot will be used).
 
     RETURNS
 
@@ -373,18 +381,30 @@ def simulator_from_config(config: Union[dict, str, pathlib.Path]):
         >>> sim = hklpy2.simulator_from_config("e4cv-config.yml")
         >>> sim.wh()
 
+        Or directly from an existing diffractometer::
+
+        >>> sim = hklpy2.simulator_from_config(diffractometer)
+
     SEE ALSO
 
         :func:`~hklpy2.diffract.creator` — create a diffractometer from scratch.
     """
+    from .diffract import DiffractometerBase
     from .diffract import creator
 
+    if isinstance(config, DiffractometerBase):
+        logger.debug(
+            "simulator_from_config: snapshotting diffractometer %r",
+            getattr(config, "name", None),
+        )
+        config = config.configuration
     if isinstance(config, (str, pathlib.Path)):
         logger.debug("simulator_from_config: loading from file %r", str(config))
         config = load_yaml_file(config)
     if not isinstance(config, dict):
         raise TypeError(
-            f"Expected a dict or path to a YAML file. Received: {type(config)!r}"
+            "Expected a dict, path to a YAML file, or DiffractometerBase"
+            f" instance. Received: {type(config)!r}"
         )
     if "_header" not in config:
         raise KeyError(MISSING_HEADER_KEY_MSG)

--- a/src/hklpy2/tests/test_i210.py
+++ b/src/hklpy2/tests/test_i210.py
@@ -46,7 +46,10 @@ TESTS_DIR = pathlib.Path(__file__).parent
         pytest.param(
             dict(config=42),
             pytest.raises(
-                TypeError, match=re.escape("Expected a dict or path to a YAML file.")
+                TypeError,
+                match=re.escape(
+                    "Expected a dict, path to a YAML file, or DiffractometerBase"
+                ),
             ),
             id="invalid config type raises TypeError",
         ),
@@ -475,3 +478,34 @@ def test_simulator_from_config_default_geometry(parms, context):
         assert mock_creator.called
         call_kwargs = mock_creator.call_args.kwargs
         assert call_kwargs["geometry"] == HklSolver.default_geometry()
+
+
+# ---------------------------------------------------------------------------
+# Issue #371: simulator_from_config() accepts a diffractometer instance
+# directly (in addition to dict / path / str).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(config=TESTS_DIR / "e4cv-silicon-example.yml"),
+            does_not_raise(),
+            id="diffractometer instance: e4cv silicon",
+        ),
+    ],
+)
+def test_simulator_from_config_accepts_diffractometer(parms, context):
+    """Per #371: passing a diffractometer instance is equivalent to passing
+    its ``configuration`` snapshot."""
+    with context:
+        original = simulator_from_config(parms["config"])
+        # Pass the diffractometer instance directly (the new behaviour).
+        sim = simulator_from_config(original)
+
+        assert sim is not original  # a fresh instance, not the same object
+        assert sim.core.solver.geometry == original.core.solver.geometry
+        assert sim.real_axis_names == original.real_axis_names
+        assert sim.pseudo_axis_names == original.pseudo_axis_names
+        assert set(sim.core.samples.keys()) == set(original.core.samples.keys())

--- a/src/hklpy2/utils.py
+++ b/src/hklpy2/utils.py
@@ -68,6 +68,7 @@ from .typing import Matrix3x3
 
 if TYPE_CHECKING:
     from .backends.base import SolverBase  # noqa: F401
+    from .diffract import DiffractometerBase  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -437,7 +438,7 @@ def validate_and_canonical_unit(value: str, target_units: str) -> str:
 
 
 def benchmark(
-    diffractometer,
+    diffractometer: "DiffractometerBase",
     n: int = 500,
     print: bool = True,
     snapshot: bool = True,
@@ -509,7 +510,7 @@ def benchmark(
     if snapshot:
         from .run_utils import simulator_from_config
 
-        target = simulator_from_config(diffractometer.configuration)
+        target = simulator_from_config(diffractometer)
     else:
         target = diffractometer
 


### PR DESCRIPTION
- closes #371

## Summary

- ``simulator_from_config()`` now accepts a ``DiffractometerBase``
  instance directly, in addition to dict / str / Path.  The instance's
  current ``configuration`` snapshot is used.
- ``benchmark()`` simplified to take advantage of the new ergonomic
  (``simulator_from_config(diffractometer)`` instead of
  ``simulator_from_config(diffractometer.configuration)``).
- Added ``@versionchanged(version="0.6.1", ...)`` decorator to record
  the API change.
- Added a **Version Decorators** section to ``AGENTS.md`` documenting
  the convention for keeping ``@versionadded``/``@versionchanged``
  decorators in sync with code changes.
- Annotated ``benchmark()``'s ``diffractometer`` parameter with
  ``"DiffractometerBase"`` (forward reference under ``TYPE_CHECKING``).
- Added a regression test ``test_simulator_from_config_accepts_diffractometer``
  in ``tests/test_i210.py``.
- Added a one-line entry under Enhancements in ``RELEASE_NOTES.rst``.

## Tests

- ``pytest src/hklpy2`` — 1078 passed, 7 skipped
- ``pre-commit run --all-files`` — clean

Agent: OpenCode (claudeopus47)