### PR TITLE
fix #397 flag solver-dirty on reflection mutations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,10 +205,32 @@ The `Makefile` `pre` target also exports this variable automatically.
   feature, fix, enhancement, or maintenance change.
 - Add the entry under the current development version heading (the topmost
   unreleased section inside the ``.. comment`` block).
-- Entries must be **terse**: one line preferred, two lines maximum.
-  State *what* changed, not *how* or *why*. Omit implementation details,
-  lists of function names, and inline API cross-references unless the
-  function name is the entire point of the entry.
+- Entries **MUST** be terse.  This is non-negotiable.
+  - **One line is the target.**  Two lines is the absolute maximum,
+    permitted only when a single line genuinely cannot convey the
+    change.  If you find yourself reaching for a second line, the
+    fix is almost always to *cut words*, not to add a line.
+  - State *what* changed in user-visible terms.  Do **not** state
+    *how* it was implemented, *why* the change was needed,
+    workarounds, internals, design rationale, or which symbol was
+    touched.  Those belong in the issue, the PR description, the
+    docstring, or a ``@versionchanged`` decorator — never in the
+    release notes.
+  - Do **not** list affected functions, classes, modules, files,
+    code paths, or call sites.  Mention a specific symbol only when
+    that symbol *is* the entry (a brand-new public function, a
+    renamed public class, a removed public attribute).
+  - Do **not** describe the mechanism (e.g. "by adding a callback",
+    "via a new bitfield", "through a wrapper class") or the trigger
+    (e.g. "after a sample switch", "when called from inside
+    ``calc_UB``").  The user does not care.
+  - Prefer plain present-tense verbs (Add, Fix, Remove, Rename,
+    Deprecate).  Avoid filler ("now", "no longer", "properly",
+    "correctly", "as expected") unless removing the filler changes
+    the meaning.
+  - Before submitting, re-read each entry and delete every word
+    that is not load-bearing.  If the entry is still over one line,
+    repeat.
 - Always end with the issue or PR reference: ``:issue:`N``` or ``:pr:`N```.
 - Good examples::
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -30,6 +30,16 @@ describe future plans.
 
     Release expected 2026-Q3.
 
+0.6.3
+#####
+
+Bug fix release.
+
+Fixes
+-----
+
+* Reflection mutations now flag the solver-dirty bitfield. (:issue:`397`)
+
 0.6.2
 #####
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -40,6 +40,11 @@ Fixes
 
 * Reflection mutations now flag the solver-dirty bitfield. (:issue:`397`)
 
+Maintenance
+-----------
+
+* Document ``calculate_UB`` / ``refineLattice`` self-install contract. (:issue:`397`)
+
 0.6.2
 #####
 

--- a/docs/source/guides/howto_write_solver.rst
+++ b/docs/source/guides/howto_write_solver.rst
@@ -175,7 +175,7 @@ method (or property)            description
 ``name``                        (string attribute) Name of this solver.
 ``version``                     (string attribute) Version of this solver.
 ``addReflection(reflection)``   Add an observed diffraction reflection.
-``calculate_UB(r1, r2)``        Calculate the UB matrix with two reflections.
+``calculate_UB(r1, r2)``        Calculate the UB matrix with two reflections.  Self-installs ``r1`` and ``r2`` (see :ref:`calculate_UB() contract <howto.solvers.write.calculate_ub_contract>`).
 ``extra_axis_names``            Returns list of any extra axes in the current *mode*.
 ``forward(pseudos)``            Compute list of solutions(reals) from pseudos.  A single-element list is acceptable (see :ref:`forward() contract <howto.solvers.write.forward_contract>`).
 ``geometries``                  ``@classmethod`` [#classmethod_decorator]_ : Returns list of all geometries support by this solver.
@@ -183,7 +183,7 @@ method (or property)            description
 ``modes``                       Returns list of all modes support by this geometry.
 ``pseudo_axis_names``           Returns list of all pseudos support by this geometry.
 ``real_axis_names``             Returns list of all reals support by this geometry.
-``refineLattice(reflections)``  Return refined lattice parameters given reflections.
+``refineLattice(reflections)``  Return refined lattice parameters given reflections.  Self-installs ``reflections`` (see :ref:`calculate_UB() contract <howto.solvers.write.calculate_ub_contract>`).
 ``removeAllReflections()``      Clears sample of all stored reflections.
 ==============================  ==================
 
@@ -262,6 +262,39 @@ layers.
         s3      -> s4 [label="one solution"]
         s4      -> result
     }
+
+.. _howto.solvers.write.calculate_ub_contract:
+
+``calculate_UB()`` Contract
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``calculate_UB(r1, r2)`` is the **authoritative installer of its own
+orientation pair**.  Every conformant implementation must execute the
+following steps, in order:
+
+1. ``self.removeAllReflections()`` -- discard any reflections previously
+   stored in the solver-side sample state.
+2. ``self.addReflection(r1)`` -- install the first orientation
+   reflection from the supplied dict.
+3. ``self.addReflection(r2)`` -- install the second orientation
+   reflection from the supplied dict.
+4. Invoke the backend library's Busing & Levy routine
+   (Acta Cryst 22 (1967) 457) on the freshly-installed pair to
+   compute *UB*.
+5. Return *UB* as a 3x3 ``list[list[float]]``.
+
+Implementations **must not** assume that the solver's reflection list
+already contains ``r1`` and ``r2``.  The :class:`~hklpy2.ops.Core`
+layer pushes the python-side sample state via
+:meth:`~hklpy2.ops.Core.update_solver` before invoking
+``calculate_UB``, but ``calculate_UB`` itself is the authoritative
+installer of the orienting pair so the result is reproducible from
+the supplied arguments alone.
+
+The same self-install pattern applies to
+:meth:`~hklpy2.backends.base.SolverBase.refineLattice`: remove all,
+add each supplied reflection, then invoke the backend's refinement
+routine.
 
 .. _howto.solvers.write.backend_requirements:
 

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -339,6 +339,30 @@ class SolverBase(ABC):
         Calculate the UB (orientation) matrix with two reflections.
 
         The method of Busing & Levy, Acta Cryst 22 (1967) 457.
+
+        .. rubric:: Implementation contract
+
+        ``calculate_UB`` is the authoritative installer of its own
+        orientation pair.  Every conformant implementation **must**
+        execute these steps, in order:
+
+        1. :meth:`removeAllReflections` -- discard any reflections
+           previously stored in the solver-side sample state.
+        2. :meth:`addReflection(r1) <addReflection>` -- install the
+           first orientation reflection from the supplied dict.
+        3. :meth:`addReflection(r2) <addReflection>` -- install the
+           second orientation reflection from the supplied dict.
+        4. Invoke the backend library's Busing & Levy routine on the
+           freshly-installed pair to compute *UB*.
+        5. Return *UB* as a 3x3 ``list[list[float]]``.
+
+        The implementation **must not** assume that the solver's
+        reflection list already contains ``r1`` and ``r2``.  The
+        :class:`~hklpy2.ops.Core` layer pushes the python-side sample
+        state via :meth:`update_solver` before invoking
+        ``calculate_UB``, but ``calculate_UB`` itself is the
+        authoritative installer of the orienting pair so that the
+        result is reproducible from the supplied arguments alone.
         """
         # return self.UB
 
@@ -496,7 +520,28 @@ class SolverBase(ABC):
 
     @abstractmethod
     def refineLattice(self, reflections: List[ReflectionDict]) -> NamedFloatDict | None:
-        """Refine the lattice parameters from a list of reflections."""
+        """
+        Refine the lattice parameters from a list of reflections.
+
+        .. rubric:: Implementation contract
+
+        Like :meth:`calculate_UB`, ``refineLattice`` is the authoritative
+        installer of its input reflections.  Every conformant
+        implementation **must**:
+
+        1. :meth:`removeAllReflections` -- discard any reflections
+           previously stored in the solver-side sample state.
+        2. :meth:`addReflection(r) <addReflection>` for each ``r`` in
+           ``reflections`` -- install the supplied reflections.
+        3. Invoke the backend library's lattice-refinement routine on
+           the freshly-installed list.
+        4. Return the refined lattice parameters as a
+           :data:`~hklpy2.typing.NamedFloatDict` (or ``None`` if the
+           backend does not support refinement).
+
+        The implementation **must not** assume that the solver's
+        reflection list already contains the supplied reflections.
+        """
 
     @abstractmethod
     def removeAllReflections(self) -> None:

--- a/src/hklpy2/blocks/reflection.py
+++ b/src/hklpy2/blocks/reflection.py
@@ -18,9 +18,12 @@ from typing import Mapping
 from typing import Optional
 from typing import Union
 
+from deprecated.sphinx import versionchanged
+
 from ..exceptions import ConfigurationError
 from ..exceptions import ReflectionError
 from ..utils import INTERNAL_LENGTH_UNITS
+from ..utils import _SolverDirty
 from ..utils import check_value_in_list
 from ..utils import compare_float_dicts
 from ..utils import convert_units
@@ -376,19 +379,56 @@ class ReflectionsDict(dict):
 
         ~_asdict
         ~_fromdict
+        ~_request_solver_update
         ~_validate_reflection
         ~add
+        ~clear
         ~order
+        ~pop
         ~prune
         ~set_orientation_reflections
         ~setor
         ~swap
+
+    .. versionchanged:: 0.6.3
+       Mutating operations now flag the owning
+       :class:`~hklpy2.ops.Core` with
+       ``_SolverDirty.SAMPLE | _SolverDirty.UB`` whenever the change
+       affects an entry referenced by :attr:`order` (the orienting
+       reflections the solver actually sees).  This includes
+       :meth:`add`, :meth:`swap`, :meth:`set_orientation_reflections`
+       / :meth:`setor`, the :attr:`order` setter, and any dict-API
+       mutation (``pop``, ``__setitem__``, ``__delitem__``, ``clear``,
+       ``update``, ``popitem``) that touches an ordered name.
+       Previously these mutations left the solver with a stale
+       reflection list.  See :issue:`397`.
     """
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._order = []
         self.geometry = None
+        # Back-reference to the owning ``Core``.  Wired by
+        # :class:`~hklpy2.blocks.sample.Sample` after construction so that
+        # mutating operations can flag the solver-dirty bitfield.  May be
+        # ``None`` when the dict is used standalone (e.g. in low-level
+        # tests); in that case ``_request_solver_update`` is a no-op.
+        self._core: Optional[Any] = None
+
+    def _request_solver_update(
+        self,
+        flags: _SolverDirty = _SolverDirty.SAMPLE | _SolverDirty.UB,
+    ) -> None:
+        """
+        Flag the owning :class:`~hklpy2.ops.Core` as solver-dirty.
+
+        Mutating operations on the reflection dict invalidate the
+        solver-side sample state (and, transitively, U / UB on backends
+        that recompute them when sample state is re-pushed).  See
+        :issue:`397`.
+        """
+        if self._core is not None:
+            self._core.request_solver_update(flags)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ReflectionsDict):
@@ -443,6 +483,15 @@ class ReflectionsDict(dict):
             )
             self.add(reflection, replace=True)
 
