### PR TITLE
feat #399 strict refusal of half-defined orientation transitions

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -30,10 +30,15 @@ describe future plans.
 
     Release expected 2026-Q3.
 
-0.6.3
+0.7.0
 #####
 
-Bug fix release.
+Bug fixes plus a behavior change to orientation-reflection management.
+
+Breaking Changes
+----------------
+
+* Refuse mutations that would leave the sample half-defined. (:issue:`399`)
 
 Fixes
 -----

--- a/src/hklpy2/blocks/reflection.py
+++ b/src/hklpy2/blocks/reflection.py
@@ -13,7 +13,9 @@ Associates diffractometer angles (real-space) with crystalline reciprocal-space
 """
 
 import logging
+from contextlib import contextmanager
 from typing import Any
+from typing import Iterable
 from typing import Mapping
 from typing import Optional
 from typing import Union
@@ -390,7 +392,7 @@ class ReflectionsDict(dict):
         ~setor
         ~swap
 
-    .. versionchanged:: 0.6.3
+    .. versionchanged:: 0.7.0
        Mutating operations now flag the owning
        :class:`~hklpy2.ops.Core` with
        ``_SolverDirty.SAMPLE | _SolverDirty.UB`` whenever the change
@@ -402,18 +404,35 @@ class ReflectionsDict(dict):
        ``update``, ``popitem``) that touches an ordered name.
        Previously these mutations left the solver with a stale
        reflection list.  See :issue:`397`.
+
+    .. versionchanged:: 0.7.0
+       Mutations that would leave the sample *half-defined* (two or
+       more reflections still in the dict, but fewer than two named
+       in :attr:`order`) now raise :class:`~hklpy2.exceptions.ReflectionError`.
+       The user must explicitly designate the new orienting pair (via
+       :meth:`set_orientation_reflections` or by assigning :attr:`order`)
+       **before** removing the current one, or remove non-orienting
+       reflections first so the sample falls below the orientation
+       threshold.  See :issue:`399`.
     """
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._order = []
         self.geometry = None
+
         # Back-reference to the owning ``Core``.  Wired by
         # :class:`~hklpy2.blocks.sample.Sample` after construction so that
         # mutating operations can flag the solver-dirty bitfield.  May be
         # ``None`` when the dict is used standalone (e.g. in low-level
         # tests); in that case ``_request_solver_update`` is a no-op.
         self._core: Optional[Any] = None
