### PR TITLE
feat #396 warn when restoring older / unknown configuration schema

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -40,6 +40,11 @@ Breaking Changes
 
 * Refuse mutations that would leave the sample half-defined. (:issue:`399`)
 
+Enhancements
+------------
+
+* Warn on restore from older or unknown configuration schema. (:issue:`396`)
+
 Fixes
 -----
 

--- a/src/hklpy2/blocks/configure.py
+++ b/src/hklpy2/blocks/configure.py
@@ -9,14 +9,92 @@ Export and restore sample UB matrix and other diffractometer configuration.
 """
 
 import logging
+import warnings
 from typing import Any
+from typing import Mapping
 
+from deprecated.sphinx import versionadded
 from deprecated.sphinx import versionchanged
 
 from ..exceptions import ConfigurationError
 from ..typing import KeyValueMap
 
 logger = logging.getLogger(__name__)
+
+
+CONFIG_SCHEMA_VERSION: int = 1
+"""
+Integer revision of the configuration file schema written by
+:meth:`~hklpy2.ops.Core._asdict` and validated by
+:meth:`~hklpy2.diffract.DiffractometerBase.restore`.
+
+Bump monotonically when the on-disk configuration layout changes in a way
+that older readers might mishandle.
+
+.. versionadded:: 0.7.0
+"""
+
+
+@versionadded(
+    version="0.7.0",
+    reason="Warn when restoring a configuration whose schema is missing, older, or newer.",
+)
+def _check_schema_version(header: Mapping[str, Any]) -> None:
+    """
+    Emit a :class:`UserWarning` if the configuration ``_header`` does not
+    match the current :data:`CONFIG_SCHEMA_VERSION`.
+
+    Always proceeds (warn-and-proceed); never raises.
+
+    PARAMETERS
+
+    header : Mapping
+        The ``_header`` block from a loaded configuration dict.
+    """
+    version = header.get("config_schema_version")
+    if version is None:
+        warnings.warn(
+            (
+                "Configuration file has no schema version; it was written"
+                " by an older hklpy2 (pre-schema-versioning).  Loading"
+                f" against current schema v{CONFIG_SCHEMA_VERSION}."
+            ),
+            UserWarning,
+            stacklevel=3,
+        )
+        return
+    if not isinstance(version, int) or isinstance(version, bool):
+        warnings.warn(
+            (
+                f"Unrecognized configuration schema version: {version!r}."
+                f"  Expected an int (current schema v{CONFIG_SCHEMA_VERSION})."
+            ),
+            UserWarning,
+            stacklevel=3,
+        )
+        return
+    if version == CONFIG_SCHEMA_VERSION:
+        return
+    if version < CONFIG_SCHEMA_VERSION:
+        warnings.warn(
+            (
+                f"Configuration schema v{version} is older than current"
+                f" v{CONFIG_SCHEMA_VERSION}; some fields may have changed"
+                " meaning."
+            ),
+            UserWarning,
+            stacklevel=3,
+        )
+        return
+    # version > CONFIG_SCHEMA_VERSION
+    warnings.warn(
+        (
+            f"Configuration schema v{version} is newer than supported"
+            f" v{CONFIG_SCHEMA_VERSION}; some fields may be ignored."
+        ),
+        UserWarning,
+        stacklevel=3,
+    )
 
 
 class Configuration:

--- a/src/hklpy2/blocks/tests/test_configure.py
+++ b/src/hklpy2/blocks/tests/test_configure.py
@@ -13,7 +13,9 @@ from ...utils import load_yaml_file
 from ...tests.models import E4CV_CONFIG_FILE
 from ...tests.models import add_oriented_vibranium_to_e4cv
 from ...tests.models import e4cv_config
+from ..configure import CONFIG_SCHEMA_VERSION
 from ..configure import Configuration
+from ..configure import _check_schema_version
 
 e4cv = creator(name="e4cv")
 add_oriented_vibranium_to_e4cv(e4cv)
@@ -27,6 +29,11 @@ twopi = 2 * math.pi
     [
         pytest.param("_header.datetime", None, id="header-datetime"),
         pytest.param("_header.hklpy2_version", __version__, id="header-hklpy2-version"),
+        pytest.param(
+            "_header.config_schema_version",
+            CONFIG_SCHEMA_VERSION,
+            id="header-config-schema-version",
+        ),
         pytest.param(
             "_header.python_class", e4cv.__class__.__name__, id="header-python-class"
         ),
@@ -660,3 +667,132 @@ def test_presets_round_trip(parms, context, tmp_path):
         restored = fresh.core._mode_presets.get(parms["preset_mode"], {})
         for axis, value in parms["presets"].items():
             assert restored.get(axis) == pytest.approx(value)
+
+
+# ---------------------------------------------------------------------------
+# Issue #396: warn when restoring an older / unknown configuration schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(version=CONFIG_SCHEMA_VERSION, expect_warning=False),
+            does_not_raise(),
+            id="current-schema-no-warning",
+        ),
+        pytest.param(
+            dict(version="__omit__", expect_warning="no schema version"),
+            does_not_raise(),
+            id="missing-schema-version",
+        ),
+        pytest.param(
+            dict(version=CONFIG_SCHEMA_VERSION - 1, expect_warning="older"),
+            does_not_raise(),
+            id="older-schema",
+        ),
+        pytest.param(
+            dict(version=CONFIG_SCHEMA_VERSION + 1, expect_warning="newer"),
+            does_not_raise(),
+            id="newer-schema",
+        ),
+        pytest.param(
+            dict(version="bogus", expect_warning="Unrecognized"),
+            does_not_raise(),
+            id="non-int-schema",
+        ),
+        pytest.param(
+            dict(version=True, expect_warning="Unrecognized"),
+            does_not_raise(),
+            id="bool-schema-rejected",
+        ),
+    ],
+)
+def test_check_schema_version(parms, context):
+    """``_check_schema_version`` warns on missing / older / newer / bogus."""
+    import warnings as _warnings
+
+    with context:
+        header: dict = {"datetime": "x", "hklpy2_version": "y", "python_class": "z"}
+        if parms["version"] != "__omit__":
+            header["config_schema_version"] = parms["version"]
+
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            _check_schema_version(header)
+
+        schema_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "schema" in str(w.message).lower()
+        ]
+        if parms["expect_warning"] is False:
+            assert schema_warnings == [], f"unexpected warnings: {schema_warnings!r}"
+        else:
+            assert len(schema_warnings) == 1, (
+                f"expected one schema warning, got: {schema_warnings!r}"
+            )
+            assert parms["expect_warning"] in str(schema_warnings[0].message)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(mutate=None, expect_warning=False),
+            does_not_raise(),
+            id="round-trip-no-warning",
+        ),
+        pytest.param(
+            dict(mutate="drop", expect_warning="no schema version"),
+            does_not_raise(),
+            id="drop-version-warns",
+        ),
+        pytest.param(
+            dict(mutate=("set", CONFIG_SCHEMA_VERSION - 1), expect_warning="older"),
+            does_not_raise(),
+            id="older-version-warns",
+        ),
+        pytest.param(
+            dict(mutate=("set", CONFIG_SCHEMA_VERSION + 1), expect_warning="newer"),
+            does_not_raise(),
+            id="newer-version-warns",
+        ),
+    ],
+)
+def test_restore_emits_schema_warning(parms, context, tmp_path):
+    """End-to-end: ``restore()`` surfaces the schema warning."""
+    import warnings as _warnings
+
+    with context:
+        # Round-trip a fresh export through restore() to drive the
+        # warning path on a real diffractometer.
+        orig = creator(name="e4cv_schema_orig")
+        cfg_file = tmp_path / "schema.yml"
+        orig.export(cfg_file)
+        config = load_yaml_file(cfg_file)
+
+        if parms["mutate"] == "drop":
+            config["_header"].pop("config_schema_version", None)
+        elif isinstance(parms["mutate"], tuple) and parms["mutate"][0] == "set":
+            config["_header"]["config_schema_version"] = parms["mutate"][1]
+
+        target = creator(name="e4cv_schema_target")
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            target.restore(config)
+
+        schema_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "schema" in str(w.message).lower()
+        ]
+        if parms["expect_warning"] is False:
+            assert schema_warnings == [], f"unexpected warnings: {schema_warnings!r}"
+        else:
+            assert any(
+                parms["expect_warning"] in str(w.message) for w in schema_warnings
+            ), f"expected {parms['expect_warning']!r} in {schema_warnings!r}"

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -41,6 +41,7 @@ from ophyd.device import required_for_connection
 from ophyd.pseudopos import pseudo_position_argument
 from ophyd.pseudopos import real_position_argument
 
+from .blocks.configure import _check_schema_version
 from .blocks.reflection import Reflection
 from .blocks.sample import Sample
 from .incident import WavelengthXray
@@ -382,6 +383,14 @@ class DiffractometerBase(PseudoPositioner):
             "the kwargs explicitly to override.  See :issue:`390`."
         ),
     )
+    @versionchanged(
+        version="0.7.0",
+        reason=(
+            "Emit a ``UserWarning`` when the configuration ``_header`` "
+            "lacks ``config_schema_version`` or carries a value that does "
+            "not match the current schema.  See :issue:`396`."
+        ),
+    )
     def restore(
         self,
         config,
@@ -471,6 +480,7 @@ class DiffractometerBase(PseudoPositioner):
         if header is None:
             raise KeyError(MISSING_HEADER_KEY_MSG)
         # Note: python_class key is not testable, could be anything.
+        _check_schema_version(header)
 
         # Resolve safety defaults based on is_simulator.  Sections that
         # change the inputs to the next forward() default OFF on a

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -136,11 +136,13 @@ class Core:
     def _asdict(self) -> KeyValueMap:
         """Describe the diffractometer as a dictionary."""
         from .__init__ import __version__
+        from .blocks.configure import CONFIG_SCHEMA_VERSION
 
         header: ConfigHeaderDict = {
             "datetime": str(datetime.datetime.now()),
             "hklpy2_version": __version__,
             "python_class": self.diffractometer.__class__.__name__,
+            "config_schema_version": CONFIG_SCHEMA_VERSION,
         }
         return {
             "_header": header,

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -408,6 +408,9 @@ def simulator_from_config(config):
         )
     if "_header" not in config:
         raise KeyError(MISSING_HEADER_KEY_MSG)
+    from .blocks.configure import _check_schema_version
+
+    _check_schema_version(config["_header"])
 
     solver_cfg = config.get("solver", {})
     # Default solver name remains "hkl_soleil" because the config

--- a/src/hklpy2/tests/configuration_i240.yml
+++ b/src/hklpy2/tests/configuration_i240.yml
@@ -3,6 +3,7 @@
 _header:
   datetime: '2026-04-30 17:31:46.831426'
   hklpy2_version: 0.6.2.dev4+gde2b3abb7.d20260430
+  config_schema_version: 1
   python_class: Hklpy2Diffractometer
   file: /home/beams1/JEMIAN/Documents/projects/Bluesky/hklpy2/src/hklpy2/tests/configuration_i240.yml.reexport.tmp
   comment: 're-exported for issue #390 schema sync (configuration_i240.yml)'

--- a/src/hklpy2/tests/e4cv-silicon-example.yml
+++ b/src/hklpy2/tests/e4cv-silicon-example.yml
@@ -3,6 +3,7 @@
 _header:
   datetime: '2026-04-30 17:31:45.287102'
   hklpy2_version: 0.6.2.dev4+gde2b3abb7.d20260430
+  config_schema_version: 1
   python_class: Hklpy2Diffractometer
   file: /home/beams1/JEMIAN/Documents/projects/Bluesky/hklpy2/src/hklpy2/tests/e4cv-silicon-example.yml.reexport.tmp
   comment: 're-exported for issue #390 schema sync (e4cv-silicon-example.yml)'

--- a/src/hklpy2/tests/e4cv_orient.yml
+++ b/src/hklpy2/tests/e4cv_orient.yml
@@ -3,6 +3,7 @@
 _header:
   datetime: '2026-04-30 17:31:44.495500'
   hklpy2_version: 0.6.2.dev4+gde2b3abb7.d20260430
+  config_schema_version: 1
   python_class: Hklpy2Diffractometer
   file: /home/beams1/JEMIAN/Documents/projects/Bluesky/hklpy2/src/hklpy2/tests/e4cv_orient.yml.reexport.tmp
   comment: 're-exported for issue #390 schema sync (e4cv_orient.yml)'

--- a/src/hklpy2/tests/fourc-configuration.yml
+++ b/src/hklpy2/tests/fourc-configuration.yml
@@ -3,6 +3,7 @@
 _header:
   datetime: '2025-04-07'
   hklpy2_version: 0.0.25.dev88+g6e0f270.d20240926
+  config_schema_version: 1
   python_class: Fourc
   file: fourc-configuration.yml
   comment: 'E4CV with Fourc axes names and vibranium orientation'

--- a/src/hklpy2/tests/fourc-i183.yml
+++ b/src/hklpy2/tests/fourc-i183.yml
@@ -3,6 +3,7 @@
 _header:
   datetime: '2026-04-30 17:31:46.053305'
   hklpy2_version: 0.6.2.dev4+gde2b3abb7.d20260430
+  config_schema_version: 1
   python_class: Hklpy2Diffractometer
   file: /home/beams1/JEMIAN/Documents/projects/Bluesky/hklpy2/src/hklpy2/tests/fourc-i183.yml.reexport.tmp
   comment: 're-exported for issue #390 schema sync (fourc-i183.yml)'

--- a/src/hklpy2/tests/tardis.yml
+++ b/src/hklpy2/tests/tardis.yml
@@ -3,6 +3,7 @@
 _header:
   datetime: '2025-04-09 21:38:25.942848'
   hklpy2_version: 0.0.29.dev43+gdc399a0.d20250410
+  config_schema_version: 1
   python_class: Hklpy2Diffractometer
   file: dev_tardis-cmazzoli.yml
   comment: NSLS-II tardis with oriented sample from @cmazzoli

--- a/src/hklpy2/typing.py
+++ b/src/hklpy2/typing.py
@@ -120,7 +120,7 @@ NamedFloatDict = Mapping[str, NUMERIC]
 # ---------------------------------------------------------------------------
 
 
-class ConfigHeaderDict(TypedDict):
+class ConfigHeaderDict(TypedDict, total=False):
     """
     Typed structure for the configuration ``_header`` block.
 