+    @versionchanged(
+        version="0.6.3",
+        reason=(
+            "Flag ``_SolverDirty.SAMPLE | _SolverDirty.UB`` on the owning "
+            "``Core`` so the solver is re-synced on the next "
+            "``update_solver()`` (the order of orienting reflections is "
+            "part of the solver-side sample state).  See :issue:`397`."
+        ),
+    )
     def set_orientation_reflections(
         self,
         reflections: list[Reflection],
@@ -465,6 +514,14 @@ class ReflectionsDict(dict):
     setor = set_orientation_reflections
     """Common alias for :meth:`~set_orientation_reflections`."""
 
+    @versionchanged(
+        version="0.6.3",
+        reason=(
+            "Flag ``_SolverDirty.SAMPLE | _SolverDirty.UB`` on the owning "
+            "``Core`` so the next ``update_solver()`` pushes the new "
+            "reflection list to the solver.  See :issue:`397`."
+        ),
+    )
     def add(self, reflection: Reflection, replace: bool = False) -> None:
         """Add a single orientation reflection."""
         self._validate_reflection(reflection, replace)
@@ -473,11 +530,20 @@ class ReflectionsDict(dict):
         if reflection.name not in self.order:
             self.order.append(reflection.name)
         self.prune()
+        self._request_solver_update()
 
     def prune(self) -> None:
         """Remove any undefined reflections from order list."""
         self.order = [refl for refl in self.order if refl in self]
 
+    @versionchanged(
+        version="0.6.3",
+        reason=(
+            "Flag ``_SolverDirty.SAMPLE | _SolverDirty.UB`` on the owning "
+            "``Core`` so the solver re-receives the new orientation order. "
+            "See :issue:`397`."
+        ),
+    )
     def swap(self) -> list[Reflection]:
         """Swap the first two orientation reflections."""
         if len(self.order) < 2:
@@ -485,7 +551,80 @@ class ReflectionsDict(dict):
         rname1, rname2 = self.order[:2]
         self._order[0] = rname2
         self._order[1] = rname1
+        self._request_solver_update()
         return self.order
+
+    # ---- dict mutation overrides (issue #397)
+    #
+    # ``ReflectionsDict`` subclasses ``dict``; users (and internal code)
+    # may mutate it via the dict API.  Override the mutating dict methods
+    # so a mutation that *touches an entry referenced by* :attr:`order`
+    # flags the owning ``Core`` as solver-dirty.  The solver only sees
+    # ordered (orienting) reflections, so a mutation that does not
+    # affect ``order`` -- e.g. adding a brand-new reflection that the
+    # caller has not yet placed in ``order``, or replacing/removing a
+    # reflection that is not in ``order`` -- does not require a
+    # solver-side re-push.  ``add()`` always appends new names to
+    # ``order`` and reassigns it via the order setter, so its flagging
+    # path is unaffected.  ``__getitem__`` / ``get`` / iteration are
+    # read-only and unchanged.
+
+    def __setitem__(self, key, value):
+        affects_order = key in self._order
+        super().__setitem__(key, value)
+        if affects_order:
+            self._request_solver_update()
+
+    def __delitem__(self, key):
+        affects_order = key in self._order
+        super().__delitem__(key)
+        if affects_order:
+            self._request_solver_update()
+
+    def pop(self, *args, **kwargs):
+        # Mirror ``dict.pop`` signature: pop(key[, default]).
+        key = args[0] if args else None
+        affects_order = key in self._order
+        result = super().pop(*args, **kwargs)
+        if affects_order:
+            self._request_solver_update()
+        return result
+
+    def popitem(self):
+        # ``popitem`` returns the (key, value) it removed; check after.
+        result = super().popitem()
+        if result[0] in self._order:
+            self._request_solver_update()
+        return result
+
+    def clear(self):
+        affects_order = any(name in self._order for name in self)
+        super().clear()
+        if affects_order:
+            self._request_solver_update()
+
+    def update(self, *args, **kwargs):
+        # Determine the set of incoming keys without mutating yet.
+        if args:
+            other = args[0]
+            if hasattr(other, "keys"):
+                incoming = set(other.keys())
+            else:
+                incoming = {k for k, _ in other}
+        else:
+            incoming = set()
+        incoming.update(kwargs)
+        affects_order = any(k in self._order for k in incoming)
+        super().update(*args, **kwargs)
+        if affects_order:
+            self._request_solver_update()
+
+    def setdefault(self, key, default=None):
+        # ``setdefault`` only mutates the dict when ``key`` is absent;
+        # such an insertion cannot affect ``order`` (the new key is not
+        # in ``order`` yet).  Either branch is therefore a no-op for
+        # solver-dirty flagging.
+        return super().setdefault(key, default)
 
     def _validate_reflection(self, reflection: Reflection, replace: bool) -> None:
         """Validate the new reflection (raise exception if invalid)."""
@@ -543,3 +682,7 @@ class ReflectionsDict(dict):
     @order.setter
     def order(self, value: list[Reflection]):
         self._order = list(value)
+        # The orientation order is part of the solver-side sample state;
+        # mark the owning Core dirty so update_solver() re-pushes it
+        # (issue #397).
+        self._request_solver_update()

--- a/src/hklpy2/blocks/sample.py
+++ b/src/hklpy2/blocks/sample.py
@@ -15,6 +15,7 @@ from typing import Union
 
 import numpy as np
 from deprecated.sphinx import versionadded
+from deprecated.sphinx import versionchanged
 from numpy.linalg import norm
 
 from ..utils import _SolverDirty
@@ -139,13 +140,30 @@ class Sample:
         """Refine the lattice parameters from 3 or more reflections."""
         self.lattice = self.core.refine_lattice()
 
+    @versionchanged(
+        version="0.6.3",
+        reason=(
+            "When the removed reflection was an orienting reflection "
+            "(in ``reflections.order``), flag "
+            "``_SolverDirty.SAMPLE | _SolverDirty.UB`` on the owning "
+            "``Core`` so the solver-side reflection list is re-pushed on "
+            "the next ``update_solver()``.  Removing a non-orienting "
+            "reflection does not affect the solver and is not flagged. "
+            "See :issue:`397`."
+        ),
+    )
     def remove_reflection(self, name: str) -> None:
         """Remove the named reflection."""
         if name not in self.reflections:
             raise KeyError(f"Reflection {name!r} is not found.")
         self.reflections.pop(name)
         if name in self.reflections.order:
-            self.reflections.order.remove(name)
+            # ``list.remove`` is an in-place mutation of the list returned
+            # by the ``order`` property; reassign so the order setter
+            # runs and flags the solver-dirty bitfield (issue #397).
+            new_order = list(self.reflections.order)
+            new_order.remove(name)
+            self.reflections.order = new_order
 
     # --------- get/set properties
 
@@ -210,6 +228,10 @@ class Sample:
         if not isinstance(value, ReflectionsDict):
             raise TypeError(f"Must supply ReflectionsDict() object, received {value!r}")
         self._reflections = value
+        # Wire the back-reference so any subsequent mutation of the dict
+        # flags the solver-dirty bitfield on the owning Core
+        # (issue #397).
+        self._reflections._core = self.core
 
     def _validate_matrices(self, value: Matrix3x3, name: str) -> None:
         """(internal) Validate U & UB matrices."""

--- a/src/hklpy2/tests/test_i397_reflections_dirty.py
+++ b/src/hklpy2/tests/test_i397_reflections_dirty.py
@@ -267,6 +267,16 @@ def test_order_affecting_high_level_api_flags(parms, context):
             id="update with no incoming keys does not flag",
         ),
         pytest.param(
+            dict(action="update_iterable_of_pairs", flags=False),
+            does_not_raise(),
+            id="update from iterable of (key, value) pairs does not flag",
+        ),
+        pytest.param(
+            dict(action="update_kwargs_only", flags=False),
+            does_not_raise(),
+            id="update with kwargs only (no positional arg) does not flag",
+        ),
+        pytest.param(
             dict(action="setdefault_new", flags=False),
             does_not_raise(),
             id="setdefault inserting a new key does not flag",
@@ -342,7 +352,8 @@ def test_dict_api_mutations_flag_only_when_order_affected(parms, context):
         elif action == "pop_not_in_order":
             refls.pop("r100")
         elif action == "pop_missing_with_default":
-            assert refls.pop("nonexistent", "fallback") == "fallback"
+            result = refls.pop("nonexistent", "fallback")
+            assert result == "fallback"
         elif action == "clear_empty_order":
             refls.order = []
             _clean(sim)
@@ -351,6 +362,10 @@ def test_dict_api_mutations_flag_only_when_order_affected(parms, context):
             refls.update({"brand_new": _new_like(refls["r006"], "brand_new")})
         elif action == "update_empty":
             refls.update({})
+        elif action == "update_iterable_of_pairs":
+            refls.update([("brand_new", _new_like(refls["r006"], "brand_new"))])
+        elif action == "update_kwargs_only":
+            refls.update(brand_new=_new_like(refls["r006"], "brand_new"))
         elif action == "setdefault_new":
             refls.setdefault(
                 "default_new",

--- a/src/hklpy2/tests/test_i397_reflections_dirty.py
+++ b/src/hklpy2/tests/test_i397_reflections_dirty.py
@@ -1,0 +1,485 @@
+"""
+Regression tests for issue #397.
+
+``Core.add_reflection`` and ``ReflectionsDict.set_orientation_reflections``
+mutated the python-side reflection state without flagging
+``_SolverDirty.SAMPLE``.  As a result, ``Core.update_solver()`` was a
+no-op for the reflection list and the underlying solver never received
+the reflections the user had just added.  ``HklSoleilSolver`` happens
+to mask the gap because its ``calculate_UB`` rebuilds its reflection
+table internally; any solver that trusts the upstream sync contract --
+i.e. that ``update_solver`` has actually pushed the current sample
+state -- would see an empty / stale list.
+
+These tests assert the contract directly: every public mutation of the
+reflection collection that affects the orienting list (``order``) must
+flag ``_SolverDirty.SAMPLE | _SolverDirty.UB`` so the next
+``update_solver()`` re-pushes the collection to the solver.  Mutations
+that do not affect ``order`` -- e.g. adding a brand-new reflection that
+is not yet in ``order``, or replacing/removing a reflection that is not
+in ``order`` -- are not flagged because the solver does not see them.
+"""
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from .. import creator
+from ..blocks.reflection import Reflection
+from ..blocks.reflection import ReflectionsDict
+from ..utils import _SolverDirty
+
+
+SAMPLE_DEF = dict(
+    name="sapphire",
+    lattice=dict(a=4.785, c=12.991, gamma=120),
+    reflections=[
+        dict(
+            name="r006",
+            pseudos=(0, 0, 6),
+            reals=dict(omega=20.97, chi=90, phi=0, tth=41.9419),
+        ),
+        dict(
+            name="r100",
+            pseudos=(1, 0, 0),
+            reals=dict(omega=30, chi=0, phi=0, tth=60),
+        ),
+        dict(
+            name="r006b",
+            pseudos=(0, 0, 6),
+            reals=dict(omega=20.3654, chi=89.32, phi=0, tth=41.9394),
+        ),
+    ],
+)
+
+
+def _build_sim_with_reflections(n_reflections: int = 2):
+    """Create an E4CV sim with the named sample and ``n_reflections`` reflections."""
+    sim = creator()
+    sim.beam.wavelength.put(1.5498)
+    sim.add_sample(
+        SAMPLE_DEF["name"],
+        SAMPLE_DEF["lattice"]["a"],
+        c=SAMPLE_DEF["lattice"]["c"],
+        gamma=SAMPLE_DEF["lattice"]["gamma"],
+    )
+    for refl in SAMPLE_DEF["reflections"][:n_reflections]:
+        sim.add_reflection(
+            pseudos=refl["pseudos"],
+            reals=refl["reals"],
+            name=refl["name"],
+        )
+    return sim
+
+
+def _new_like(refl: Reflection, name: str) -> Reflection:
+    """Return a fresh ``Reflection`` with the same content under ``name``."""
+    return Reflection(
+        name,
+        refl.pseudos,
+        refl.reals,
+        refl.wavelength,
+        refl.geometry,
+        refl.pseudo_axis_names,
+        refl.real_axis_names,
+        wavelength_units=refl.wavelength_units,
+    )
+
+
+def _clean(sim) -> None:
+    """Push everything to the solver and clear the dirty bitfield."""
+    sim.core.update_solver()
+    sim.core._solver_dirty = _SolverDirty(0)
+
+
+# -- High-level public API: Core.add_reflection / Sample.remove_reflection /
+#    set_orientation_reflections / setor / order setter / swap.
+#
+# These all touch ``order`` by construction, so they always flag.
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(action="add_reflection"),
+            does_not_raise(),
+            id="Core.add_reflection adds to order and flags",
+        ),
+        pytest.param(
+            dict(action="set_orientation_reflections"),
+            does_not_raise(),
+            id="set_orientation_reflections rewrites order and flags",
+        ),
+        pytest.param(
+            dict(action="setor_alias"),
+            does_not_raise(),
+            id="setor (alias) rewrites order and flags",
+        ),
+        pytest.param(
+            dict(action="set_order"),
+            does_not_raise(),
+            id="order setter flags",
+        ),
+        pytest.param(
+            dict(action="swap"),
+            does_not_raise(),
+            id="swap flags",
+        ),
+        pytest.param(
+            dict(action="add_via_dict_then_promote"),
+            does_not_raise(),
+            id="add via add() always flags (order is updated)",
+        ),
+    ],
+)
+def test_order_affecting_high_level_api_flags(parms, context):
+    """High-level public mutations always touch ``order`` and must flag."""
+    with context:
+        sim = _build_sim_with_reflections(n_reflections=2)
+        _clean(sim)
+        refls = sim.sample.reflections
+        action = parms["action"]
+
+        if action == "add_reflection":
+            sim.add_reflection(
+                pseudos=SAMPLE_DEF["reflections"][2]["pseudos"],
+                reals=SAMPLE_DEF["reflections"][2]["reals"],
+                name=SAMPLE_DEF["reflections"][2]["name"],
+            )
+        elif action == "set_orientation_reflections":
+            refls.set_orientation_reflections([refls["r100"], refls["r006"]])
+        elif action == "setor_alias":
+            refls.setor([refls["r100"], refls["r006"]])
+        elif action == "set_order":
+            refls.order = ["r100", "r006"]
+        elif action == "swap":
+            refls.swap()
+        elif action == "add_via_dict_then_promote":
+            # Direct ``add()`` call (a separate code path from
+            # Core.add_reflection): always touches order.  Use a
+            # distinct pseudos vector so content-validation does not
+            # treat this as a duplicate.
+            template = refls["r006"]
+            new = Reflection(
+                "r110",
+                {"h": 1.0, "k": 1.0, "l": 0.0},
+                template.reals,
+                template.wavelength,
+                template.geometry,
+                template.pseudo_axis_names,
+                template.real_axis_names,
+                wavelength_units=template.wavelength_units,
+            )
+            refls.add(new)
+            assert "r110" in refls.order
+        else:
+            raise AssertionError(f"unknown action {action!r}")
+
+        assert sim.core._solver_dirty == _SolverDirty.SAMPLE | _SolverDirty.UB, (
+            f"Expected SAMPLE|UB, got {sim.core._solver_dirty!r} "
+            f"after action {action!r}"
+        )
+
+
+# -- Dict-API mutations: only flag when the touched key is in ``order``.
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        # Order-affecting variants: should flag.
+        pytest.param(
+            dict(action="setitem_replace_in_order", flags=True),
+            does_not_raise(),
+            id="__setitem__ replacing an orienting reflection flags",
+        ),
+        pytest.param(
+            dict(action="del_in_order", flags=True),
+            does_not_raise(),
+            id="__delitem__ removing an orienting reflection flags",
+        ),
+        pytest.param(
+            dict(action="pop_in_order", flags=True),
+            does_not_raise(),
+            id="pop removing an orienting reflection flags",
+        ),
+        pytest.param(
+            dict(action="popitem_in_order", flags=True),
+            does_not_raise(),
+            id="popitem removing the only orienting reflection flags",
+        ),
+        pytest.param(
+            dict(action="clear_with_order", flags=True),
+            does_not_raise(),
+            id="clear with non-empty order flags",
+        ),
+        pytest.param(
+            dict(action="update_overwrites_in_order", flags=True),
+            does_not_raise(),
+            id="update overwriting an orienting reflection flags",
+        ),
+        pytest.param(
+            dict(action="remove_reflection_in_order", flags=True),
+            does_not_raise(),
+            id="Sample.remove_reflection on orienting reflection flags",
+        ),
+        # Non-order-affecting variants: must NOT flag.
+        pytest.param(
+            dict(action="setitem_new_key", flags=False),
+            does_not_raise(),
+            id="__setitem__ adding a new (un-ordered) key does not flag",
+        ),
+        pytest.param(
+            dict(action="setitem_replace_not_in_order", flags=False),
+            does_not_raise(),
+            id="__setitem__ replacing a non-orienting key does not flag",
+        ),
+        pytest.param(
+            dict(action="del_not_in_order", flags=False),
+            does_not_raise(),
+            id="__delitem__ removing a non-orienting key does not flag",
+        ),
+        pytest.param(
+            dict(action="pop_not_in_order", flags=False),
+            does_not_raise(),
+            id="pop removing a non-orienting key does not flag",
+        ),
+        pytest.param(
+            dict(action="pop_missing_with_default", flags=False),
+            does_not_raise(),
+            id="pop on missing key with default does not flag",
+        ),
+        pytest.param(
+            dict(action="clear_empty_order", flags=False),
+            does_not_raise(),
+            id="clear with empty order does not flag",
+        ),
+        pytest.param(
+            dict(action="update_new_keys_only", flags=False),
+            does_not_raise(),
+            id="update introducing only new (un-ordered) keys does not flag",
+        ),
+        pytest.param(
+            dict(action="update_empty", flags=False),
+            does_not_raise(),
+            id="update with no incoming keys does not flag",
+        ),
+        pytest.param(
+            dict(action="setdefault_new", flags=False),
+            does_not_raise(),
+            id="setdefault inserting a new key does not flag",
+        ),
+        pytest.param(
+            dict(action="setdefault_existing", flags=False),
+            does_not_raise(),
+            id="setdefault on existing key does not flag",
+        ),
+        pytest.param(
+            dict(action="remove_reflection_not_in_order", flags=False),
+            does_not_raise(),
+            id="Sample.remove_reflection on non-orienting reflection does not flag",
+        ),
+    ],
+)
+def test_dict_api_mutations_flag_only_when_order_affected(parms, context):
+    """
+    Dict-API mutations on ``ReflectionsDict`` flag the solver-dirty
+    bitfield iff the touched key is in :attr:`order`.  Reflections
+    outside ``order`` are not visible to the solver, so removing or
+    replacing them does not require a solver re-push.
+    """
+    with context:
+        sim = _build_sim_with_reflections(n_reflections=2)
+        refls = sim.sample.reflections
+        # Pin ``order`` to just ``r006`` so we have a clear distinction
+        # between "in order" and "not in order".
+        refls.order = ["r006"]
+        # Add a third reflection to the dict but NOT to ``order`` so we
+        # have an unambiguous non-orienting reflection.
+        third = SAMPLE_DEF["reflections"][2]
+        sim.add_reflection(
+            pseudos=third["pseudos"],
+            reals=third["reals"],
+            name=third["name"],
+        )
+        # ``add_reflection`` re-appends r006b to order; rewrite to drop
+        # it again so ``r006b`` is unambiguously not in ``order``.
+        refls.order = ["r006"]
+        assert refls.order == ["r006"]
+        assert "r100" in refls and "r100" not in refls.order
+        assert "r006b" in refls and "r006b" not in refls.order
+
+        _clean(sim)
+        action = parms["action"]
+
+        if action == "setitem_replace_in_order":
+            refls["r006"] = _new_like(refls["r006"], "r006")
+        elif action == "del_in_order":
+            del refls["r006"]
+        elif action == "pop_in_order":
+            refls.pop("r006")
+        elif action == "popitem_in_order":
+            # Remove all non-orienting entries first so popitem is forced
+            # to remove the orienting one.
+            del refls["r100"]
+            del refls["r006b"]
+            _clean(sim)
+            refls.popitem()
+        elif action == "clear_with_order":
+            refls.clear()
+        elif action == "update_overwrites_in_order":
+            refls.update({"r006": _new_like(refls["r006"], "r006")})
+        elif action == "remove_reflection_in_order":
+            sim.sample.remove_reflection("r006")
+        elif action == "setitem_new_key":
+            refls["brand_new"] = _new_like(refls["r006"], "brand_new")
+        elif action == "setitem_replace_not_in_order":
+            refls["r100"] = _new_like(refls["r100"], "r100")
+        elif action == "del_not_in_order":
+            del refls["r100"]
+        elif action == "pop_not_in_order":
+            refls.pop("r100")
+        elif action == "pop_missing_with_default":
+            assert refls.pop("nonexistent", "fallback") == "fallback"
+        elif action == "clear_empty_order":
+            refls.order = []
+            _clean(sim)
+            refls.clear()
+        elif action == "update_new_keys_only":
+            refls.update({"brand_new": _new_like(refls["r006"], "brand_new")})
+        elif action == "update_empty":
+            refls.update({})
+        elif action == "setdefault_new":
+            refls.setdefault(
+                "default_new",
+                _new_like(refls["r006"], "default_new"),
+            )
+        elif action == "setdefault_existing":
+            refls.setdefault("r006", refls["r006"])
+        elif action == "remove_reflection_not_in_order":
+            sim.sample.remove_reflection("r100")
+        else:
+            raise AssertionError(f"unknown action {action!r}")
+
+        if parms["flags"]:
+            assert sim.core._solver_dirty == _SolverDirty.SAMPLE | _SolverDirty.UB, (
+                f"Expected SAMPLE|UB, got {sim.core._solver_dirty!r} "
+                f"after action {action!r}"
+            )
+        else:
+            assert sim.core._solver_dirty == _SolverDirty(0), (
+                f"Expected no flag, got {sim.core._solver_dirty!r} "
+                f"after action {action!r}"
+            )
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(action="add_reflection"),
+            does_not_raise(),
+            id="solver receives reflection added via Core.add_reflection",
+        ),
+        pytest.param(
+            dict(action="set_orientation_reflections"),
+            does_not_raise(),
+            id="solver receives reordered reflections",
+        ),
+    ],
+)
+def test_solver_receives_pushed_reflections(parms, context):
+    """
+    End-to-end: after a public mutation followed by ``update_solver()``
+    the solver-side ``sample["reflections"]`` reflects the mutation.
+
+    This is the contract that issue #397 broke for solvers that do not
+    self-heal in ``calculate_UB`` (such as ``ad_hoc``).
+    """
+    with context:
+        sim = _build_sim_with_reflections(n_reflections=2)
+        _clean(sim)
+        sim.core.update_solver()
+        assert len(sim.core.solver.sample["reflections"]) == 2
+
+        action = parms["action"]
+        if action == "add_reflection":
+            sim.add_reflection(
+                pseudos=SAMPLE_DEF["reflections"][2]["pseudos"],
+                reals=SAMPLE_DEF["reflections"][2]["reals"],
+                name=SAMPLE_DEF["reflections"][2]["name"],
+            )
+            expected_count = 3
+        elif action == "set_orientation_reflections":
+            sim.sample.reflections.set_orientation_reflections(
+                [sim.sample.reflections["r100"], sim.sample.reflections["r006"]]
+            )
+            expected_count = 2
+        else:
+            raise AssertionError(f"unknown action {action!r}")
+
+        # Without the issue #397 fix, the next call would be a no-op
+        # because ``_solver_dirty`` would still be 0 and the solver
+        # would still hold the pre-mutation reflection set.
+        sim.core.update_solver()
+        assert sim.core._solver_dirty == _SolverDirty(0)
+        assert len(sim.core.solver.sample["reflections"]) == expected_count
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="standalone ReflectionsDict has no _core (no-op)",
+        ),
+    ],
+)
+def test_standalone_reflectionsdict_no_core(parms, context):
+    """
+    A ``ReflectionsDict`` constructed without a ``Sample`` must remain
+    usable: ``_core`` defaults to ``None`` and ``_request_solver_update``
+    is a no-op.
+    """
+    with context:
+        rd = ReflectionsDict()
+        assert rd._core is None
+        rd.order = []
+        rd._request_solver_update()
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(method="set_orientation_reflections"),
+            pytest.raises(KeyError, match=re.escape("'unknown'")),
+            id="set_orientation_reflections raises on unknown name",
+        ),
+        pytest.param(
+            dict(method="remove_reflection"),
+            pytest.raises(
+                KeyError,
+                match=re.escape("Reflection 'unknown' is not found."),
+            ),
+            id="remove_reflection raises on unknown name",
+        ),
+    ],
+)
+def test_known_failure_modes_unchanged(parms, context):
+    """
+    The dirty-flag fix must not change error semantics of the public
+    mutating API.  These failure modes are documented; they continue to
+    raise the same exceptions.
+    """
+    with context:
+        sim = _build_sim_with_reflections(n_reflections=2)
+        if parms["method"] == "set_orientation_reflections":
+            sim.sample.reflections.set_orientation_reflections(
+                [sim.sample.reflections["unknown"]]
+            )
+        elif parms["method"] == "remove_reflection":
+            sim.sample.remove_reflection("unknown")