+
+        # Re-entrancy counter for the strict orientation-health check
+        # (issue #399).  Incremented while inside multi-step internal
+        # operations (``add``, ``_fromdict``) that legitimately
+        # traverse intermediate states which would otherwise raise.
+        self._strict_check_suspended: int = 0
 
     def _request_solver_update(
         self,
@@ -429,6 +448,68 @@ class ReflectionsDict(dict):
         """
         if self._core is not None:
             self._core.request_solver_update(flags)
+
+    @contextmanager
+    def _suspend_strict_check(self):
+        """
+        Suspend :meth:`_check_strict_order_health` for the duration of
+        a multi-step internal operation (issue #399).
+        """
+        self._strict_check_suspended += 1
+        try:
+            yield
+        finally:
+            self._strict_check_suspended -= 1
+
+    def _check_strict_order_health(
+        self,
+        prospective_order: Iterable[str],
+        prospective_keys: Iterable[str],
+    ) -> None:
+        """
+        Refuse mutations that would leave the sample half-defined.
+
+        A sample is *half-defined* when the dict still holds two or
+        more reflections but :attr:`order` -- restricted to names that
+        actually exist in the dict -- has fewer than two entries.  In
+        that state ``calc_UB`` cannot be repeated and the previously
+        computed UB silently references a no-longer-orienting pair.
+
+        The strict policy refuses such mutations at the source so the
+        user explicitly designates the new orienting pair (via
+        :meth:`set_orientation_reflections` or by assigning
+        :attr:`order`) before removing the current one, or removes
+        non-orienting reflections first so the sample falls below the
+        orientation threshold.  See :issue:`399`.
+
+        Parameters
+        ----------
+        prospective_order : Iterable[str]
+            The proposed value of :attr:`order` after the pending
+            mutation.
+        prospective_keys : Iterable[str]
+            The proposed set of dict keys after the pending mutation.
+
+        Raises
+        ------
+        ReflectionError
+            If the post-mutation state would be half-defined.
+        """
+        if self._strict_check_suspended:
+            return
+        prospective_keys = set(prospective_keys)
+        prospective_order = list(prospective_order)
+        effective = [n for n in prospective_order if n in prospective_keys]
+        if len(prospective_keys) >= 2 and len(effective) < 2:
+            raise ReflectionError(
+                "Refusing to leave the sample half-defined: the pending"
+                f" mutation would leave {len(effective)} orientation"
+                f" reflection(s) in `order` while {len(prospective_keys)}"
+                " reflections remain in the sample.  UB requires two"
+                " orientation reflections.  Designate a new orienting"
+                " pair first (`reflections.set_orientation_reflections("
+                "[r1, r2])` or `reflections.order = [...]`)."
+            )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ReflectionsDict):
@@ -449,7 +530,7 @@ class ReflectionsDict(dict):
         return {v.name: v._asdict() for v in self.values()}
 
     @versionchanged(
-        version="0.6.3",
+        version="0.7.0",
         reason=(
             "Re-key restored reflections by the diffractometer's local "
             "real-axis names instead of the solver's canonical names, "
@@ -467,40 +548,53 @@ class ReflectionsDict(dict):
         """Add or redefine reflections from a (configuration) dictionary."""
         from ..ops import Core
 
-        for refl_config in config.values():
-            if isinstance(core, Core):
-                # Remap the names of all the real axes to the current solver.
-                # Real axes MUST be specified in the order specified by the solver.
-                refl_config["reals"] = {
-                    axis: value
-                    for axis, value in zip(
-                        # core.solver.real_axis_names,
-                        core.diffractometer.real_axis_names,
-                        refl_config["reals"].values(),
-                    )
-                }
+        # Restoring reflections is a multi-step internal operation that
+        # legitimately traverses intermediate states which would
+        # otherwise trip the strict orientation-health check (#399).
+        with self._suspend_strict_check():
+            for refl_config in config.values():
+                if isinstance(core, Core):
+                    # Remap the names of all the real axes to the current solver.
+                    # Real axes MUST be specified in the order specified by the solver.
+                    refl_config["reals"] = {
+                        axis: value
+                        for axis, value in zip(
+                            # core.solver.real_axis_names,
+                            core.diffractometer.real_axis_names,
+                            refl_config["reals"].values(),
+                        )
+                    }
 
-            reflection = Reflection(
-                refl_config["name"],
-                refl_config["pseudos"],
-                refl_config["reals"],
-                wavelength=refl_config["wavelength"],
-                wavelength_units=refl_config.get("wavelength_units"),
-                geometry=refl_config["geometry"],
-                pseudo_axis_names=list(refl_config["pseudos"]),
-                real_axis_names=list(refl_config["reals"]),
-                digits=refl_config.get("digits"),
-                core=core,
-            )
-            self.add(reflection, replace=True)
+                reflection = Reflection(
+                    refl_config["name"],
+                    refl_config["pseudos"],
+                    refl_config["reals"],
+                    wavelength=refl_config["wavelength"],
+                    wavelength_units=refl_config.get("wavelength_units"),
+                    geometry=refl_config["geometry"],
+                    pseudo_axis_names=list(refl_config["pseudos"]),
+                    real_axis_names=list(refl_config["reals"]),
+                    digits=refl_config.get("digits"),
+                    core=core,
+                )
+                self.add(reflection, replace=True)
 
     @versionchanged(
-        version="0.6.3",
+        version="0.7.0",
         reason=(
             "Flag ``_SolverDirty.SAMPLE | _SolverDirty.UB`` on the owning "
             "``Core`` so the solver is re-synced on the next "
             "``update_solver()`` (the order of orienting reflections is "
             "part of the solver-side sample state).  See :issue:`397`."
+        ),
+    )
+    @versionchanged(
+        version="0.7.0",
+        reason=(
+            "Refuse to designate an orienting list that would leave the "
+            "sample half-defined (fewer than two orientation reflections "
+            "while two or more reflections remain in the sample); raises "
+            "``ReflectionError``.  See :issue:`399`."
         ),
     )
     def set_orientation_reflections(
@@ -526,7 +620,7 @@ class ReflectionsDict(dict):
     """Common alias for :meth:`~set_orientation_reflections`."""
 
     @versionchanged(
-        version="0.6.3",
+        version="0.7.0",
         reason=(
             "Flag ``_SolverDirty.SAMPLE | _SolverDirty.UB`` on the owning "
             "``Core`` so the next ``update_solver()`` pushes the new "
@@ -535,20 +629,28 @@ class ReflectionsDict(dict):
     )
     def add(self, reflection: Reflection, replace: bool = False) -> None:
         """Add a single orientation reflection."""
-        self._validate_reflection(reflection, replace)
+        # ``add`` is a multi-step operation: ``_validate_reflection``
+        # may pop a duplicate, ``__setitem__`` then inserts, and
+        # ``prune`` rewrites ``order``.  Each individual step could
+        # transiently look half-defined (#399); suspend the strict
+        # check for the whole sequence and let the final post-state
+        # speak for itself (the new reflection is always appended to
+        # ``order``, so the post-state cannot be half-defined).
+        with self._suspend_strict_check():
+            self._validate_reflection(reflection, replace)
 
-        self[reflection.name] = reflection
-        if reflection.name not in self.order:
-            self.order.append(reflection.name)
-        self.prune()
-        self._request_solver_update()
+            self[reflection.name] = reflection
+            if reflection.name not in self.order:
+                self.order.append(reflection.name)
+            self.prune()
+            self._request_solver_update()
 
     def prune(self) -> None:
         """Remove any undefined reflections from order list."""
         self.order = [refl for refl in self.order if refl in self]
 
     @versionchanged(
-        version="0.6.3",
+        version="0.7.0",
         reason=(
             "Flag ``_SolverDirty.SAMPLE | _SolverDirty.UB`` on the owning "
             "``Core`` so the solver re-receives the new orientation order. "
@@ -581,12 +683,19 @@ class ReflectionsDict(dict):
     # read-only and unchanged.
 
     def __setitem__(self, key, value):
+        # ``__setitem__`` either replaces an existing entry or adds a
+        # new one; neither shrinks the dict or ``order``.  The strict
+        # check (#399) cannot be tripped, but include it for symmetry.
+        prospective_keys = set(self) | {key}
+        self._check_strict_order_health(self._order, prospective_keys)
         affects_order = key in self._order
         super().__setitem__(key, value)
         if affects_order:
             self._request_solver_update()
 
     def __delitem__(self, key):
+        prospective_keys = set(self) - {key}
+        self._check_strict_order_health(self._order, prospective_keys)
         affects_order = key in self._order
         super().__delitem__(key)
         if affects_order:
@@ -595,6 +704,9 @@ class ReflectionsDict(dict):
     def pop(self, *args, **kwargs):
         # Mirror ``dict.pop`` signature: pop(key[, default]).
         key = args[0] if args else None
+        if key in self:
+            prospective_keys = set(self) - {key}
+            self._check_strict_order_health(self._order, prospective_keys)
         affects_order = key in self._order
         result = super().pop(*args, **kwargs)
         if affects_order:
@@ -602,20 +714,33 @@ class ReflectionsDict(dict):
         return result
 
     def popitem(self):
-        # ``popitem`` returns the (key, value) it removed; check after.
+        # ``dict.popitem`` removes the last-inserted entry (CPython
+        # 3.7+).  Peek the prospective key so the strict check can
+        # run before the mutation.  When the dict is empty,
+        # ``super().popitem()`` raises ``KeyError`` and the strict
+        # check is unreachable.
+        if len(self) > 0:
+            popped_key = next(reversed(self))
+            prospective_keys = set(self) - {popped_key}
+            self._check_strict_order_health(self._order, prospective_keys)
         result = super().popitem()
         if result[0] in self._order:
             self._request_solver_update()
         return result
 
     def clear(self):
+        # ``clear`` always leaves the dict empty, so the post-state is
+        # never half-defined; the strict check is a no-op here.
         affects_order = any(name in self._order for name in self)
         super().clear()
         if affects_order:
             self._request_solver_update()
 
     def update(self, *args, **kwargs):
-        # Determine the set of incoming keys without mutating yet.
+        # ``update`` only inserts or replaces keys, never deletes; the
+        # post-state cannot be half-defined when starting from a
+        # well-defined state.  The strict check is included for
+        # symmetry but will not fire in normal use.
         if args:
             other = args[0]
             if hasattr(other, "keys"):
@@ -625,6 +750,8 @@ class ReflectionsDict(dict):
         else:
             incoming = set()
         incoming.update(kwargs)
+        prospective_keys = set(self) | incoming
+        self._check_strict_order_health(self._order, prospective_keys)
         affects_order = any(k in self._order for k in incoming)
         super().update(*args, **kwargs)
         if affects_order:
@@ -692,7 +819,9 @@ class ReflectionsDict(dict):
 
     @order.setter
     def order(self, value: list[Reflection]):
-        self._order = list(value)
+        new_order = list(value)
+        self._check_strict_order_health(new_order, set(self))
+        self._order = new_order
         # The orientation order is part of the solver-side sample state;
         # mark the owning Core dirty so update_solver() re-pushes it
         # (issue #397).

--- a/src/hklpy2/blocks/sample.py
+++ b/src/hklpy2/blocks/sample.py
@@ -141,7 +141,7 @@ class Sample:
         self.lattice = self.core.refine_lattice()
 
     @versionchanged(
-        version="0.6.3",
+        version="0.7.0",
         reason=(
             "When the removed reflection was an orienting reflection "
             "(in ``reflections.order``), flag "
@@ -150,6 +150,16 @@ class Sample:
             "the next ``update_solver()``.  Removing a non-orienting "
             "reflection does not affect the solver and is not flagged. "
             "See :issue:`397`."
+        ),
+    )
+    @versionchanged(
+        version="0.7.0",
+        reason=(
+            "Refuse to remove an orienting reflection when doing so "
+            "would leave the sample half-defined (fewer than two "
+            "orientation reflections while two or more reflections "
+            "remain in the sample); raises ``ReflectionError``.  See "
+            ":issue:`399`."
         ),
     )
     def remove_reflection(self, name: str) -> None:

--- a/src/hklpy2/blocks/tests/test_reflection.py
+++ b/src/hklpy2/blocks/tests/test_reflection.py
@@ -287,17 +287,22 @@ def test_ReflectionsDict(parms, representation, context, expected):
             assert len(db.order) == i
 
             r1 = list(db.values())[0]
-            db.setor([r1])
-            assert len(db._asdict()) == i  # unchanged
-            assert len(db.order) == 1
+            # Strict orientation-health check (#399) refuses to leave
+            # ``order`` shorter than two while ``len(db) >= 2``; only
+            # exercise the single-element ``setor`` / ``order`` paths
+            # when the dict is below the orientation threshold.
+            if i < 2:
+                db.setor([r1])
+                assert len(db._asdict()) == i  # unchanged
+                assert len(db.order) == 1
 
-            db.set_orientation_reflections([r1])
-            assert len(db._asdict()) == i  # unchanged
-            assert len(db.order) == 1
+                db.set_orientation_reflections([r1])
+                assert len(db._asdict()) == i  # unchanged
+                assert len(db.order) == 1
 
-            db.order = [r1.name]
-            assert len(db._asdict()) == i  # unchanged
-            assert len(db.order) == 1
+                db.order = [r1.name]
+                assert len(db._asdict()) == i  # unchanged
+                assert len(db.order) == 1
 
         assert representation in repr(db)
 
@@ -402,9 +407,14 @@ def test_duplicate_reflection(reflection, context):
     [
         pytest.param([r_1, r_4, r_5], ["r1", "r4"], does_not_raise(), id="swap-r1-r4"),
         pytest.param([r_1, r_4, r_5], ["r5", "r4"], does_not_raise(), id="swap-r5-r4"),
+        # The strict orientation-health check (#399) blocks setting
+        # ``order`` to fewer than two entries while two or more
+        # reflections remain in the dict, so swap()'s "need two
+        # reflections" error path is reached only with a dict that has
+        # fewer than two entries.
         pytest.param(
-            [r_1, r_4, r_5],
-            ["r5"],
+            [r_1],
+            ["r1"],
             pytest.raises(
                 ReflectionError,
                 match=re.escape("Need at least two reflections to swap."),
@@ -412,7 +422,7 @@ def test_duplicate_reflection(reflection, context):
             id="swap-single-reflection-error",
         ),
         pytest.param(
-            [r_1, r_4, r_5],
+            [],
             [],
             pytest.raises(
                 ReflectionError,

--- a/src/hklpy2/blocks/tests/test_sample.py
+++ b/src/hklpy2/blocks/tests/test_sample.py
@@ -4,7 +4,7 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from ...diffract import creator
-from ...exceptions import CoreError
+from ...exceptions import ReflectionError
 from ...utils import IDENTITY_MATRIX_3X3
 from ...utils import load_yaml
 from ...utils import unique_name
@@ -235,7 +235,19 @@ def test_fromdict():
     "remove, context",
     [
         pytest.param(None, does_not_raise(), id="all-reflections"),
-        pytest.param("r004", pytest.raises(CoreError), id="remove-r004"),
+        # ``r004`` is one of the orienting reflections (calc_UB used
+        # r040 + r004 in the helper).  Under the strict
+        # orientation-health check (#399), popping it while two
+        # reflections remain in the sample is refused with a
+        # ``ReflectionError`` before ``refine_lattice`` is reached.
+        pytest.param(
+            "r004",
+            pytest.raises(
+                ReflectionError,
+                match=re.escape("Refusing to leave the sample half-defined"),
+            ),
+            id="remove-r004",
+        ),
         pytest.param("wrong", pytest.raises(KeyError), id="remove-nonexistent"),
     ],
 )
@@ -251,7 +263,20 @@ def test_refine_lattice(remove, context):
 @pytest.mark.parametrize(
     "rname, context",
     [
-        pytest.param("r400", does_not_raise(), id="existing-reflection"),
+        # ``r004`` is the non-orienting reflection (calc_UB below uses
+        # r040 + r400), so removing it is permitted by the strict
+        # orientation-health check (#399).
+        pytest.param("r004", does_not_raise(), id="existing-non-orienting-reflection"),
+        # Removing an orienting reflection while two or more remain is
+        # refused under the strict policy (#399).
+        pytest.param(
+            "r400",
+            pytest.raises(
+                ReflectionError,
+                match=re.escape("Refusing to leave the sample half-defined"),
+            ),
+            id="orienting-reflection-refused",
+        ),
         pytest.param(
             "r1",
             pytest.raises(KeyError, match=re.escape("Reflection 'r1' is not found")),

--- a/src/hklpy2/blocks/tests/test_ub_staleness.py
+++ b/src/hklpy2/blocks/tests/test_ub_staleness.py
@@ -62,7 +62,13 @@ def _setup_initial(action: str):
     elif action == "remove_non_orienting":
         sample.remove_reflection("r400")
     elif action == "remove_order_zero":
-        sample.remove_reflection(refls.order[0])
+        # Removing an orienting reflection while two or more remain is
+        # normally refused under the strict orientation-health check
+        # (#399).  This test deliberately constructs the half-defined
+        # state to verify that ``Sample.UB_is_stale`` reports it; the
+        # strict check is suspended for the setup only.
+        with refls._suspend_strict_check():
+            sample.remove_reflection(refls.order[0])
     elif action == "mutate_orienting_pseudos":
         first = refls[refls.order[0]]
         # Bump h by 1 to force a content change (any change suffices).
@@ -303,8 +309,12 @@ def test_compute_snapshot_with_missing_order_name(parms, context):
     with context:
         e4cv = _oriented_e4cv()
         # Bypass remove_reflection (which would also clean up ``order``) by
-        # popping directly from the underlying dict.
-        e4cv.sample.reflections.pop(e4cv.sample.reflections.order[0])
+        # popping directly from the underlying dict.  The strict
+        # orientation-health check (#399) refuses this transition
+        # under normal use; suspend it for the setup so the defensive
+        # snapshot path can be exercised.
+        with e4cv.sample.reflections._suspend_strict_check():
+            e4cv.sample.reflections.pop(e4cv.sample.reflections.order[0])
         # ``order`` still references the popped name; the snapshot must
         # gracefully return None instead of raising KeyError.
         assert e4cv.sample._compute_ub_snapshot() is None

--- a/src/hklpy2/tests/test_i397_reflections_dirty.py
+++ b/src/hklpy2/tests/test_i397_reflections_dirty.py
@@ -186,6 +186,62 @@ def test_order_affecting_high_level_api_flags(parms, context):
 # -- Dict-API mutations: only flag when the touched key is in ``order``.
 
 
+def _setup_for_action(action):
+    """
+    Build a sim with a setup tailored to the test action.
+
+    The strict orientation-health check (#399) refuses transitions
+    into a half-defined state (``len(reflections) >= 2`` while
+    ``order`` shrinks below two effective entries).  Each test action
+    therefore needs a setup whose post-mutation state stays
+    well-defined so the original flag-behavior contract from #397 can
+    be observed in isolation.
+
+    Layout:
+
+    * removal of an orienting key (``del``/``pop``/``remove_reflection``)
+      starts with two reflections and a two-entry ``order``; the
+      removal drops the dict to one entry, which is below the
+      orientation threshold and therefore strict-allowed.
+    * ``popitem`` of an orienting key starts with a single reflection.
+    * non-orienting actions start with three reflections and a
+      two-entry ``order``; the third reflection is the unambiguous
+      non-orienting target.
+    * ``clear`` and ``update`` actions (which never shrink ``order``
+      below two effective entries) reuse the three-reflection setup
+      for variety.
+    """
+    one_orienting_actions = {"popitem_in_order"}
+    drop_orienting_actions = {
+        "setitem_replace_in_order",
+        "del_in_order",
+        "pop_in_order",
+        "update_overwrites_in_order",
+        "remove_reflection_in_order",
+    }
+
+    if action in one_orienting_actions:
+        sim = _build_sim_with_reflections(n_reflections=1)
+        return sim
+    if action in drop_orienting_actions:
+        sim = _build_sim_with_reflections(n_reflections=2)
+        sim.sample.reflections.order = ["r006", "r100"]
+        return sim
+    # Default: three reflections, order = [r006, r100], r006b is the
+    # non-orienting reflection.
+    sim = _build_sim_with_reflections(n_reflections=2)
+    third = SAMPLE_DEF["reflections"][2]
+    sim.add_reflection(
+        pseudos=third["pseudos"],
+        reals=third["reals"],
+        name=third["name"],
+    )
+    sim.sample.reflections.order = ["r006", "r100"]
+    assert "r006b" in sim.sample.reflections
+    assert "r006b" not in sim.sample.reflections.order
+    return sim
+
+
 @pytest.mark.parametrize(
     "parms, context",
     [
@@ -301,28 +357,11 @@ def test_dict_api_mutations_flag_only_when_order_affected(parms, context):
     replacing them does not require a solver re-push.
     """
     with context:
-        sim = _build_sim_with_reflections(n_reflections=2)
+        action = parms["action"]
+        sim = _setup_for_action(action)
         refls = sim.sample.reflections
-        # Pin ``order`` to just ``r006`` so we have a clear distinction
-        # between "in order" and "not in order".
-        refls.order = ["r006"]
-        # Add a third reflection to the dict but NOT to ``order`` so we
-        # have an unambiguous non-orienting reflection.
-        third = SAMPLE_DEF["reflections"][2]
-        sim.add_reflection(
-            pseudos=third["pseudos"],
-            reals=third["reals"],
-            name=third["name"],
-        )
-        # ``add_reflection`` re-appends r006b to order; rewrite to drop
-        # it again so ``r006b`` is unambiguously not in ``order``.
-        refls.order = ["r006"]
-        assert refls.order == ["r006"]
-        assert "r100" in refls and "r100" not in refls.order
-        assert "r006b" in refls and "r006b" not in refls.order
 
         _clean(sim)
-        action = parms["action"]
 
         if action == "setitem_replace_in_order":
             refls["r006"] = _new_like(refls["r006"], "r006")
@@ -331,11 +370,8 @@ def test_dict_api_mutations_flag_only_when_order_affected(parms, context):
         elif action == "pop_in_order":
             refls.pop("r006")
         elif action == "popitem_in_order":
-            # Remove all non-orienting entries first so popitem is forced
-            # to remove the orienting one.
-            del refls["r100"]
-            del refls["r006b"]
-            _clean(sim)
+            # Single-reflection setup; popitem removes the only entry
+            # (which is also the only orienting reflection).
             refls.popitem()
         elif action == "clear_with_order":
             refls.clear()
@@ -346,16 +382,19 @@ def test_dict_api_mutations_flag_only_when_order_affected(parms, context):
         elif action == "setitem_new_key":
             refls["brand_new"] = _new_like(refls["r006"], "brand_new")
         elif action == "setitem_replace_not_in_order":
-            refls["r100"] = _new_like(refls["r100"], "r100")
+            refls["r006b"] = _new_like(refls["r006b"], "r006b")
         elif action == "del_not_in_order":
-            del refls["r100"]
+            del refls["r006b"]
         elif action == "pop_not_in_order":
-            refls.pop("r100")
+            refls.pop("r006b")
         elif action == "pop_missing_with_default":
             result = refls.pop("nonexistent", "fallback")
             assert result == "fallback"
         elif action == "clear_empty_order":
-            refls.order = []
+            # Drop ``order`` to two-then-empty in two well-defined
+            # steps before clearing the dict.
+            with refls._suspend_strict_check():
+                refls.order = []
             _clean(sim)
             refls.clear()
         elif action == "update_new_keys_only":
@@ -374,7 +413,7 @@ def test_dict_api_mutations_flag_only_when_order_affected(parms, context):
         elif action == "setdefault_existing":
             refls.setdefault("r006", refls["r006"])
         elif action == "remove_reflection_not_in_order":
-            sim.sample.remove_reflection("r100")
+            sim.sample.remove_reflection("r006b")
         else:
             raise AssertionError(f"unknown action {action!r}")
 

--- a/src/hklpy2/tests/test_i399_strict_orientation.py
+++ b/src/hklpy2/tests/test_i399_strict_orientation.py
@@ -1,0 +1,504 @@
+"""
+Regression tests for issue #399.
+
+Strict orientation-health policy (option A): refuse mutations that
+would leave the sample *half-defined* -- two or more reflections still
+in the dict, but fewer than two named in
+:attr:`hklpy2.blocks.reflection.ReflectionsDict.order` (restricted to
+names that actually exist in the dict).
+
+The user retains complete control: they must explicitly designate the
+new orienting pair (via
+:meth:`~hklpy2.blocks.reflection.ReflectionsDict.set_orientation_reflections`
+or by assigning :attr:`order`) **before** removing the current one,
+or remove the non-orienting reflections first so the sample falls
+below the orientation threshold.
+"""
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from .. import creator
+from ..blocks.reflection import Reflection
+from ..blocks.reflection import ReflectionsDict
+from ..exceptions import ReflectionError
+
+
+SAMPLE_DEF = dict(
+    name="sapphire",
+    lattice=dict(a=4.785, c=12.991, gamma=120),
+    reflections=[
+        dict(
+            name="r006",
+            pseudos=(0, 0, 6),
+            reals=dict(omega=20.97, chi=90, phi=0, tth=41.9419),
+        ),
+        dict(
+            name="r100",
+            pseudos=(1, 0, 0),
+            reals=dict(omega=30, chi=0, phi=0, tth=60),
+        ),
+        dict(
+            name="r006b",
+            pseudos=(0, 0, 6),
+            reals=dict(omega=20.3654, chi=89.32, phi=0, tth=41.9394),
+        ),
+    ],
+)
+
+
+def _build_three_oriented():
+    """Sim with three reflections; ``order = ['r006', 'r100']``."""
+    sim = creator()
+    sim.beam.wavelength.put(1.5498)
+    sim.add_sample(
+        SAMPLE_DEF["name"],
+        SAMPLE_DEF["lattice"]["a"],
+        c=SAMPLE_DEF["lattice"]["c"],
+        gamma=SAMPLE_DEF["lattice"]["gamma"],
+    )
+    for refl in SAMPLE_DEF["reflections"]:
+        sim.add_reflection(
+            pseudos=refl["pseudos"],
+            reals=refl["reals"],
+            name=refl["name"],
+        )
+    sim.sample.reflections.order = ["r006", "r100"]
+    return sim
+
+
+def _new_like(refl: Reflection, name: str) -> Reflection:
+    return Reflection(
+        name,
+        refl.pseudos,
+        refl.reals,
+        refl.wavelength,
+        refl.geometry,
+        refl.pseudo_axis_names,
+        refl.real_axis_names,
+        wavelength_units=refl.wavelength_units,
+    )
+
+
+HALF_DEFINED_MSG = re.escape("Refusing to leave the sample half-defined")
+
+
+# -- All nine mutation paths from the issue: half-defined transitions
+#    must raise; benign mutations must not.
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        # Path 1: Sample.remove_reflection on an orienting reflection
+        # while two or more remain.
+        pytest.param(
+            dict(action="sample_remove_orienting"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-1-Sample.remove_reflection-on-orienting",
+        ),
+        # Path 2: __delitem__ on an orienting key.
+        pytest.param(
+            dict(action="del_orienting"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-2-__delitem__-on-orienting",
+        ),
+        # Path 3: pop on an orienting key.
+        pytest.param(
+            dict(action="pop_orienting"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-3-pop-on-orienting",
+        ),
+        # Path 4: popitem when it would remove an orienting key.
+        pytest.param(
+            dict(action="popitem_orienting"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-4-popitem-on-orienting",
+        ),
+        # Path 8: order setter assigned a list of length < 2 while
+        # two or more reflections remain.
+        pytest.param(
+            dict(action="order_setter_length_zero"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-8a-order-setter-empty",
+        ),
+        pytest.param(
+            dict(action="order_setter_length_one"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-8b-order-setter-single-entry",
+        ),
+        pytest.param(
+            dict(action="order_setter_two_but_one_unknown"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-8c-order-setter-two-but-one-unknown-name",
+        ),
+        # Path 9: set_orientation_reflections / setor with < 2
+        # reflections from a multi-reflection dict.
+        pytest.param(
+            dict(action="setor_single_reflection"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-9a-set_orientation_reflections-single-entry",
+        ),
+        pytest.param(
+            dict(action="setor_alias_single_reflection"),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="path-9b-setor-alias-single-entry",
+        ),
+    ],
+)
+def test_strict_check_raises_on_half_defined_transition(parms, context):
+    """Every documented half-defined transition raises ``ReflectionError``."""
+    with context:
+        sim = _build_three_oriented()
+        refls = sim.sample.reflections
+        action = parms["action"]
+
+        if action == "sample_remove_orienting":
+            sim.sample.remove_reflection("r006")
+        elif action == "del_orienting":
+            del refls["r006"]
+        elif action == "pop_orienting":
+            refls.pop("r006")
+        elif action == "popitem_orienting":
+            # Reduce the dict so popitem would remove the last (and
+            # ordered) entry while two remain in the dict.  Insertion
+            # order at this point is r006, r100, r006b.  Pop r006b
+            # (non-orienting) first, then assign order to keep two
+            # entries; popitem will then remove r100 (orienting).
+            del refls["r006b"]
+            # Now dict = {r006, r100}, order = [r006, r100]; popitem
+            # would remove r100, leaving dict={r006} and effective
+            # order=[r006] -- below threshold but dict<2 after.  That
+            # case is *not* half-defined.  To force the half-defined
+            # transition, add a non-orienting third entry and popitem
+            # it... but popitem removes last-inserted.  Instead, drop
+            # one orienting entry by reassigning order to keep both,
+            # then add a third reflection so popitem removes that --
+            # but again, that third would not be orienting.
+            #
+            # The cleanest way to provoke a half-defined ``popitem``
+            # is to leave the ordered key at the end of the dict.
+            # Re-add r006 last so it becomes the popitem target.
+            r006_template = SAMPLE_DEF["reflections"][0]
+            sim.add_reflection(
+                pseudos=r006_template["pseudos"],
+                reals=r006_template["reals"],
+                name="r006",
+                replace=True,
+            )
+            # Now dict = {r100, r006} (r006 is last), order should
+            # still include both.  popitem removes r006: dict goes
+            # 2 -> 1.  Effective order = [r100], dict size = 1
+            # post-pop -- not half-defined.  Need 3 entries with the
+            # ordered one at the end.
+            extra = SAMPLE_DEF["reflections"][2]
+            sim.add_reflection(
+                pseudos=extra["pseudos"],
+                reals=extra["reals"],
+                name="r006b",
+                replace=True,
+            )
+            # popitem removes r006b (last inserted) but r006b is not
+            # in order.  Adjust order to include r006b instead of one
+            # of the others, but keep two entries.
+            refls.order = ["r006b", "r100"]
+            # Now order's last (r006b) is the popitem target and dict
+            # has 3 entries; post-popitem dict = 2, effective order =
+            # [r100] (only). Half-defined.
+            refls.popitem()
+        elif action == "order_setter_length_zero":
+            refls.order = []
+        elif action == "order_setter_length_one":
+            refls.order = ["r006"]
+        elif action == "order_setter_two_but_one_unknown":
+            refls.order = ["r006", "no_such_name"]
+        elif action == "setor_single_reflection":
+            refls.set_orientation_reflections([refls["r006"]])
+        elif action == "setor_alias_single_reflection":
+            refls.setor([refls["r006"]])
+        else:
+            raise AssertionError(f"unknown action {action!r}")
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        # Removing the only orienting reflection while the dict drops
+        # below two entries: not half-defined.
+        pytest.param(
+            dict(action="remove_orienting_drops_below_two"),
+            does_not_raise(),
+            id="remove-orienting-when-dict-drops-below-two",
+        ),
+        # Removing a non-orienting reflection: order is untouched.
+        pytest.param(
+            dict(action="remove_non_orienting"),
+            does_not_raise(),
+            id="remove-non-orienting",
+        ),
+        # Order setter assigned a valid two-reflection list.
+        pytest.param(
+            dict(action="order_setter_two_valid"),
+            does_not_raise(),
+            id="order-setter-two-valid-entries",
+        ),
+        # Atomic rewrite to a valid pair (issue acceptance criterion).
+        pytest.param(
+            dict(action="atomic_swap_via_order_setter"),
+            does_not_raise(),
+            id="atomic-swap-via-order-setter",
+        ),
+        # set_orientation_reflections with two reflections.
+        pytest.param(
+            dict(action="setor_two_reflections"),
+            does_not_raise(),
+            id="setor-two-reflections",
+        ),
+        # __setitem__ does not shrink dict or order; never half-defined.
+        pytest.param(
+            dict(action="setitem_replace_orienting"),
+            does_not_raise(),
+            id="setitem-replace-orienting-key",
+        ),
+        # update overwriting an orienting key: same as setitem.
+        pytest.param(
+            dict(action="update_overwrites_orienting"),
+            does_not_raise(),
+            id="update-overwrites-orienting-key",
+        ),
+        # update inserting only new keys: dict grows, order unchanged.
+        pytest.param(
+            dict(action="update_new_keys"),
+            does_not_raise(),
+            id="update-inserts-new-keys",
+        ),
+        # clear: post-state is always empty (not half-defined).
+        pytest.param(
+            dict(action="clear_three_reflections"),
+            does_not_raise(),
+            id="clear-three-reflections",
+        ),
+        # Sample with a single reflection: removing it is allowed
+        # (dict drops to 0; not half-defined).
+        pytest.param(
+            dict(action="single_reflection_removal"),
+            does_not_raise(),
+            id="single-reflection-removal",
+        ),
+        # The downstream ``calc_UB(r1, r2)`` path must continue to
+        # work because it explicitly calls
+        # ``set_orientation_reflections([r1, r2])`` first -- the
+        # strict check on the order setter sees a length-2 list and
+        # accepts it.
+        pytest.param(
+            dict(action="calc_UB_round_trip"),
+            does_not_raise(),
+            id="calc_UB-still-works",
+        ),
+    ],
+)
+def test_strict_check_does_not_fire_on_well_defined_transitions(parms, context):
+    """Mutations whose post-state is well-defined must not raise."""
+    with context:
+        action = parms["action"]
+        if action == "single_reflection_removal":
+            sim = creator()
+            sim.beam.wavelength.put(1.5498)
+            sim.add_sample(
+                SAMPLE_DEF["name"],
+                SAMPLE_DEF["lattice"]["a"],
+                c=SAMPLE_DEF["lattice"]["c"],
+                gamma=SAMPLE_DEF["lattice"]["gamma"],
+            )
+            sim.add_reflection(
+                pseudos=SAMPLE_DEF["reflections"][0]["pseudos"],
+                reals=SAMPLE_DEF["reflections"][0]["reals"],
+                name="r006",
+            )
+            assert len(sim.sample.reflections) == 1
+            sim.sample.remove_reflection("r006")
+            assert len(sim.sample.reflections) == 0
+            return
+
+        sim = _build_three_oriented()
+        refls = sim.sample.reflections
+
+        if action == "remove_orienting_drops_below_two":
+            # Remove non-orienting first so the dict is at 2; then
+            # remove an orienting reflection -- post-state has 1
+            # entry, so no half-defined raise.
+            sim.sample.remove_reflection("r006b")
+            sim.sample.remove_reflection("r006")
+            assert len(refls) == 1
+        elif action == "remove_non_orienting":
+            sim.sample.remove_reflection("r006b")
+            assert "r006b" not in refls
+            assert refls.order == ["r006", "r100"]
+        elif action == "order_setter_two_valid":
+            refls.order = ["r100", "r006"]
+            assert refls.order == ["r100", "r006"]
+        elif action == "atomic_swap_via_order_setter":
+            refls.order = ["r006b", "r100"]
+            assert refls.order == ["r006b", "r100"]
+        elif action == "setor_two_reflections":
+            refls.set_orientation_reflections([refls["r006b"], refls["r100"]])
+            assert refls.order == ["r006b", "r100"]
+        elif action == "setitem_replace_orienting":
+            refls["r006"] = _new_like(refls["r006"], "r006")
+        elif action == "update_overwrites_orienting":
+            refls.update({"r006": _new_like(refls["r006"], "r006")})
+        elif action == "update_new_keys":
+            refls.update({"brand_new": _new_like(refls["r006"], "brand_new")})
+            assert "brand_new" in refls
+        elif action == "clear_three_reflections":
+            refls.clear()
+            assert len(refls) == 0
+        elif action == "calc_UB_round_trip":
+            sim.core.calc_UB("r006b", "r100")
+            assert refls.order == ["r006b", "r100"]
+        else:
+            raise AssertionError(f"unknown action {action!r}")
+
+
+# -- The dict and ``order`` must be unchanged after the exception fires.
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(action="del_orienting"),
+            does_not_raise(),
+            id="state-preserved-after-del-raises",
+        ),
+        pytest.param(
+            dict(action="pop_orienting"),
+            does_not_raise(),
+            id="state-preserved-after-pop-raises",
+        ),
+        pytest.param(
+            dict(action="sample_remove_orienting"),
+            does_not_raise(),
+            id="state-preserved-after-Sample.remove_reflection-raises",
+        ),
+        pytest.param(
+            dict(action="order_setter"),
+            does_not_raise(),
+            id="state-preserved-after-order-setter-raises",
+        ),
+        pytest.param(
+            dict(action="setor"),
+            does_not_raise(),
+            id="state-preserved-after-setor-raises",
+        ),
+    ],
+)
+def test_state_unchanged_when_strict_check_raises(parms, context):
+    """The dict and ``order`` are unchanged when the exception fires."""
+    with context:
+        sim = _build_three_oriented()
+        refls = sim.sample.reflections
+        # Snapshot the pre-mutation state.
+        keys_before = list(refls.keys())
+        order_before = list(refls.order)
+
+        action = parms["action"]
+        if action == "del_orienting":
+            with pytest.raises(ReflectionError, match=HALF_DEFINED_MSG):
+                del refls["r006"]
+        elif action == "pop_orienting":
+            with pytest.raises(ReflectionError, match=HALF_DEFINED_MSG):
+                refls.pop("r006")
+        elif action == "sample_remove_orienting":
+            with pytest.raises(ReflectionError, match=HALF_DEFINED_MSG):
+                sim.sample.remove_reflection("r006")
+        elif action == "order_setter":
+            with pytest.raises(ReflectionError, match=HALF_DEFINED_MSG):
+                refls.order = ["r006"]
+        elif action == "setor":
+            with pytest.raises(ReflectionError, match=HALF_DEFINED_MSG):
+                refls.set_orientation_reflections([refls["r006"]])
+        else:
+            raise AssertionError(f"unknown action {action!r}")
+
+        assert list(refls.keys()) == keys_before, (
+            "Dict keys changed despite the exception"
+        )
+        assert list(refls.order) == order_before, "Order changed despite the exception"
+
+
+# -- Standalone (no Core) ReflectionsDict still enforces the policy
+#    because it does not depend on the Core back-reference.
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            pytest.raises(ReflectionError, match=HALF_DEFINED_MSG),
+            id="standalone-ReflectionsDict-still-enforces",
+        ),
+    ],
+)
+def test_strict_check_works_standalone(parms, context):
+    """The strict check is independent of the Core back-reference."""
+    with context:
+        rd = ReflectionsDict()
+        # Two minimally valid reflections, same geometry.
+        r1 = Reflection(
+            "r1",
+            {"h": 1, "k": 0, "l": 0},
+            {"omega": 0},
+            1.0,
+            "g",
+            ["h", "k", "l"],
+            ["omega"],
+        )
+        r2 = Reflection(
+            "r2",
+            {"h": 0, "k": 1, "l": 0},
+            {"omega": 1},
+            1.0,
+            "g",
+            ["h", "k", "l"],
+            ["omega"],
+        )
+        rd.add(r1)
+        rd.add(r2)
+        # Both are orienting after add().  Drop order to length 1
+        # while two reflections remain in the dict -- raise.
+        rd.order = ["r1"]
+
+
+# -- The suspend mechanism deliberately bypasses the strict check
+#    for internal multi-step operations (and for tests that need to
+#    construct half-defined states intentionally).
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="suspend-mechanism-allows-half-defined-setup",
+        ),
+    ],
+)
+def test_suspend_mechanism_bypasses_strict_check(parms, context):
+    """``_suspend_strict_check`` allows internal/setup code to traverse the half-defined state."""
+    with context:
+        sim = _build_three_oriented()
+        refls = sim.sample.reflections
+
+        with refls._suspend_strict_check():
+            # Same mutations that would normally raise.
+            refls.order = ["r006"]
+            assert refls.order == ["r006"]
+
+        # Outside the context, the strict check is active again.
+        with pytest.raises(ReflectionError, match=HALF_DEFINED_MSG):
+            del refls["r006"]


