### PR TITLE
feat #370 solver_summary() accepts diffractometer argument

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,17 @@ question in code maintenance: *Why is this change being made?*
 
 All development happens on feature branches, never directly on `main`.
 
+- **MANDATORY:** Before making *any* change to the working tree (edits,
+  new files, or test scaffolding), create the feature branch first.  Do
+  not edit on `main`.  Verify with ``git branch --show-current`` before
+  the first edit.
+- If you discover you have started editing on `main`, immediately stash
+  the changes, create the feature branch from `main`, and pop the stash::
+
+      git stash push -m "WIP issue #N"
+      git checkout -b <ISSUE_NUMBER>-<concise-title> main
+      git stash pop
+
 - **Naming convention**: `<ISSUE_NUMBER>-<CONCISE-TITLE>`
   - The concise title is derived from the issue title, using lowercase words
     separated by hyphens.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -43,6 +43,8 @@ Enhancements
   ratio. (:issue:`369`, :issue:`373`)
 * ``simulator_from_config()`` accepts a diffractometer instance directly,
   using its current configuration snapshot. (:issue:`371`)
+* ``solver_summary()`` accepts a diffractometer argument; canonical
+  implementation moved to ``hklpy2.utils.solver_summary``. (:issue:`370`)
 * ``Solver.default_geometry()`` and ``Solver.default_mode(geometry)``;
   remove hardcoded ``"E4CV"`` fallback in ``simulator_from_config()``.
   (:issue:`372`)

--- a/src/hklpy2/tests/test_user.py
+++ b/src/hklpy2/tests/test_user.py
@@ -524,6 +524,29 @@ def test_solver_summary(fourc, capsys):
     assert "h2, k2, l2, psi" in summary
 
 
+def test_solver_summary_accepts_diffractometer_arg(fourc, capsys):
+    """Issue #370: solver_summary(diffractometer) bypasses the selection."""
+    # Clear any selection to prove the argument is being used.
+    set_diffractometer(None)
+
+    # Pass the diffractometer directly, no set_diffractometer() call.
+    summary = solver_summary(fourc, write=False)
+    assert isinstance(summary, Table)
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+    text = str(summary)
+    assert "bissector" in text
+    assert "h2, k2, l2, psi" in text
+
+    # write=True path also works.
+    result = solver_summary(fourc)
+    assert result is None
+    out, err = capsys.readouterr()
+    assert "bissector" in out
+    assert err == ""
+
+
 @pytest.mark.parametrize(
     "specs, mode, pseudos, text, context",
     [

--- a/src/hklpy2/tests/test_utils.py
+++ b/src/hklpy2/tests/test_utils.py
@@ -42,6 +42,7 @@ from ..utils import load_yaml_file
 from ..utils import pick_closest_solution
 from ..utils import pick_first_solution
 from ..utils import roundoff
+from ..utils import solver_summary
 from ..run_utils import ConfigurationRunWrapper
 from ..run_utils import simulator_from_config
 from ..run_utils import get_run_orientation
@@ -1289,3 +1290,74 @@ def test_module_all_covers_public_defs(parms, context):
         assert not missing, (
             f"{parms['module_name']}.__all__ is missing public defs: {missing!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #370: solver_summary() accepts a diffractometer argument.
+# ---------------------------------------------------------------------------
+
+from pyRestTable import Table  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(diffractometer=sim4c, write=True),
+            does_not_raise(),
+            id="utils.solver_summary(sim4c, write=True) prints, returns None",
+        ),
+        pytest.param(
+            dict(diffractometer=sim4c, write=False),
+            does_not_raise(),
+            id="utils.solver_summary(sim4c, write=False) returns Table",
+        ),
+        pytest.param(
+            dict(diffractometer=sim6c, write=False),
+            does_not_raise(),
+            id="utils.solver_summary(sim6c, write=False) returns Table",
+        ),
+        pytest.param(
+            dict(diffractometer="not-a-diffractometer", write=False),
+            pytest.raises(AttributeError),
+            id="non-diffractometer object raises AttributeError",
+        ),
+    ],
+)
+def test_solver_summary_with_diffractometer(parms, context, capsys):
+    with context:
+        result = solver_summary(**parms)
+        out, err = capsys.readouterr()
+        if parms["write"]:
+            assert result is None
+            assert len(out) > 0
+            assert err == ""
+        else:
+            assert isinstance(result, Table)
+            assert out == ""
+            assert err == ""
+            text = str(result)
+            # E4CV / E6C both have a 'bissector' mode in the hkl engine.
+            assert "bissector" in text
+
+
+def test_solver_summary_no_argument_uses_selected(capsys):
+    """utils.solver_summary() with no argument falls back to the selected diffractometer."""
+    from ..user import set_diffractometer
+
+    set_diffractometer(sim4c)
+    try:
+        result = solver_summary(write=False)
+        assert isinstance(result, Table)
+        assert "bissector" in str(result)
+    finally:
+        set_diffractometer(None)
+
+
+def test_solver_summary_no_argument_no_selection_raises():
+    """utils.solver_summary() with no argument and no selected diffractometer raises."""
+    from ..user import set_diffractometer
+
+    set_diffractometer(None)
+    with pytest.raises(ValueError, match=re.escape("No diffractometer selected")):
+        solver_summary(write=False)

--- a/src/hklpy2/user.py
+++ b/src/hklpy2/user.py
@@ -35,6 +35,7 @@ from typing import Union
 
 from bluesky.protocols import Movable
 from bluesky.protocols import Readable
+from deprecated.sphinx import versionchanged
 from pyRestTable import Table
 
 from .blocks.lattice import Lattice
