### PR TITLE
feat #391 add Sample.UB_is_stale and warn on stale UB

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -43,6 +43,8 @@ New Features
   the detector arm. (:issue:`360`)
 * Add ``restore_samples`` / ``restore_extras`` / ``restore_presets``
   kwargs to ``restore()``. (:issue:`390`)
+* Add ``Sample.UB_is_stale`` and warn when ``forward`` / ``inverse``
+  run with stale UB. (:issue:`391`)
 
 Enhancements
 ------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -183,7 +183,7 @@ points in the ``forward()`` computation:
 The UB matrix looks wrong, or ``pa()`` and ``configuration`` show different values.
 ------------------------------------------------------------------------------------
 
-Two common causes:
+Three common causes:
 
 1. **Axis mapping is swapped.**  If ``axes_xref`` has detector angles wired to
    sample-rotation slots (or vice versa), the UB calculation receives the wrong
@@ -195,6 +195,14 @@ Two common causes:
    matrix retains full floating-point precision.  A sign difference (e.g.
    ``+0.0101`` vs. ``-0.0101``) on a near-zero element is a display rounding
    artefact.  Retrieve the full matrix via ``diffractometer.sample.UB``.
+
+3. **The UB is :term:`stale UB <stale ub>`.**  An orienting reflection was
+   added, removed, reordered, or edited after ``calc_UB()`` last ran, so
+   the stored matrix no longer reflects the chosen pair.  ``pa()`` shows
+   ``UB stale: True`` and ``forward()`` / ``inverse()`` emit a
+   ``UserWarning``.  Check
+   ``diffractometer.sample.UB_is_stale``; refresh by calling
+   ``calc_UB()`` again.  See :ref:`how_calc_ub.stale`.
 
 .. seealso::
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -221,6 +221,15 @@ Glossary
         *pseudo* and *real* axes for a defined *diffractometer* *geometry*.  The
         library also provides one or more diffractometer geometries.
 
+    stale UB
+        State of a *sample* whose stored *UB* matrix no longer reflects the
+        current orienting *reflections* (the first two entries of
+        ``Sample.reflections.order``).  Detected via
+        :attr:`~hklpy2.blocks.sample.Sample.UB_is_stale`; cleared by
+        running :meth:`~hklpy2.ops.Core.calc_UB` again or by direct
+        assignment to :attr:`~hklpy2.blocks.sample.Sample.U` /
+        :attr:`~hklpy2.blocks.sample.Sample.UB` (user takes ownership).
+
     U
     UB
         Orientation matrix (3 x 3).

--- a/docs/source/guides/how_calc_ub.rst
+++ b/docs/source/guides/how_calc_ub.rst
@@ -98,6 +98,8 @@ SPEC's ``or_swap`` command::
 
 The new :math:`UB` matrix is returned and stored automatically.
 
+.. _how_calc_ub.set_manually:
+
 How do I set UB manually from a known matrix?
 ----------------------------------------------
 
@@ -144,6 +146,58 @@ To remove all reflections and reset the sample to defaults::
     reflections and recreates a single default sample.  Use
     :func:`~hklpy2.user.remove_reflection` if you only want to discard
     one reflection while keeping others.