### PR DESCRIPTION
- closes #399

## Summary

Adopts **option A (strict)** for the half-defined orientation state
identified during #397: mutations that would leave the sample with
two or more reflections still in the dict but fewer than two named in
``reflections.order`` (restricted to existing names) now raise
``ReflectionError`` **before** the mutation is committed.

The user must explicitly designate the new orienting pair (via
``set_orientation_reflections([r1, r2])`` or by assigning
``reflections.order = [r1, r2]``) before removing the current one,
or remove non-orienting reflections first so the sample falls below
the orientation threshold.

## Implementation

* New private helper ``_check_strict_order_health(prospective_order,
  prospective_keys)`` computes the post-mutation state and raises
  early; the dict and ``order`` are unchanged when the exception
  fires.
* New private context manager ``_suspend_strict_check()`` (re-entrant
  counter) bypasses the helper for multi-step internal operations
  (``add``, ``_fromdict``) that legitimately traverse intermediate
  states.
* All nine documented mutation paths now gate on the helper:
  ``Sample.remove_reflection``, ``__delitem__``, ``pop``, ``popitem``,
  ``clear``, ``update``, ``__setitem__``, the ``order`` setter, and
  ``set_orientation_reflections`` / ``setor``.  Paths that cannot
  shrink ``order`` (``__setitem__``, ``update``, ``clear``) keep the
  check for symmetry; it is a no-op for them in normal use.