@@ -291,9 +292,29 @@ def calc_UB(
     return get_diffractometer().core.calc_UB(r1, r2)
 
 
-def solver_summary(write=True) -> Table | None:
+@versionchanged(
+    version="0.6.1",
+    reason=(
+        "Accept a ``diffractometer`` argument; underlying implementation"
+        " moved to ``hklpy2.utils.solver_summary``."
+    ),
+)
+def solver_summary(
+    diffractometer: Optional[DiffractometerBase] = None,
+    write: bool = True,
+) -> Table | None:
     """
     Table of diffractometer solver's modes, axes, ...
+
+    PARAMETERS
+
+    diffractometer : DiffractometerBase, optional
+        The diffractometer to summarize.  When ``None`` (default), the
+        currently-selected diffractometer (set via
+        :func:`~hklpy2.user.set_diffractometer`) is used.
+    write : bool, optional
+        When ``True`` (default), print the table and return ``None``.
+        When ``False``, return the :class:`~pyRestTable.Table` object.
 
     EXAMPLE:
 
@@ -320,15 +341,20 @@ def solver_summary(write=True) -> Table | None:
         emergence emergence          emergence, azimuth omega, chi, phi, tth                      x, y, z
         ========= ================== ================== ==================== ==================== ===============
 
+    Pass any diffractometer directly (no need to call ``set_diffractometer``)::
+
+        >>> e4cv = hklpy2.creator(name="e4cv")
+        >>> solver_summary(e4cv)
+
     .. seealso:: :ref:`geometries.summary_tables`,
-        :meth:`hklpy2.backends.base.SolverBase.summary()`
+        :meth:`hklpy2.backends.base.SolverBase.summary()`,
+        :func:`hklpy2.utils.solver_summary`
     """
-    table = get_diffractometer().core.solver_summary
-    if write:
-        print(table)
-    else:
-        return table
-    return None
+    from .utils import solver_summary as _impl
+
+    if diffractometer is None:
+        diffractometer = get_diffractometer()
+    return _impl(diffractometer, write=write)
 
 
 def get_diffractometer() -> Union[DiffractometerBase, None]:

--- a/src/hklpy2/utils.py
+++ b/src/hklpy2/utils.py
@@ -98,6 +98,7 @@ __all__ = [
     "pick_closest_solution",
     "pick_first_solution",
     "roundoff",
+    "solver_summary",
     "unique_name",
     "validate_and_canonical_unit",
     "validate_not_parallel",
@@ -589,3 +590,57 @@ def benchmark(
         f"\n  target: {TARGET:,} ops/sec (+/-{tolerance:.0%})"
     )
     return None
+
+
+@versionadded(
+    version="0.6.1",
+    reason="Solver summary helper that accepts any diffractometer instance.",
+)
+def solver_summary(
+    diffractometer: "DiffractometerBase | None" = None,
+    write: bool = True,
+):
+    """
+    Table of the diffractometer solver's modes, axes, ...
+
+    PARAMETERS
+
+    diffractometer : DiffractometerBase, optional
+        The diffractometer to summarize.  When ``None`` (default), the
+        currently-selected diffractometer (set via
+        :func:`~hklpy2.user.set_diffractometer`) is used.
+    write : bool, optional
+        When ``True`` (default), print the table and return ``None``.
+        When ``False``, return the :class:`~pyRestTable.Table` object.
+
+    RETURNS
+
+    pyRestTable.Table or None
+
+    EXAMPLE::
+
+        >>> import hklpy2
+        >>> diffract = hklpy2.creator(name="e4cv")
+        >>> hklpy2.utils.solver_summary(diffract)
+
+    SEE ALSO
+
+        :func:`hklpy2.user.solver_summary`
+    """
+    if diffractometer is None:
+        # Lazy import to avoid circularity (user imports from utils).
+        from .user import get_diffractometer
+
+        diffractometer = get_diffractometer()
+        if diffractometer is None:
+            raise ValueError(
+                "No diffractometer selected and none provided."
+                " Pass a diffractometer instance, or call"
+                " 'set_diffractometer(diffr)' first."
+            )
+
+    table = diffractometer.core.solver_summary
+    if write:
+        print(table)
+        return None
+    return table


### PR DESCRIPTION
- closes #370

## Summary

- Move the canonical implementation of ``solver_summary`` into
  ``hklpy2.utils.solver_summary``; ``hklpy2.user.solver_summary`` becomes
  a thin stub that delegates and now accepts an optional diffractometer
  argument (default: currently-selected via ``set_diffractometer()``).
- New: ``hklpy2.utils.solver_summary(diffractometer=None, write=True)``
  with ``@versionadded(0.6.1)``.
- ``user.solver_summary`` gains a ``diffractometer`` parameter and a
  ``@versionchanged(0.6.1)`` decorator; existing UX preserved.
- Improved error message when no diffractometer argument is given and
  none has been selected.
- Tests added in ``tests/test_utils.py`` (parametrized, covering
  ``write=True``/``write=False``, multiple geometries, no-selection
  fallback, and the no-selection-raises path) and in
  ``tests/test_user.py`` for the new ``user`` stub argument.
- ``RELEASE_NOTES.rst`` entry added under Enhancements (alphabetical).
- ``AGENTS.md``: added a **MANDATORY** "create the feature branch
  before any edits" rule with stash/branch/pop recovery steps.

## Tests

- ``pytest src/hklpy2`` — 1085 passed, 7 skipped
- ``pre-commit run --all-files`` — clean

Agent: OpenCode (claudeopus47)