+
+.. _how_calc_ub.stale:
+
+How do I tell if my UB is stale?
+---------------------------------
+
+.. index::
+    pair: UB matrix; stale
+    see: UB_is_stale; stale UB
+
+After :func:`~hklpy2.user.calc_UB`, the stored :math:`UB` matrix
+reflects the two orienting reflections (the first two entries of
+``sample.reflections.order``) *as they were at the moment*
+:func:`~hklpy2.user.calc_UB` *ran*.  Several common edits leave the
+stored matrix inconsistent with the current orienting pair — a
+:term:`stale UB`.
+
+Triggers for stale UB include:
+
+* Removing one of the two orienting reflections (for example,
+  ``remove_reflection(r1.name)`` above).
+* Reassigning ``sample.reflections.order`` so a different reflection
+  becomes ``order[0]`` or ``order[1]``.
+* Editing the ``pseudos``, ``reals``, or ``wavelength`` of either
+  orienting reflection in place.
+
+Edits that do **not** invalidate the UB include: adding or removing a
+reflection that is not in ``order[:2]``, editing a non-orienting
+reflection, and assigning :attr:`~hklpy2.blocks.sample.Sample.U` /
+:attr:`~hklpy2.blocks.sample.Sample.UB` directly (the user has taken
+ownership of the matrix; see :ref:`how_calc_ub.set_manually`).
+
+Check the current state via
+:attr:`~hklpy2.blocks.sample.Sample.UB_is_stale`::
+
+    >>> fourc.sample.UB_is_stale
+    False
+    >>> remove_reflection(r1.name)
+    >>> fourc.sample.UB_is_stale
+    True
+
+When :meth:`~hklpy2.diffract.DiffractometerBase.forward` or
+:meth:`~hklpy2.diffract.DiffractometerBase.inverse` runs against a
+stale UB, a single ``UserWarning`` is emitted and :func:`pa`
+annotates its output with ``UB stale: True``.  Refresh the matrix by
+running :func:`~hklpy2.user.calc_UB` again with the desired
+orienting pair::
+
+    >>> r4 = setor(0, 4, 0, tth=69.0966, omega=-145.451, chi=90, phi=0)
+    >>> calc_UB(r4, r2)
+    >>> fourc.sample.UB_is_stale
+    False
 
 How do I refine the lattice parameters?
 -----------------------------------------

--- a/src/hklpy2/blocks/sample.py
+++ b/src/hklpy2/blocks/sample.py
@@ -9,9 +9,12 @@ A Crystalline Sample.
 import logging
 import math
 from typing import Mapping
+from typing import Optional
+from typing import Tuple
 from typing import Union
 
 import numpy as np
+from deprecated.sphinx import versionadded
 from numpy.linalg import norm
 
 from ..utils import _SolverDirty
@@ -21,6 +24,18 @@ from .lattice import Lattice
 from .lattice import LatticeDictType
 from .reflection import Reflection
 from .reflection import ReflectionsDict
