### PR TITLE
docs #387 fix simulator_from_config link and rename howto file

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -54,6 +54,9 @@ Fixes
 * ``how_analyzer.ipynb``: correct stale prose about config save/restore
   (axis names are stored, positions are not; solver mode is restored);
   remove duplicate Bragg-law cell. (:issue:`360`)
+* ``how_simulator_from_config.rst``: fix broken ``:func:`` reference
+  (module is ``hklpy2.run_utils``, not ``hklpy2.misc``); rename file
+  to match the function. (:issue:`387`)
 * ``pa()`` / ``wh(full=True)`` no longer crashes when an auxiliary
   component returns a structured (multi-field) position; rendered
   inline as ``name={field=value, ...}``. (:issue:`385`)

--- a/docs/source/guides/how_simulator_from_config.rst
+++ b/docs/source/guides/how_simulator_from_config.rst
@@ -9,7 +9,7 @@ How to Create a Simulator from a Config
     simulator; from configuration
     configuration; restore as simulator
 
-:func:`~hklpy2.misc.simulator_from_config` creates a fully configured
+:func:`~hklpy2.run_utils.simulator_from_config` creates a fully configured
 simulated diffractometer — with no hardware connections — from a previously
 saved configuration file or dictionary.  All real-axis positioners are soft
 (simulated) positioners regardless of how they were defined in the original


### PR DESCRIPTION
- closes #387

## Summary

- Fix broken `:func:` cross-reference in the howto guide so the
  first-paragraph mention of `simulator_from_config()` links to the
  API documentation. The function lives in `hklpy2.run_utils`, not
  `hklpy2.misc`.
- Rename `docs/source/guides/how_creator_from_config.rst` ->
  `how_simulator_from_config.rst` so the filename and published URL
  match the page title, label, and function name.
- Add a Fixes entry to `RELEASE_NOTES.rst` under 0.6.2.

## Verification

- `pre-commit` hooks pass on commit.
- `make -C docs clean html` succeeds with no warnings related to the
  change.
- The rendered first-paragraph `simulator_from_config()` is hyperlinked
  to `autoapi/hklpy2/run_utils/index.html#hklpy2.run_utils.simulator_from_config`.
- Guides toctree resolves to the renamed file.

## Side effects

- Published URL changes from `.../guides/how_creator_from_config.html`
  to `.../guides/how_simulator_from_config.html`. External bookmarks
  to the old URL will 404 (accepted, pre-1.0 churn).

Agent: OpenCode (claudeopus47)