* ``calc_UB(r1, r2)`` continues to work because it explicitly
  re-assigns ``order`` to a length-2 list before invoking the
  solver.

## Breaking change

Workflows that drop an orienting reflection without designating its
replacement now raise instead of silently proceeding to a stale UB.
The unreleased section in ``RELEASE_NOTES.rst`` bumps from 0.6.3 to
**0.7.0** per the project's SemVer policy (behavior change → MINOR
bump).

## Tests

**New** ``src/hklpy2/tests/test_i399_strict_orientation.py`` — 27
parametrized tests in agent style:

- 9 cases covering all paths from the issue (#1, 2, 3, 4, 8a/b/c,
  9a/b): each raises ``ReflectionError`` matching "Refusing to leave
  the sample half-defined".
- 11 well-defined-transition cases: removal-when-dict-drops-below-two,
  removal of non-orienting, atomic ``order`` setter rewrite, valid
  ``setor`` / ``order``, ``setitem`` / ``update`` (which never
  shrink), ``clear``, single-reflection removal, ``calc_UB``
  round-trip — all ``does_not_raise()``.
- 5 state-preservation cases: dict and ``order`` unchanged after the
  exception fires.
- 1 standalone (no ``Core``) case: the strict check works without a
  back-reference.
- 1 suspend-mechanism case: setup-time bypass works; check
  re-engages on exit.

**Updated** existing tests so the new strict semantics are honoured
without losing the original test intent:

- ``test_swap`` error cases now use a sub-2-element dict.
- ``test_ReflectionsDict`` gates single-element ``setor`` calls on
  ``i < 2``.
- ``test_remove_reflection`` and ``test_refine_lattice`` updated to
  expect ``ReflectionError`` on orienting removals.
- ``test_ub_staleness`` uses ``_suspend_strict_check()`` to set up
  the half-defined state intentionally.
- ``test_i397_reflections_dirty`` restructured (per-action setup) so
  the #397 flag-behavior contract is verified without colliding
  with the strict check.

## Verification

- All 27 new tests pass.
- All 31 prior #397 tests pass after restructuring.
- All 7 prior #398 tests pass.
- Full suite: **1226 passed**, 7 skipped.
- 100% coverage on ``reflection.py``.
- pre-commit: all hooks pass.

Agent: OpenCode (claudeopus47)