+
+# Reflection fields that, when changed for an orienting reflection,
+# invalidate the previously computed UB.  ``digits`` is intentionally
+# omitted (presentation only); ``name`` is implicit in ``order[:2]``.
+_UB_REFLECTION_FIELDS: Tuple[str, ...] = (
+    "geometry",
+    "pseudos",
+    "reals",
+    "reals_units",
+    "wavelength",
+    "wavelength_units",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +79,7 @@ class Sample:
         ~remove_reflection
         ~U
         ~UB
+        ~UB_is_stale
     """
 
     def __init__(
@@ -79,6 +95,12 @@ class Sample:
             raise TypeError(f"Unexpected type {core=!r}, expected Core")
         self.name = name or unique_name()
         self.core = core
+        # Snapshot of the orientation-reflection state at the end of the
+        # last successful ``calc_UB``.  ``None`` means "no snapshot is
+        # stored", which is the case until ``calc_UB`` runs and any time
+        # the user takes ownership of U / UB by direct assignment.  See
+        # :issue:`391`.
+        self._ub_snapshot: Optional[tuple] = None
         self.lattice = lattice
         self.U = IDENTITY_MATRIX_3X3
         # Consider: UB = self.U @ self.lattice.B
@@ -218,6 +240,10 @@ class Sample:
         self._U = value
         # U changes require only a UB push; no full _sample rebuild.
         self.core.request_solver_update(_SolverDirty.UB)
+        # Direct assignment: the user has taken ownership of U; clear
+        # any prior calc_UB snapshot so ``UB_is_stale`` reports False
+        # until the next ``calc_UB`` (:issue:`391`).
+        self._ub_snapshot = None
 
     @property
     def UB(self) -> Matrix3x3:
@@ -237,3 +263,72 @@ class Sample:
         self._UB = value
         # UB changes require only a UB push; no full _sample rebuild.
         self.core.request_solver_update(_SolverDirty.UB)
+        # Direct assignment: the user has taken ownership of UB; clear
+        # any prior calc_UB snapshot so ``UB_is_stale`` reports False
+        # until the next ``calc_UB`` (:issue:`391`).
+        self._ub_snapshot = None
+
+    def _compute_ub_snapshot(self) -> Optional[tuple]:
+        """
+        Return a comparable snapshot of the current orientation-reflection state.
+
+        The snapshot captures the two orienting reflection names plus the
+        physics-relevant fields of those reflections (``geometry``,
+        ``pseudos``, ``reals``, ``reals_units``, ``wavelength``,
+        ``wavelength_units``).  Any change to those values invalidates a
+        previously computed UB.  Returns ``None`` when fewer than two
+        reflections are available (UB is not computable) or when an
+        ordered name no longer maps to a known reflection.
+        """
+        order = self.reflections.order
+        if len(order) < 2:
+            return None
+        head = tuple(order[:2])
+        try:
+            contents = tuple(
+                tuple(
+                    (field, self.reflections[name]._asdict()[field])
+                    for field in _UB_REFLECTION_FIELDS
+                )
+                for name in head
+            )
+        except KeyError:
+            # ``order`` references a name that is no longer in the dict.
+            return None
+        return (head, contents)
+
+    @property
+    @versionadded(
+        version="0.6.2",
+        reason=(
+            "Detect when the orientation reflections have changed since "
+            "the last ``calc_UB``, indicating the stored UB no longer "
+            "reflects the chosen orienting pair.  See :issue:`391`."
+        ),
+    )
+    def UB_is_stale(self) -> bool:
+        """
+        ``True`` iff the orientation reflections have changed since the
+        last successful ``calc_UB`` for this sample.
+
+        Returns ``False`` in any of these cases:
+
+        * ``calc_UB`` has not been called for this sample (no snapshot
+          to compare against),
+        * the user has assigned :attr:`U` or :attr:`UB` directly (they
+          have explicitly taken ownership of the matrix; the snapshot
+          is cleared),
+        * the orientation reflections (``reflections.order[:2]`` and
+          their physics-relevant contents) are unchanged since the last
+          ``calc_UB``.
+
+        Returns ``True`` when ``order[:2]`` itself changes (reorder,
+        prepend a new orienting reflection, remove an orienting one) or
+        when an in-place mutation of one of the orienting reflections
+        changes its ``pseudos``, ``reals``, ``wavelength``, or unit
+        fields.  Reflections outside ``order[:2]`` do not affect
+        staleness.
+        """
+        if self._ub_snapshot is None:
+            return False
+        return self._compute_ub_snapshot() != self._ub_snapshot

--- a/src/hklpy2/blocks/tests/test_ub_staleness.py
+++ b/src/hklpy2/blocks/tests/test_ub_staleness.py
@@ -1,0 +1,285 @@
+"""
+Tests for ``Sample.UB_is_stale`` (:issue:`391`).
+
+Covers the staleness-detection matrix in the issue:
+
+* ``calc_UB`` -> not stale.
+* Reorder of ``order[:2]`` -> stale.
+* Add a non-orienting reflection -> not stale.
+* Add a reflection AND prepend it to ``order`` -> stale.
+* Remove a non-orienting reflection -> not stale.
+* Remove ``order[0]`` -> stale.
+* In-place mutation of an orienting reflection's ``pseudos`` -> stale.
+* In-place mutation of a non-orienting reflection's ``pseudos`` -> not stale.
+* Direct ``Sample.UB = M`` after calc_UB -> not stale (user owns UB).
+* Single reflection with no calc_UB possible -> not stale.
+
+Lifecycle of ``Sample._ub_snapshot``:
+
+* New sample -> ``None``.
+* After ``calc_UB`` -> tuple snapshot.
+* After ``Sample.U = ...`` -> cleared to ``None``.
+* After ``Sample.UB = ...`` -> cleared to ``None``.
+* After a second ``calc_UB`` -> fresh snapshot for the new pair.
+"""
+
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ...diffract import creator
+from ...tests.models import add_oriented_vibranium_to_e4cv
+from ...utils import IDENTITY_MATRIX_3X3
+
+
+def _oriented_e4cv():
+    """Return an E4CV diffractometer with vibranium oriented via calc_UB."""
+    e4cv = creator(name="e4cv")
+    add_oriented_vibranium_to_e4cv(e4cv)
+    return e4cv
+
+
+def _setup_initial(action: str):
+    """Apply ``action`` against a freshly oriented E4CV; return the diffractometer."""
+    e4cv = _oriented_e4cv()
+    sample = e4cv.sample
+    refls = sample.reflections
+
+    if action == "noop":
+        pass
+    elif action == "swap_order":
+        # vibranium has order = ['r040', 'r004'] after add_oriented_*.
+        refls.order = list(reversed(refls.order))
+    elif action == "add_non_orienting":
+        # 'r400' is already in the dict but not in order; mimic adding a fresh
+        # one outside the orienting pair by re-adding with replace=True.
+        # The 'r400' name is added by add_oriented_vibranium_to_e4cv but only
+        # 'r040', 'r004' are placed in ``order`` by calc_UB.
+        assert "r400" in refls and "r400" not in refls.order
+    elif action == "add_and_prepend":
+        # Prepend an existing non-orienting reflection to ``order``.
+        refls.order = ["r400"] + list(refls.order)
+    elif action == "remove_non_orienting":
+        sample.remove_reflection("r400")
+    elif action == "remove_order_zero":
+        sample.remove_reflection(refls.order[0])
+    elif action == "mutate_orienting_pseudos":
+        first = refls[refls.order[0]]
+        # Bump h by 1 to force a content change (any change suffices).
+        new = dict(first.pseudos)
+        first_key = next(iter(new))
+        new[first_key] = new[first_key] + 1
+        first.pseudos = new
+    elif action == "mutate_non_orienting_pseudos":
+        non = refls["r400"]
+        new = dict(non.pseudos)
+        first_key = next(iter(new))
+        new[first_key] = new[first_key] + 1
+        non.pseudos = new
+    elif action == "assign_UB":
+        sample.UB = IDENTITY_MATRIX_3X3
+    elif action == "assign_U":
+        sample.U = IDENTITY_MATRIX_3X3
+    else:
+        raise ValueError(f"Unknown action {action!r}")
+
+    return e4cv
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(action="noop", expected=False),
+            does_not_raise(),
+            id="calc_UB-then-check",
+        ),
+        pytest.param(
+            dict(action="swap_order", expected=True),
+            does_not_raise(),
+            id="swap-order[:2]",
+        ),
+        pytest.param(
+            dict(action="add_non_orienting", expected=False),
+            does_not_raise(),
+            id="add-3rd-reflection-not-in-order",
+        ),
+        pytest.param(
+            dict(action="add_and_prepend", expected=True),
+            does_not_raise(),
+            id="add-reflection-AND-prepend-to-order",
+        ),
+        pytest.param(
+            dict(action="remove_non_orienting", expected=False),
+            does_not_raise(),
+            id="remove-non-order-reflection",
+        ),
+        pytest.param(
+            dict(action="remove_order_zero", expected=True),
+            does_not_raise(),
+            id="remove-order[0]",
+        ),
+        pytest.param(
+            dict(action="mutate_orienting_pseudos", expected=True),
+            does_not_raise(),
+            id="modify-pseudos-of-order[0]",
+        ),
+        pytest.param(
+            dict(action="mutate_non_orienting_pseudos", expected=False),
+            does_not_raise(),
+            id="modify-pseudos-of-non-order-reflection",
+        ),
+        pytest.param(
+            dict(action="assign_UB", expected=False),
+            does_not_raise(),
+            id="direct-UB-assignment-clears-snapshot",
+        ),
+        pytest.param(
+            dict(action="assign_U", expected=False),
+            does_not_raise(),
+            id="direct-U-assignment-clears-snapshot",
+        ),
+    ],
+)
+def test_ub_is_stale_matrix(parms, context):
+    with context:
+        e4cv = _setup_initial(parms["action"])
+        assert e4cv.sample.UB_is_stale is parms["expected"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="single-reflection-no-calc_UB",
+        ),
+    ],
+)
+def test_ub_is_stale_with_fewer_than_two_reflections(parms, context):
+    """A sample with <2 reflections cannot have a calc_UB snapshot."""
+    with context:
+        e4cv = creator(name="e4cv")
+        e4cv.add_sample("vibranium", 6.28, digits=3, replace=True)
+        e4cv.beam.wavelength.put(1.54)
+        e4cv.add_reflection(
+            (4, 0, 0),
+            dict(omega=-145.451, chi=0, phi=0, tth=69.066),
+            name="r400",
+        )
+        # No calc_UB possible.
+        assert e4cv.sample._ub_snapshot is None
+        assert e4cv.sample.UB_is_stale is False
+        # Reordering with one reflection is a no-op for staleness.
+        e4cv.sample.reflections.order = ["r400"]
+        assert e4cv.sample.UB_is_stale is False
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="snapshot-set-by-calc_UB",
+        ),
+    ],
+)
+def test_snapshot_set_by_calc_UB(parms, context):
+    with context:
+        e4cv = creator(name="e4cv")
+        e4cv.add_sample("vibranium", 6.28, digits=3, replace=True)
+        e4cv.beam.wavelength.put(1.54)
+        r040 = e4cv.add_reflection((0, 4, 0), (-145.451, 0, 90, 69.066), name="r040")
+        r004 = e4cv.add_reflection((0, 0, 4), (-145.451, 90, 0, 69.066), name="r004")
+
+        # Pre-condition: snapshot is None until calc_UB runs.
+        assert e4cv.sample._ub_snapshot is None
+
+        e4cv.core.calc_UB(r040, r004)
+
+        # Post-condition: snapshot captured.
+        snap = e4cv.sample._ub_snapshot
+        assert snap is not None
+        # First element is the orienting names tuple.
+        assert snap[0] == ("r040", "r004")
+        # Second element is per-reflection content tuples.
+        assert len(snap[1]) == 2
+        # Idempotent: a fresh snapshot of the unchanged state must equal
+        # the stored one.
+        assert e4cv.sample._compute_ub_snapshot() == snap
+        assert e4cv.sample.UB_is_stale is False
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(setter="U"),
+            does_not_raise(),
+            id="U-setter-clears-snapshot",
+        ),
+        pytest.param(
+            dict(setter="UB"),
+            does_not_raise(),
+            id="UB-setter-clears-snapshot",
+        ),
+    ],
+)
+def test_direct_assignment_clears_snapshot(parms, context):
+    with context:
+        e4cv = _oriented_e4cv()
+        # Pre-condition: calc_UB ran, snapshot present.
+        assert e4cv.sample._ub_snapshot is not None
+        if parms["setter"] == "U":
+            e4cv.sample.U = IDENTITY_MATRIX_3X3
+        else:
+            e4cv.sample.UB = IDENTITY_MATRIX_3X3
+        # Post-condition: snapshot cleared, UB_is_stale is False.
+        assert e4cv.sample._ub_snapshot is None
+        assert e4cv.sample.UB_is_stale is False
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="recalc-refreshes-snapshot",
+        ),
+    ],
+)
+def test_recalc_UB_refreshes_snapshot(parms, context):
+    with context:
+        e4cv = _oriented_e4cv()
+        # Force staleness by reordering.
+        e4cv.sample.reflections.order = list(reversed(e4cv.sample.reflections.order))
+        assert e4cv.sample.UB_is_stale is True
+
+        # Re-orient with the new order; staleness should clear.
+        new_pair = list(e4cv.sample.reflections.order)
+        e4cv.core.calc_UB(*new_pair)
+        assert e4cv.sample.UB_is_stale is False
+        assert e4cv.sample._ub_snapshot is not None
+        assert e4cv.sample._ub_snapshot[0] == tuple(new_pair)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="digits-change-does-not-cause-staleness",
+        ),
+    ],
+)
+def test_digits_change_does_not_cause_staleness(parms, context):
+    """``digits`` is a presentation field; changing it must not flag UB stale."""
+    with context:
+        e4cv = _oriented_e4cv()
+        first = e4cv.sample.reflections[e4cv.sample.reflections.order[0]]
+        first.digits = first.digits + 1
+        assert e4cv.sample.UB_is_stale is False

--- a/src/hklpy2/blocks/tests/test_ub_staleness.py
+++ b/src/hklpy2/blocks/tests/test_ub_staleness.py
@@ -283,3 +283,30 @@ def test_digits_change_does_not_cause_staleness(parms, context):
         first = e4cv.sample.reflections[e4cv.sample.reflections.order[0]]
         first.digits = first.digits + 1
         assert e4cv.sample.UB_is_stale is False
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="order-references-missing-name",
+        ),
+    ],
+)
+def test_compute_snapshot_with_missing_order_name(parms, context):
+    """``_compute_ub_snapshot`` must return ``None`` when ``order`` references
+    a reflection name that is no longer in the dict (defensive: catches the
+    inconsistent-state case where the dict is mutated without using
+    :meth:`Sample.remove_reflection`)."""
+    with context:
+        e4cv = _oriented_e4cv()
+        # Bypass remove_reflection (which would also clean up ``order``) by
+        # popping directly from the underlying dict.
+        e4cv.sample.reflections.pop(e4cv.sample.reflections.order[0])
+        # ``order`` still references the popped name; the snapshot must
+        # gracefully return None instead of raising KeyError.
+        assert e4cv.sample._compute_ub_snapshot() is None
+        # And UB_is_stale must report True (snapshot != stored snapshot).
+        assert e4cv.sample.UB_is_stale is True

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -1095,6 +1095,12 @@ class DiffractometerBase(PseudoPositioner):
             print(f"Orienting reflections: {self.sample.reflections.order}")
             print(f"U={format_array(self.sample.U)}")
             print(f"UB={format_array(self.sample.UB)}")
+            if self.sample.UB_is_stale:
+                # Surface UB staleness in pa() output (:issue:`391`).
+                print(
+                    "UB stale: True"
+                    "  (orientation reflections changed since last calc_UB)"
+                )
             for v in self.core.constraints.values():
                 print(f"constraint: {v}")
             print(f"Mode: {self.core.mode}")

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -551,8 +551,6 @@ class Core:
         is performed.
         """
         sample = self.sample
-        if sample is None:
-            return
         if sample.UB_is_stale:
             warnings.warn(
                 f"UB for sample {sample.name!r} is stale "

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -11,6 +11,7 @@ library.
 
 import datetime
 import logging
+import warnings
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 from typing import Mapping
@@ -530,7 +531,37 @@ class Core:
         self.sample.U = self.solver.U
         self.sample.UB = ub
         self.update_solver()
+        # Snapshot the orientation-reflection state used to derive UB so
+        # ``Sample.UB_is_stale`` can later detect drift (:issue:`391`).
+        # Note: the U / UB setters above clear ``_ub_snapshot`` (direct
+        # assignment is treated as user ownership); the snapshot must be
+        # set after those writes, as the final step of a successful
+        # calc_UB.
+        self.sample._ub_snapshot = self.sample._compute_ub_snapshot()
         return ub
+
+    def _warn_if_ub_stale(self) -> None:
+        """
+        Emit a ``UserWarning`` when the current sample's UB is stale.
+
+        Called from :meth:`forward` and :meth:`inverse`.  Staleness is
+        detected via :attr:`Sample.UB_is_stale` (:issue:`391`); the
+        result of the call may not reflect the current orientation
+        reflections.  The user retains full control: no recomputation
+        is performed.
+        """
+        sample = self.sample
+        if sample is None:
+            return
+        if sample.UB_is_stale:
+            warnings.warn(
+                f"UB for sample {sample.name!r} is stale "
+                "(orientation reflections changed since last calc_UB); "
+                "the result may not reflect the current orientation. "
+                "Call calc_UB() to refresh.",
+                UserWarning,
+                stacklevel=3,
+            )
 
     @property
     def extras(self) -> list[str]:
@@ -561,6 +592,7 @@ class Core:
             self.__class__.__name__,
             pseudos,
         )
+        self._warn_if_ub_stale()
 
         pdict = self.standardize_pseudos(pseudos)
         base_reals = self.diffractometer.real_position._asdict()  # Original values.
@@ -680,6 +712,8 @@ class Core:
         if self.solver is None or len(self.axes_xref) == 0:
             # Called from the constructor before solver is defined.
             return pseudos  # current values of pseudos
+
+        self._warn_if_ub_stale()
 
         # Just the reals expected by the solver.
         # Dictionary in order expected by the solver.

--- a/src/hklpy2/tests/test_i391_ub_stale_warnings.py
+++ b/src/hklpy2/tests/test_i391_ub_stale_warnings.py
@@ -1,0 +1,156 @@
+"""
+Tests for the stale-UB ``UserWarning`` in :class:`hklpy2.ops.Core`
+and the ``pa()`` annotation (:issue:`391`).
+
+When ``Sample.UB_is_stale`` is ``True``, ``Core.forward`` and
+``Core.inverse`` emit a single ``UserWarning`` per call and
+``DiffractometerBase.wh(full=True)`` (i.e. ``pa()``) prints a
+``UB stale: True`` annotation.  When ``UB_is_stale`` is ``False``, no
+warning is emitted and the annotation is absent.
+"""
+
+import re
+import warnings
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ..diffract import creator
+from .models import add_oriented_vibranium_to_e4cv
+
+_STALE_PATTERN = re.compile(
+    r"UB for sample .* is stale .*orientation reflections changed"
+)
+
+
+def _oriented_e4cv():
+    e4cv = creator(name="e4cv")
+    add_oriented_vibranium_to_e4cv(e4cv)
+    return e4cv
+
+
+def _make_stale(e4cv):
+    """Force the diffractometer's UB to be stale."""
+    e4cv.sample.reflections.order = list(reversed(e4cv.sample.reflections.order))
+    assert e4cv.sample.UB_is_stale is True
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(method="forward", make_stale=True, expect_warning=True),
+            does_not_raise(),
+            id="forward-stale-warns",
+        ),
+        pytest.param(
+            dict(method="forward", make_stale=False, expect_warning=False),
+            does_not_raise(),
+            id="forward-fresh-no-warning",
+        ),
+        pytest.param(
+            dict(method="inverse", make_stale=True, expect_warning=True),
+            does_not_raise(),
+            id="inverse-stale-warns",
+        ),
+        pytest.param(
+            dict(method="inverse", make_stale=False, expect_warning=False),
+            does_not_raise(),
+            id="inverse-fresh-no-warning",
+        ),
+    ],
+)
+def test_stale_ub_warning(parms, context):
+    with context:
+        e4cv = _oriented_e4cv()
+        if parms["make_stale"]:
+            _make_stale(e4cv)
+        else:
+            assert e4cv.sample.UB_is_stale is False
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            if parms["method"] == "forward":
+                e4cv.core.forward(dict(h=1, k=0, l=0))
+            else:
+                e4cv.core.inverse(dict(omega=-145.451, chi=0, phi=0, tth=69.066))
+
+        stale_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and _STALE_PATTERN.search(str(w.message))
+        ]
+        if parms["expect_warning"]:
+            assert len(stale_warnings) == 1, [str(w.message) for w in caught]
+        else:
+            assert stale_warnings == []
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(make_stale=True, expect_annotation=True),
+            does_not_raise(),
+            id="pa-shows-stale-annotation",
+        ),
+        pytest.param(
+            dict(make_stale=False, expect_annotation=False),
+            does_not_raise(),
+            id="pa-no-annotation-when-fresh",
+        ),
+    ],
+)
+def test_pa_surface_stale_annotation(parms, context, capsys):
+    with context:
+        e4cv = _oriented_e4cv()
+        if parms["make_stale"]:
+            _make_stale(e4cv)
+
+        # ``pa()`` is ``wh(full=True)``.  Suppress the stale-UB warning
+        # that ``wh()`` may itself indirectly trigger so it does not
+        # interfere with capsys output.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            e4cv.wh(full=True)
+
+        captured = capsys.readouterr().out
+        if parms["expect_annotation"]:
+            assert "UB stale: True" in captured
+            assert "orientation reflections changed since last calc_UB" in captured
+        else:
+            assert "UB stale" not in captured
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="recalc_UB-clears-warning",
+        ),
+    ],
+)
+def test_recalc_clears_warning(parms, context):
+    """After re-running ``calc_UB`` the warning must stop firing."""
+    with context:
+        e4cv = _oriented_e4cv()
+        _make_stale(e4cv)
+        # Re-orient with the new pair.
+        new_pair = list(e4cv.sample.reflections.order)
+        e4cv.core.calc_UB(*new_pair)
+        assert e4cv.sample.UB_is_stale is False
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            e4cv.core.forward(dict(h=1, k=0, l=0))
+
+        stale = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and _STALE_PATTERN.search(str(w.message))
+        ]
+        assert stale == []