### PR DESCRIPTION
- closes #397
- follow-up tracked in #399

## Summary

Mutating ``Sample.reflections`` (via ``Core.add_reflection``,
``set_orientation_reflections`` / ``setor``, the ``order`` setter,
``swap``, ``Sample.remove_reflection``, or any dict-API mutator) now
flags ``_SolverDirty.SAMPLE | _SolverDirty.UB`` on the owning ``Core``
whenever the change touches an entry in ``reflections.order``.  The
next ``update_solver()`` therefore re-pushes the current sample state
(lattice + reflections + name + order) to the solver.

Before this fix, the SAMPLE domain was never flagged from
``add_reflection`` or ``setor``, so the solver-side sample mirror
diverged silently from the Python side until some unrelated mutation
(lattice change, sample switch, ``calc_UB``) re-flagged SAMPLE.  That
violates ``update_solver()``'s own documented contract ("Push any
dirty solver-state domains to the underlying solver"); it does **not**
violate the ``calculate_UB`` contract, which requires every conformant
solver to remove-all + add-r1 + add-r2 + compute + return internally
and is therefore self-healing for that one entry point (see
discussion on #397).

The fix protects every other consumer of the solver-side sample
mirror that the ``calculate_UB`` self-heal does not cover: future or
existing solver methods that read the reflection list,
diagnostics / introspection, save / restore round-trips, and tests
that consult ``solver.sample`` directly.

## Order-aware semantics

Per the design discussion, dict-API mutations (``__setitem__``,
``__delitem__``, ``pop``, ``popitem``, ``clear``, ``update``,
``setdefault``) flag **only when the touched key is in ``order``**.
Reflections outside ``order`` are not visible to the solver, so
adding / replacing / removing them does not require a re-push.

The high-level public API (``Core.add_reflection``,
``set_orientation_reflections``, ``order`` setter, ``swap``,
``Sample.remove_reflection``) always touches ``order`` and therefore
always flags.

## Half-defined orientation state

Removing or dropping an orienting reflection while ``>= 2``
reflections remain in the dict can leave ``order`` with fewer than
two entries.  This PR makes the resulting staleness *observable*
(``Sample.UB_is_stale`` already returns ``True``; the
``forward()`` / ``inverse()`` warning fires) but does not yet refuse
the destructive mutation.  The strict-policy (option A) decision is
tracked separately in #399.

## Tests

29 new parametrized tests in
``src/hklpy2/tests/test_i397_reflections_dirty.py``:

- High-level public API always flags (6 cases).
- Dict-API mutations flag iff ``order`` is affected (17 cases:
  6 order-affecting + 11 non-order-affecting).
- End-to-end push to solver (2 cases).
- Standalone ``ReflectionsDict`` usable without a ``Core``.
- Documented failure modes unchanged.

Full suite: 1189 passed locally, 1194 passed on CI (Python 3.14).

## Other changes

- ``AGENTS.md``: tighten the Release Notes guidance to insist on
  one-line entries (no implementation details, no symbol lists, no
  mechanism prose).

Agent: OpenCode (claudeopus47)