@@ -135,8 +135,18 @@ class ConfigHeaderDict(TypedDict):
         Version of |hklpy2| used to write the configuration.
     python_class : str
         ``__class__.__name__`` of the diffractometer.
+    config_schema_version : int
+        Integer revision of the configuration file schema.  Compared by
+        :meth:`~hklpy2.diffract.DiffractometerBase.restore` to detect
+        files written by older or unknown schemas.  Absent in files
+        written by versions of |hklpy2| prior to the introduction of the
+        schema-version field.
+
+    .. versionchanged:: 0.7.0
+       Added ``config_schema_version``.
     """
 
     datetime: str
     hklpy2_version: str
     python_class: str
+    config_schema_version: int


### PR DESCRIPTION
- closes #396

## Summary

* Introduce ``CONFIG_SCHEMA_VERSION`` (integer, currently ``1``) as a
  monotonic revision tag for the on-disk configuration layout, separate
  from the package's ``hklpy2_version``.
* Stamp ``config_schema_version`` into the ``_header`` block on every
  ``export()`` (via ``Core._asdict()``).
* In ``DiffractometerBase.restore()`` and ``simulator_from_config()``,
  emit a single ``UserWarning`` when the file's schema version is
  missing, non-integer, older, or newer than the current value.
  Behavior is **warn-and-proceed**: restore still runs, no exceptions.

## Implementation notes

* The check lives in a private ``_check_schema_version(header)`` helper
  in ``hklpy2.blocks.configure`` so both call sites share one
  implementation.
* ``ConfigHeaderDict`` gains an optional ``config_schema_version: int``
  field (``total=False``); legacy headers without it are still valid.
* The six fixture YAMLs under ``src/hklpy2/tests/`` were re-exported
  (the new field injected) so test runs are not flooded with warnings.
* The four warn paths (missing / older / newer / non-int) are covered
  by parametrized tests in ``test_check_schema_version`` and an
  end-to-end ``test_restore_emits_schema_warning``.

## Verification

* ``pre-commit run --all-files``: all hooks pass.
* ``pytest src/hklpy2``: 1237 passed, 7 skipped, 8 deselected (no new
  failures).

Agent: OpenCode (claudeopus47)