### PR DESCRIPTION
- closes #391

## Summary

Detect when the orientation reflections used to derive `UB` have changed
since the last `calc_UB` and surface the condition non-fatally.

* `Sample.UB_is_stale` (new property) reports whether `order[:2]` or the
  physics-relevant fields of those two reflections (`geometry`,
  `pseudos`, `reals`, units, `wavelength`) have changed since the last
  `calc_UB`.  Implementation uses a snapshot stored on `Sample` at the
  end of each successful `Core.calc_UB`; direct assignment to
  `Sample.U` / `Sample.UB` clears the snapshot (the user has taken
  ownership of the matrix).
* `Core.forward` and `Core.inverse` emit a single `UserWarning` per call
  when `UB` is stale.
* `pa()` (i.e. `wh(full=True)`) prints `UB stale: True (orientation
  reflections changed since last calc_UB)`.

Out of scope (per the issue's "Open policy question"): auto-recompute
(Option B) and raise-on-stale (Option C).  This PR implements
**Option A** (lazy mark-stale + warn), which the issue and the
linked discussion on #386 recommend.

## Implementation note

The issue's "Proposed mechanism" calls the snapshot a "fingerprint";
the implementation uses `_ub_snapshot` / `_compute_ub_snapshot()`
because nothing is hashed and the value exists strictly to expedite an
equality check.  The issue body is left as-is (it documents the
*why*); the rename is a *how* detail.

## Documentation

* New section "How do I tell if my UB is stale?" in
  `docs/source/guides/how_calc_ub.rst`, with anchor
  `_how_calc_ub.stale` and triggers/recovery examples.
* Companion anchor `_how_calc_ub.set_manually` on the existing
  "set UB manually" section, used as the cross-link target.
* `docs/source/faq.rst`: `faq.ub-wrong` extended from "Two common
  causes" to "Three common causes" with stale UB as the new third
  cause.
* `docs/source/glossary.rst`: new `stale UB` entry.

## Verification

* New tests: `src/hklpy2/blocks/tests/test_ub_staleness.py` (16 cases
  covering the staleness matrix, snapshot lifecycle, and the
  `digits`-doesn't-flag-stale invariant) and
  `src/hklpy2/tests/test_i391_ub_stale_warnings.py` (7 cases covering
  the `UserWarning` and `pa()` annotation).
* Full suite: 1159 passed, 7 skipped, 8 deselected — no regressions.
* `pre-commit run --all-files`: clean.
* Sphinx docs build: clean (no warnings, refs resolve).

Agent: OpenCode (claudeopus47)