### PR TITLE
fix #384 #386 stale solver state after calc_UB and sample switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,43 @@ When the user says "the full workflow", execute these steps in order:
 - When updating a file, verify that a change has actually been made by comparing
   the mtime before and after the edits.
 
+## Solver-Backend Agnosticism (MANDATORY)
+
+The hklpy2 architecture deliberately separates the diffractometer/sample/UB
+layer (``hklpy2.ops``, ``hklpy2.diffract``, ``hklpy2.blocks.*``) from the
+solver-backend layer (``hklpy2.backends.*``).  ``hkl_soleil`` (libhkl) is
+**one of many possible solver backends**; others include ``th_tth``,
+``no_op``, and future libraries.  Code and comments must respect this
+boundary.
+
+**Rules for code, comments, and docstrings outside of ``hklpy2.backends.*``:**
+
+- **Do not name a specific backend** (e.g. ``libhkl``, ``hkl_soleil``,
+  ``Hkl.Sample``, ``Sample.new``, ``compute_UB_busing_levy``,
+  ``hkl_engine_list``) in code, comments, or docstrings outside the
+  ``hklpy2/backends/<name>/`` subtree.  Reference the abstract
+  ``SolverBase`` contract instead.
+- **Do not describe a backend's internal data structures or side effects**
+  (e.g. "libhkl wipes U/UB on Sample.new", "hkl_engine_list re-binds on
+  mode change") outside the backend module.  If a side effect is
+  observable through the ``SolverBase`` API, describe it in
+  solver-agnostic terms (e.g. "a SAMPLE rebuild may invalidate U/UB and
+  EXTRAS state in the solver"); if it is not observable through the
+  contract, the contract is incomplete and should be extended.
+- **Do not design Core / Diffractometer / Sample / Block APIs around the
+  features of any one backend.** Polymorphism over solver backends is
+  the design intent.
+- **Tests of solver-specific behavior** (e.g. confirming ``hkl_soleil``
+  honours a particular constraint) belong in ``hklpy2/backends/tests/``,
+  not in ``hklpy2/tests/``.
+- **Backend-specific quirks that leak through the abstraction** are bugs
+  to be fixed in the backend or the contract, not papered over by
+  branching on the backend name in higher-level code.
+
+When a solver-agnostic phrasing isn't obvious, default to describing
+*what* the abstract layer needs (e.g. "the solver's sample state must be
+re-pushed") rather than *how* the backend implements it.
+
 ## Code Coverage
 
 - Aim for 100% coverage, but prioritize meaningful tests over simply hitting every line.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -57,6 +57,16 @@ Fixes
 * ``pa()`` / ``wh(full=True)`` no longer crashes when an auxiliary
   component returns a structured (multi-field) position; rendered
   inline as ``name={field=value, ...}``. (:issue:`385`)
+* Fix stale ``wh()`` / ``inverse()`` after ``calc_UB``. (:issue:`384`)
+* Fix stale ``wh()`` / ``inverse()`` after sample switch; unknown
+  sample names now raise ``KeyError``. (:issue:`386`)
+
+Maintenance
+-----------
+
+* Track solver-state dirty domains (sample, UB, mode, extras,
+  wavelength) with a fine-grained ``_SolverDirty`` bitfield in
+  ``Core``. (:issue:`386`)
 
 0.6.1
 #####

--- a/src/hklpy2/blocks/sample.py
+++ b/src/hklpy2/blocks/sample.py
@@ -14,6 +14,7 @@ from typing import Union
 import numpy as np
 from numpy.linalg import norm
 
+from ..utils import _SolverDirty
 from ..utils import unique_name
 from ..typing import Matrix3x3
 from .lattice import Lattice
@@ -82,7 +83,8 @@ class Sample:
         self.U = IDENTITY_MATRIX_3X3
         # Consider: UB = self.U @ self.lattice.B
         self.UB = ((2 * math.pi / self.lattice.a) * np.array(self.U)).tolist()
-        self.core._solver_needs_update = True
+        # New sample requires a full solver re-sync (lattice + UB).
+        self.core.request_solver_update(_SolverDirty.SAMPLE | _SolverDirty.UB)
         self.reflections = ReflectionsDict()
 
     def __repr__(self) -> str:
@@ -152,13 +154,18 @@ class Sample:
         value._on_change = self._lattice_changed
 
         # Flag the solver for update so it receives the new lattice (#240).
+        # A lattice change requires a full re-push of the solver's
+        # sample state.  Some backends discard U / UB as a side effect,
+        # so mark both domains dirty.
         # Guard: during __init__, core is not yet fully wired.
         if hasattr(self, "_U"):
-            self.core._solver_needs_update = True
+            self.core.request_solver_update(_SolverDirty.SAMPLE | _SolverDirty.UB)
 
     def _lattice_changed(self):
         """Called by Lattice.__setattr__ when a parameter changes (#240)."""
-        self.core._solver_needs_update = True
+        # Lattice mutation invalidates the solver's sample state and,
+        # as a side effect of re-pushing it, U / UB in some backends.
+        self.core.request_solver_update(_SolverDirty.SAMPLE | _SolverDirty.UB)
 
     @property
     def name(self) -> str:
@@ -209,7 +216,8 @@ class Sample:
         self._validate_matrices(value, "U")
 
         self._U = value
-        self.core._solver_needs_update = True
+        # U changes require only a UB push; no full _sample rebuild.
+        self.core.request_solver_update(_SolverDirty.UB)
 
     @property
     def UB(self) -> Matrix3x3:
@@ -227,4 +235,5 @@ class Sample:
         self._validate_matrices(value, "UB")
 
         self._UB = value
-        self.core._solver_needs_update = True
+        # UB changes require only a UB push; no full _sample rebuild.
+        self.core.request_solver_update(_SolverDirty.UB)

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -17,6 +17,8 @@ from typing import Mapping
 from typing import Optional
 from typing import Union
 
+from deprecated.sphinx import versionchanged
+
 from .backends.base import SolverBase
 from .blocks.configure import Configuration
 from .blocks.constraints import RealAxisConstraints
@@ -26,6 +28,7 @@ from .blocks.sample import Sample
 from .exceptions import CoreError
 from .exceptions import NoForwardSolutions
 from .solver_utils import solver_factory
+from .utils import _SolverDirty
 from .utils import axes_to_dict
 from .utils import convert_units
 from .utils import unique_name
@@ -120,9 +123,9 @@ class Core:
         self._sample_name = None
         self._samples = {}
         self._solver = None
+        self._solver_dirty = _SolverDirty.ALL
         self.constraints = None
         self.configuration = None
-        self.request_solver_update()
 
         if default_sample:
             # first sample is cubic, no reflections
@@ -375,7 +378,10 @@ class Core:
         lattice = Lattice(a, b, c, alpha, beta, gamma, digits=digits)
         self._samples[name] = Sample(self, name, lattice)
         self.sample = name
-        self.request_solver_update(True)  # 58  test_diffract line 410: 2 pi a
+        # The ``self.sample = name`` setter already flags SAMPLE | UB.
+        # An explicit ALL flag here keeps prior behavior for the eager
+        # ``solver.sample = ...`` push below (test_diffract line 410: 2 pi a).
+        self.request_solver_update(True)
         if self.solver is not None:
             self.solver.sample = self.to_solver_units()["sample"]
         return self.sample
@@ -439,6 +445,16 @@ class Core:
             self._axes_xref_reversed = {v: k for k, v in self.axes_xref.items()}
         return self._axes_xref_reversed
 
+    @versionchanged(
+        version="0.6.2",
+        reason=(
+            "No longer falsely clears all solver-dirty flags after computing "
+            "UB.  The U / UB push to the solver is now correctly tracked by "
+            "the fine-grained dirty bitfield, so ``inverse()`` / ``wh()`` "
+            "immediately after ``calc_UB()`` returns values consistent with "
+            "the freshly computed UB.  Fixes :issue:`384`."
+        ),
+    )
     def calc_UB(
         self, r1: Union[Reflection, str], r2: Union[Reflection, str]
     ) -> Matrix3x3:
@@ -469,9 +485,17 @@ class Core:
 
         solver_reflections = self._reflections_to_solver(two_reflections)
         ub = self.solver.calculate_UB(*solver_reflections)
+        # The solver has now computed U / UB and holds them internally.
+        # Mirror them into the Python Sample (the U / UB setters
+        # legitimately flag _SolverDirty.UB), then immediately re-push to
+        # the solver so the dirty flag is honestly clean.  (The prior
+        # implementation called request_solver_update(False) here, which
+        # would mask any other concurrently-dirty domain such as a
+        # pending sample switch -- the latent contributor to
+        # :issue:`384`.)
         self.sample.U = self.solver.U
         self.sample.UB = ub
-        self.request_solver_update(False)
+        self.update_solver()
         return ub
 
     @property
@@ -486,7 +510,7 @@ class Core:
         incoming = self._validate_extras(values, self.extras)
         if len(incoming) > 0:
             self._extras.update(incoming)
-            self.request_solver_update(True)
+            self.request_solver_update(_SolverDirty.EXTRAS)
 
     def forward(self, pseudos: AnyAxesType, wavelength: Optional[float] = None) -> list:
         """
@@ -676,7 +700,9 @@ class Core:
         """Return the current computation mode."""
         if self._mode is None:
             self._mode = self.solver.mode
-            self.request_solver_update(True)
+            # A mode change may reset the solver's extra-axis values,
+            # so EXTRAS must be re-pushed after MODE.
+            self.request_solver_update(_SolverDirty.MODE | _SolverDirty.EXTRAS)
         return self._mode
 
     @mode.setter
@@ -684,7 +710,9 @@ class Core:
         """Set the computation mode to be used."""
         if value in self.modes:
             self._mode = value
-            self.request_solver_update(True)
+            # A mode change may reset the solver's extra-axis values,
+            # so EXTRAS must be re-pushed after MODE.
+            self.request_solver_update(_SolverDirty.MODE | _SolverDirty.EXTRAS)
 
     @property
     def modes(self) -> list[str]:
@@ -921,14 +949,53 @@ class Core:
         self._samples.pop(name)
         self._sample_name = list(self.samples)[0]
 
-    def request_solver_update(self, flag: bool = True) -> None:
+    @versionchanged(
+        version="0.6.2",
+        reason=(
+            "Accepts ``_SolverDirty`` flags for fine-grained domain tracking. "
+            "Boolean argument is preserved for backward compatibility "
+            "(``True`` -> ``_SolverDirty.ALL``, ``False`` -> clear all)."
+        ),
+    )
+    def request_solver_update(self, flag: Union[bool, _SolverDirty] = True) -> None:
         """
-        Set (or clear) signal to trigger a solver update.
+        Mark solver state as dirty (or clean).
+
+        PARAMETERS
+
+        flag : bool or _SolverDirty
+            * ``True`` (default): mark all domains dirty (full re-sync).
+            * ``False``: clear all dirty flags.
+            * ``_SolverDirty`` value: mark the given domains dirty
+              (additive -- existing dirty flags are preserved).
 
         Needs to be a method (not a property) so it can be called from a
-        wavelength method.
+        wavelength callback (see ``DiffractometerBase.__init__``).
         """
-        self._solver_needs_update = flag
+        if isinstance(flag, bool):
+            if flag:
+                self._solver_dirty = _SolverDirty.ALL
+            else:
+                self._solver_dirty = _SolverDirty(0)
+        else:
+            self._solver_dirty |= flag
+
+    @property
+    def _solver_needs_update(self) -> bool:
+        """
+        Backward-compatible boolean view of :attr:`_solver_dirty`.
+
+        ``True`` iff any domain is dirty.  Setting to ``True`` marks all
+        domains dirty; setting to ``False`` clears all dirty flags.
+
+        .. versionchanged:: 0.6.2
+           Backed by the fine-grained :class:`_SolverDirty` bitfield.
+        """
+        return bool(self._solver_dirty)
+
+    @_solver_needs_update.setter
+    def _solver_needs_update(self, value: bool) -> None:
+        self._solver_dirty = _SolverDirty.ALL if value else _SolverDirty(0)
 
     def reset_constraints(self) -> None:
         """Restore diffractometer constraints to default settings."""
@@ -946,11 +1013,26 @@ class Core:
         return self.samples[self._sample_name]
 
     @sample.setter
+    @versionchanged(
+        version="0.6.2",
+        reason=(
+            "Re-syncs the solver with the new sample's lattice and stored UB "
+            "so subsequent ``inverse()`` / ``forward()`` / ``wh()`` calls "
+            "return values consistent with the new sample.  Raises "
+            "``KeyError`` for unknown sample names instead of silently "
+            "corrupting state.  Fixes :issue:`386`."
+        ),
+    )
     def sample(self, value: str) -> None:
+        if value not in self._samples:
+            raise KeyError(f"{value!r} not in sample list: {list(self._samples)!r}")
         self._sample_name = value
-        if self.solver is not None:
-            self.solver.U = self.sample.U
-            self.solver.UB = self.sample.UB
+        # The new sample's lattice and stored U / UB must be re-pushed to
+        # the solver on the next forward()/inverse().  The prior buggy
+        # behavior pushed only U / UB while leaving the solver's sample
+        # state (lattice + reflections) referring to the previous sample,
+        # so the new UB ended up combined with the old lattice (#386).
+        self.request_solver_update(_SolverDirty.SAMPLE | _SolverDirty.UB)
 
     @property
     def samples(self) -> Mapping[str, Sample]:
@@ -1160,17 +1242,45 @@ class Core:
         )
 
     def update_solver(self, wavelength: Optional[float] = None) -> None:
-        """Update solver data if needed."""
-        if self.solver.mode != self.mode or wavelength is not None:
-            self.request_solver_update(True)  # force the update
+        """
+        Push any dirty solver-state domains to the underlying solver.
 
-        if self._solver_needs_update:
-            std = self.to_solver_units(wavelength)
+        Per-domain pushes are gated by :attr:`_solver_dirty`
+        (a :class:`~hklpy2.utils._SolverDirty` bitfield).  A SAMPLE
+        re-push may invalidate the solver's MODE / EXTRAS / U / UB
+        state (this is permitted by the ``SolverBase`` contract and
+        observed in some backends), so those domains are re-pushed
+        implicitly whenever SAMPLE is re-pushed.
 
+        .. versionchanged:: 0.6.2
+           Switched from a single boolean flag to per-domain dirty flags
+           (:class:`~hklpy2.utils._SolverDirty`) to fix stale solver
+           state after sample switch (:issue:`386`) and after
+           ``calc_UB`` (:issue:`384`).
+        """
+        if self.solver.mode != self.mode:
+            self._solver_dirty |= _SolverDirty.MODE
+        if wavelength is not None:
+            self._solver_dirty |= _SolverDirty.WAVELENGTH
+
+        dirty = self._solver_dirty
+        if not dirty:
+            return
+
+        std = self.to_solver_units(wavelength)
+
+        if dirty & _SolverDirty.WAVELENGTH:
             self.solver.wavelength = std["wavelength"]
+        if dirty & _SolverDirty.SAMPLE:
+            # Full re-push of the solver's sample state (lattice +
+            # reflections).  Some backends reset MODE / EXTRAS / U / UB
+            # as a side effect of accepting a new sample, so flag those
+            # domains for re-push too.
             self.solver.sample = std["sample"]
+            dirty |= _SolverDirty.MODE | _SolverDirty.EXTRAS | _SolverDirty.UB
+        if dirty & _SolverDirty.MODE:
             self.solver.mode = self.mode
-
+        if dirty & _SolverDirty.EXTRAS:
             try:
                 self.solver.extras = {
                     axis: self._extras[axis]
@@ -1179,8 +1289,8 @@ class Core:
                 }
             except AttributeError:
                 pass  # Some solvers have no setter for extras
-
+        if dirty & _SolverDirty.UB:
             self.solver.U = self.sample.U
             self.solver.UB = self.sample.UB
 
-            self.request_solver_update(False)
+        self._solver_dirty = _SolverDirty(0)

--- a/src/hklpy2/tests/test_i384_i386.py
+++ b/src/hklpy2/tests/test_i384_i386.py
@@ -1,0 +1,320 @@
+"""
+Regression tests for issues #384 and #386.
+
+Issue #384
+----------
+``wh()`` (and ``inverse()``) returned values computed against a stale
+solver state immediately after a ``calc_UB()`` call.  A workaround was
+to call ``forward()`` once before reading pseudos.
+
+Issue #386
+----------
+After switching the active sample (``core.sample = "name"``), ``wh()``
+continued to return values consistent with the previous sample's
+lattice.  Even calling ``calc_UB()`` on the new sample did not refresh
+the displayed pseudos; only re-applying the lattice parameters did.
+
+Both bugs share a root cause: the previous single-boolean dirty flag
+in :class:`~hklpy2.ops.Core` did not faithfully track which solver
+state domains were out of sync.  The fix is a fine-grained
+:class:`~hklpy2.utils._SolverDirty` bitfield and corresponding
+corrections to the ``Core.sample`` setter and ``Core.calc_UB``.
+"""
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+
+from .. import creator
+from ..utils import _SolverDirty
+
+
+# Two distinct cubic samples with one obvious orientation difference
+# each, so a sample switch produces a clearly different inverse() result
+# at the same real-space position.
+SAMPLE_A = dict(
+    name="cubic_a",
+    lattice=dict(a=5.0),
+    reflections=[
+        dict(name="A100", pseudos=(1, 0, 0), reals=(-145, 0, 0, 70)),
+        dict(name="A010", pseudos=(0, 1, 0), reals=(-145, 0, 90, 70)),
+    ],
+)
+SAMPLE_B = dict(
+    name="cubic_b",
+    lattice=dict(a=4.0),
+    reflections=[
+        dict(name="B100", pseudos=(1, 0, 0), reals=(-145, 0, 0, 70)),
+        dict(name="B010", pseudos=(0, 1, 0), reals=(-145, 0, 90, 70)),
+    ],
+)
+TOL = 1e-3
+PROBE_REALS = dict(omega=-145, chi=0, phi=0, tth=70)
+
+
+def _build_two_samples():
+    """Create an E4CV simulator with two oriented cubic samples."""
+    sim = creator()
+    sim.beam.wavelength.put(1.54)
+
+    for sample_def in (SAMPLE_A, SAMPLE_B):
+        sim.add_sample(sample_def["name"], sample_def["lattice"]["a"], replace=True)
+        for refl in sample_def["reflections"]:
+            sim.add_reflection(
+                pseudos=refl["pseudos"],
+                reals=refl["reals"],
+                name=refl["name"],
+            )
+        sim.core.calc_UB(*[r["name"] for r in sample_def["reflections"]])
+
+    return sim
+
+
+def _pseudos_at_probe(sim):
+    """Compute (h, k, l) at the canonical probe real-space position."""
+    return sim.inverse(**PROBE_REALS)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        # ------------------------------------------------------------------
+        # #386 -- sample switch must re-sync the solver's lattice + UB.
+        # ------------------------------------------------------------------
+        pytest.param(
+            dict(action="switch", target="cubic_a"),
+            does_not_raise(),
+            id="switch-to-A-uses-A-lattice",
+        ),
+        pytest.param(
+            dict(action="switch", target="cubic_b"),
+            does_not_raise(),
+            id="switch-to-B-uses-B-lattice",
+        ),
+        pytest.param(
+            dict(action="round_trip", target="cubic_a"),
+            does_not_raise(),
+            id="round-trip-back-to-A-uses-A-lattice",
+        ),
+        # ------------------------------------------------------------------
+        # #384 -- inverse() / wh() right after calc_UB must not be stale.
+        # ------------------------------------------------------------------
+        pytest.param(
+            dict(action="calc_UB_then_inverse", target="cubic_a"),
+            does_not_raise(),
+            id="calc_UB-then-inverse-on-A",
+        ),
+        pytest.param(
+            dict(action="switch_then_calc_UB", target="cubic_b"),
+            does_not_raise(),
+            id="switch-then-calc_UB-then-inverse-on-B",
+        ),
+        # ------------------------------------------------------------------
+        # #386 -- unknown sample name must not silently corrupt state.
+        # ------------------------------------------------------------------
+        pytest.param(
+            dict(action="switch", target="does_not_exist"),
+            pytest.raises(
+                KeyError,
+                match=re.escape(
+                    "'does_not_exist' not in sample list: "
+                    "['sample', 'cubic_a', 'cubic_b']"
+                ),
+            ),
+            id="switch-to-unknown-sample-raises-KeyError",
+        ),
+    ],
+)
+def test_solver_resyncs_after_state_change(parms, context):
+    """Solver must be re-synced after sample switch and after calc_UB."""
+    with context:
+        sim = _build_two_samples()
+        action = parms["action"]
+        target = parms["target"]
+
+        if action == "switch":
+            sim.core.sample = target
+            actual = _pseudos_at_probe(sim)
+            assert sim.sample.name == target
+        elif action == "round_trip":
+            sim.core.sample = "cubic_b"
+            _pseudos_at_probe(sim)  # ensure intermediate state is real
+            sim.core.sample = target
+            actual = _pseudos_at_probe(sim)
+            assert sim.sample.name == target
+        elif action == "calc_UB_then_inverse":
+            sim.core.sample = target
+            sim.core.calc_UB(*[r["name"] for r in SAMPLE_A["reflections"]])
+            actual = _pseudos_at_probe(sim)
+        elif action == "switch_then_calc_UB":
+            sim.core.sample = "cubic_a"
+            _pseudos_at_probe(sim)
+            sim.core.sample = target
+            sim.core.calc_UB(*[r["name"] for r in SAMPLE_B["reflections"]])
+            actual = _pseudos_at_probe(sim)
+        else:
+            raise AssertionError(f"unknown action {action!r}")
+
+        # Build a freshly-constructed simulator with only the target
+        # sample so we have an independent reference for the expected
+        # pseudos at the probe position.
+        ref = creator()
+        ref.beam.wavelength.put(1.54)
+        sample_def = SAMPLE_A if target == "cubic_a" else SAMPLE_B
+        ref.add_sample(target, sample_def["lattice"]["a"], replace=True)
+        for refl in sample_def["reflections"]:
+            ref.add_reflection(
+                pseudos=refl["pseudos"],
+                reals=refl["reals"],
+                name=refl["name"],
+            )
+        ref.core.calc_UB(*[r["name"] for r in sample_def["reflections"]])
+        expected = _pseudos_at_probe(ref)
+
+        for axis in ("h", "k", "l"):
+            assert np.isclose(
+                getattr(actual, axis), getattr(expected, axis), atol=TOL
+            ), (
+                f"axis {axis}: actual={actual} expected={expected} "
+                f"(action={action}, target={target})"
+            )
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(action="set_lattice_param"),
+            does_not_raise(),
+            id="lattice-edit-flags-SAMPLE-and-UB",
+        ),
+        pytest.param(
+            dict(action="set_lattice_object"),
+            does_not_raise(),
+            id="lattice-replace-flags-SAMPLE-and-UB",
+        ),
+        pytest.param(
+            dict(action="set_U"),
+            does_not_raise(),
+            id="U-edit-flags-UB-only",
+        ),
+        pytest.param(
+            dict(action="set_UB"),
+            does_not_raise(),
+            id="UB-edit-flags-UB-only",
+        ),
+        pytest.param(
+            dict(action="switch_sample"),
+            does_not_raise(),
+            id="sample-switch-flags-SAMPLE-and-UB",
+        ),
+        pytest.param(
+            dict(action="set_mode"),
+            does_not_raise(),
+            id="mode-change-flags-MODE-and-EXTRAS",
+        ),
+        pytest.param(
+            dict(action="bool_True"),
+            does_not_raise(),
+            id="back-compat-True-flags-ALL",
+        ),
+        pytest.param(
+            dict(action="bool_False"),
+            does_not_raise(),
+            id="back-compat-False-clears-all",
+        ),
+        pytest.param(
+            dict(action="needs_update_setter_True"),
+            does_not_raise(),
+            id="back-compat-_solver_needs_update-setter-True",
+        ),
+        pytest.param(
+            dict(action="needs_update_setter_False"),
+            does_not_raise(),
+            id="back-compat-_solver_needs_update-setter-False",
+        ),
+    ],
+)
+def test_solver_dirty_flag_granularity(parms, context):
+    """Per-domain flagging is correct for each documented mutation."""
+    with context:
+        sim = _build_two_samples()
+        # Force a clean state so we can observe what the next mutation
+        # flags.  Mutations performed by the harness above leave the
+        # bitfield in an arbitrary state.
+        sim.core.update_solver()
+        sim.core._solver_dirty = _SolverDirty(0)
+        assert sim.core._solver_dirty == _SolverDirty(0)
+
+        action = parms["action"]
+        if action == "set_lattice_param":
+            sim.sample.lattice.a = 5.5
+            assert sim.core._solver_dirty == _SolverDirty.SAMPLE | _SolverDirty.UB
+        elif action == "set_lattice_object":
+            sim.sample.lattice = dict(a=5.5)
+            assert sim.core._solver_dirty == _SolverDirty.SAMPLE | _SolverDirty.UB
+        elif action == "set_U":
+            sim.sample.U = sim.sample.U
+            assert sim.core._solver_dirty == _SolverDirty.UB
+        elif action == "set_UB":
+            sim.sample.UB = sim.sample.UB
+            assert sim.core._solver_dirty == _SolverDirty.UB
+        elif action == "switch_sample":
+            sim.core.sample = "cubic_a"
+            assert sim.core._solver_dirty == _SolverDirty.SAMPLE | _SolverDirty.UB
+        elif action == "set_mode":
+            other_modes = [m for m in sim.core.modes if m != sim.core.mode]
+            assert other_modes, "test fixture has only one mode"
+            sim.core.mode = other_modes[0]
+            assert sim.core._solver_dirty == _SolverDirty.MODE | _SolverDirty.EXTRAS
+        elif action == "bool_True":
+            sim.core.request_solver_update(True)
+            assert sim.core._solver_dirty == _SolverDirty.ALL
+        elif action == "bool_False":
+            sim.core.request_solver_update(_SolverDirty.ALL)
+            sim.core.request_solver_update(False)
+            assert sim.core._solver_dirty == _SolverDirty(0)
+        elif action == "needs_update_setter_True":
+            sim.core._solver_needs_update = True
+            assert sim.core._solver_dirty == _SolverDirty.ALL
+            assert sim.core._solver_needs_update is True
+        elif action == "needs_update_setter_False":
+            sim.core.request_solver_update(_SolverDirty.ALL)
+            sim.core._solver_needs_update = False
+            assert sim.core._solver_dirty == _SolverDirty(0)
+            assert sim.core._solver_needs_update is False
+        else:
+            raise AssertionError(f"unknown action {action!r}")
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(domains=_SolverDirty.SAMPLE),
+            does_not_raise(),
+            id="additive-SAMPLE",
+        ),
+        pytest.param(
+            dict(domains=_SolverDirty.UB),
+            does_not_raise(),
+            id="additive-UB",
+        ),
+        pytest.param(
+            dict(domains=_SolverDirty.MODE | _SolverDirty.EXTRAS),
+            does_not_raise(),
+            id="additive-MODE-and-EXTRAS",
+        ),
+    ],
+)
+def test_request_solver_update_is_additive_for_flag_argument(parms, context):
+    """Flag-typed argument adds to existing dirty state; bool replaces it."""
+    with context:
+        sim = _build_two_samples()
+        sim.core.update_solver()
+        sim.core._solver_dirty = _SolverDirty.WAVELENGTH
+
+        sim.core.request_solver_update(parms["domains"])
+        assert sim.core._solver_dirty == _SolverDirty.WAVELENGTH | parms["domains"]

--- a/src/hklpy2/utils.py
+++ b/src/hklpy2/utils.py
@@ -1,6 +1,11 @@
 """
 General-purpose utilities for |hklpy2|.
 
+.. rubric:: Classes
+.. autosummary::
+
+    ~_SolverDirty
+
 .. rubric:: Functions
 .. autosummary::
 
@@ -44,6 +49,7 @@ import time
 import uuid
 import warnings
 from collections.abc import Iterable
+from enum import IntFlag
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Mapping
@@ -85,6 +91,8 @@ __all__ = [
     "MISSING_HEADER_KEY_MSG",
     "PINT_ERRORS",
     "UREG",
+    # Classes
+    "_SolverDirty",
     # Functions
     "axes_to_dict",
     "benchmark",
@@ -131,6 +139,49 @@ PINT_ERRORS = (pint.DimensionalityError, pint.UndefinedUnitError)
 
 DEFAULT_MOTOR_LABELS: Sequence[str] = ["motors"]
 """Default labels applied to real-axis positioners."""
+
+# ---------------------------------------------------------------------------
+# Classes
+# ---------------------------------------------------------------------------
+
+
+@versionadded(
+    version="0.6.2",
+    reason="Fine-grained dirty-domain tracking for the solver state.",
+)
+class _SolverDirty(IntFlag):
+    """
+    Bitfield identifying which solver state domains need to be re-pushed.
+
+    Used by :class:`~hklpy2.ops.Core` to track, at fine granularity, which
+    parts of the underlying solver's state have diverged from the canonical
+    Python-side state and therefore must be re-pushed before the next
+    ``forward()`` / ``inverse()`` call.
+
+    Members:
+
+    * ``SAMPLE`` -- the solver's sample state (lattice + reflections)
+      needs a full re-push.  A SAMPLE re-push may also invalidate the
+      solver's MODE / EXTRAS / U / UB state in some backends, so those
+      domains are re-pushed implicitly whenever SAMPLE is re-pushed.
+    * ``UB`` -- only the U and UB matrices need re-pushing.
+    * ``MODE`` -- the solver mode needs to be re-set.  A MODE change may
+      reset the solver's extra-axis values, so EXTRAS must be flagged
+      whenever MODE is flagged.
+    * ``EXTRAS`` -- the solver's extra-axis values need to be re-pushed.
+    * ``WAVELENGTH`` -- the wavelength needs to be re-pushed.
+    * ``ALL`` -- every domain (used for full re-sync).
+
+    .. seealso:: :issue:`384`, :issue:`386`
+    """
+
+    SAMPLE = 1
+    UB = 2
+    MODE = 4
+    EXTRAS = 8
+    WAVELENGTH = 16
+    ALL = SAMPLE | UB | MODE | EXTRAS | WAVELENGTH
+
 
 # ---------------------------------------------------------------------------
 # Functions


### PR DESCRIPTION
## Summary

- Replace ``Core._solver_needs_update`` (single boolean) with a
  fine-grained ``_SolverDirty`` bitfield (``hklpy2.utils``) tracking
  the SAMPLE / UB / MODE / EXTRAS / WAVELENGTH domains independently.
- Fix ``Core.sample`` setter (#386): re-sync the solver with the new
  sample's lattice + stored UB; raise ``KeyError`` for unknown names
  instead of silently corrupting state.
- Fix ``Core.calc_UB`` (#384): no longer falsely clear all dirty
  domains after computing UB.

Closes #384.
Closes #386.

Follow-up issue #391 tracks the (separately scoped) UX policy for
``Sample.UB_is_stale`` (orientation-reflection-change detection).

## Background

Both bugs share a root cause: the previous boolean dirty flag
conflated several distinct solver-state concerns, so a clear/set in
one place could falsely cover (or unmask) another concern elsewhere.

- **#386**: ``Core.sample = "name"`` wrote the new sample's U / UB
  onto the *previous* sample's solver state (which still had the old
  lattice and reflections), so ``inverse()`` / ``wh()`` returned values
  computed from the new UB on top of the old lattice.
- **#384**: ``Core.calc_UB`` ended with ``request_solver_update(False)``,
  which cleared *all* dirty domains and could mask any pending
  state-sync (such as a sample switch that flagged ``SAMPLE | UB``).

@strempfer (in #386) confirmed the sample-switch case is *not* a
stale-UB scenario -- the saved UB is authoritative, and only the
solver-state push was missing.

## What changed

### ``hklpy2.utils._SolverDirty`` (new, ``@versionadded``)

Bitfield enumerating the dirty domains:

```python
class _SolverDirty(IntFlag):
    SAMPLE     = 1   # solver's sample state (lattice + reflections)
    UB         = 2   # U / UB matrices
    MODE       = 4   # solver mode
    EXTRAS     = 8   # extra-axis values
    WAVELENGTH = 16
    ALL        = SAMPLE | UB | MODE | EXTRAS | WAVELENGTH
```

### ``Core.request_solver_update(flag)`` (back-compat shim)

- ``True`` -> mark all domains dirty (legacy).
- ``False`` -> clear all dirty flags (legacy).
- ``_SolverDirty`` value -> additive (mark the given domains dirty
  without disturbing others).

A read/write ``Core._solver_needs_update`` property preserves the
existing test surface (``test_incident.py``).

### ``Core.update_solver()`` (per-domain pushes)

Each dirty domain is pushed independently.  A SAMPLE re-push implies
re-pushing MODE / EXTRAS / U / UB (some backends discard those when
accepting a new sample state).

### ``Core.sample`` setter (``@versionchanged``, fixes #386)

- Raises ``KeyError`` for unknown names.
- Flags ``SAMPLE | UB``.
- Drops the partial U / UB push to the previous sample's solver state.

### ``Core.calc_UB`` (``@versionchanged``, fixes #384)

- Removes the bogus ``request_solver_update(False)`` at the end.
- Calls ``update_solver()`` after the U / UB writes so the dirty flag
  is honestly clean.

### ``Core.mode`` setter / getter

- Flag ``MODE | EXTRAS`` (a mode change may reset the solver's
  extra-axis values).

### ``blocks/sample.py``

- Lattice setter and ``_lattice_changed`` callback flag ``SAMPLE | UB``.
- ``Sample.U`` and ``Sample.UB`` setters flag ``UB`` only.

### ``AGENTS.md``

New mandatory section **"Solver-Backend Agnosticism"** formalising
the rule that backend-specific names (``libhkl``, ``hkl_soleil``,
``Hkl.Sample``, ``Sample.new``, ``compute_UB_busing_levy``, etc.)
and side-effect descriptions must not appear in code, comments, or
docstrings outside ``hklpy2/backends/<name>/``.

## Tests

New ``src/hklpy2/tests/test_i384_i386.py`` -- 19 parametrized cases:

- sample switch to A / B / round-trip (asserts hkl matches a freshly
  built reference simulator with that sample only)
- ``calc_UB``-then-``inverse``
- switch-then-``calc_UB``-then-``inverse`` (combined #384 + #386)
- unknown sample name raises ``KeyError`` with a helpful message
- per-domain dirty-flag granularity (lattice / U / UB / sample / mode)
- back-compat for ``request_solver_update`` (bool True / False) and
  ``_solver_needs_update`` (property setter True / False)
- additive behavior of ``request_solver_update(_SolverDirty.X)``

## Verification

- Full suite: **1116 passed**, 7 skipped, 8 deselected, 4 pre-existing
  warnings (200 s).
- ``pre-commit run --all-files``: all hooks pass.

## Out of scope

- ``Sample.UB_is_stale`` (orientation-reflection-change detection
  and warn / raise UX) -- tracked in #391 pending community input on
  the policy options.

Agent: OpenCode (claudeopus47)