### PR TITLE
feat #388 round-trip auxiliary sub-devices via schema v2

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -43,6 +43,8 @@ Breaking Changes
 Enhancements
 ------------
 
+* Add ``register_aux_reconstructor()`` for custom auxiliary sub-devices. (:issue:`388`)
+* Round-trip nested ``PseudoPositioner`` auxiliaries through export / restore. (:issue:`388`)
 * Warn on restore from older or unknown configuration schema. (:issue:`396`)
 
 Fixes

--- a/src/hklpy2/__init__.py
+++ b/src/hklpy2/__init__.py
@@ -65,6 +65,7 @@ from .diffract import diffractometer_class_factory  # noqa: E402, F401, F403
 from .incident import A_KEV  # noqa: E402, F401
 from .exceptions import SolverError  # noqa: E402, F401
 from .run_utils import ConfigurationRunWrapper  # noqa: E402, F401
+from .run_utils import register_aux_reconstructor  # noqa: E402, F401
 from .run_utils import simulator_from_config  # noqa: E402, F401
 from .run_utils import get_run_orientation  # noqa: E402, F401
 from .run_utils import list_orientation_runs  # noqa: E402, F401

--- a/src/hklpy2/blocks/configure.py
+++ b/src/hklpy2/blocks/configure.py
@@ -22,7 +22,7 @@ from ..typing import KeyValueMap
 logger = logging.getLogger(__name__)
 
 
-CONFIG_SCHEMA_VERSION: int = 1
+CONFIG_SCHEMA_VERSION: int = 2
 """
 Integer revision of the configuration file schema written by
 :meth:`~hklpy2.ops.Core._asdict` and validated by
@@ -32,6 +32,10 @@ Bump monotonically when the on-disk configuration layout changes in a way
 that older readers might mishandle.
 
 .. versionadded:: 0.7.0
+   Initial value ``2``: ``axes.auxiliary_axes`` is a list of records
+   (``{"name", "category", ...}``) rather than a flat list of names.
+   The flat-list form is still accepted on read for backward
+   compatibility.  See :issue:`388`.
 """
 
 

--- a/src/hklpy2/devices.py
+++ b/src/hklpy2/devices.py
@@ -29,7 +29,11 @@ from ophyd import Component
 from ophyd import Device
 from ophyd import EpicsMotor
 from ophyd import PVPositioner
+from ophyd import PseudoPositioner
 from ophyd import SoftPositioner
+from ophyd.pseudopos import PseudoSingle
+from ophyd.pseudopos import pseudo_position_argument
+from ophyd.pseudopos import real_position_argument
 
 from .typing import KeyValueMap
 
@@ -38,8 +42,10 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "VirtualPositionerBase",
     "define_real_axis",
+    "describe_aux",
     "dict_device_factory",
     "dynamic_import",
+    "make_aux_pseudo_positioner_class",
     "make_component",
     "make_dynamic_instance",
     "parse_factory_axes",
@@ -218,6 +224,15 @@ def define_real_axis(
         class_name = specs.pop("class", None)
         if class_name is None:
             raise KeyError("Expected 'class' key, received None")
+        # ``class`` may be either a dotted import-path string (the
+        # historic form) or a callable resolved at runtime — the latter
+        # supports nested PseudoPositioner stand-ins built by
+        # :func:`hklpy2.run_utils.simulator_from_config` (issue #388).
+        if not isinstance(class_name, str) and not callable(class_name):
+            raise TypeError(
+                "define_real_axis: 'class' must be a dotted import path"
+                f" (str) or a callable; got {type(class_name).__name__!r}."
+            )
         for label in specs.pop("labels", []):
             if label not in kwargs["labels"]:
                 kwargs["labels"].append(label)
@@ -290,9 +305,30 @@ def dynamic_import(full_path: str) -> type:
     return import_object
 
 
-def make_component(call_name: str, *args: Any, **kwargs: Any) -> Component:
-    """Create an Component for a custom ophyd Device class."""
-    CallableObject = dynamic_import(call_name)
+def make_component(call_name: Any, *args: Any, **kwargs: Any) -> Component:
+    """
+    Create an :class:`~ophyd.Component` for a custom ophyd Device class.
+
+    ``call_name`` may be either a dotted import path (``str``) or an
+    already-resolved callable (``type``).  The callable form is used by
+    :func:`hklpy2.run_utils.simulator_from_config` when restoring a
+    nested ``PseudoPositioner`` auxiliary whose synthetic stand-in class
+    is built at runtime and therefore cannot be addressed by an import
+    path.
+
+    .. versionchanged:: 0.7.0
+       Accept a callable in addition to a dotted import-path string.
+       See :issue:`388`.
+    """
+    if isinstance(call_name, str):
+        CallableObject = dynamic_import(call_name)
+    elif callable(call_name):
+        CallableObject = call_name
+    else:
+        raise TypeError(
+            "make_component: call_name must be a dotted import path"
+            f" (str) or a callable; got {type(call_name).__name__!r}."
+        )
     return make_dynamic_instance(
         "ophyd.Component",
         CallableObject,
@@ -379,3 +415,104 @@ def parse_factory_axes(
     attributes["_" + space.rstrip("s")] = order
 
     return attributes
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary sub-device round-trip support (issue #388)
+# ---------------------------------------------------------------------------
+
+
+@versionadded(
+    version="0.7.0",
+    reason=(
+        "Describe an auxiliary component as a schema-v2 record so its "
+        "internal structure (e.g. nested ``PseudoPositioner``) can survive "
+        "export/restore.  See :issue:`388`."
+    ),
+)
+def describe_aux(diffractometer: object, name: str) -> dict:
+    """
+    Build a single ``axes.auxiliary_axes`` record for ``name``.
+
+    Categorises the auxiliary into one of the schema-v2 categories:
+
+    * ``"scalar"`` — a plain :class:`~ophyd.PositionerBase` (the historic
+      default; the round-tripped simulator stand-in is an
+      :class:`~ophyd.SoftPositioner`).
+    * ``"pseudo_positioner"`` — a nested
+      :class:`~ophyd.pseudopos.PseudoPositioner`; sub-axis names are
+      recorded as ordered ``pseudos`` / ``reals`` lists.  ``class`` /
+      ``module`` are advisory metadata only — never imported by hklpy2 on
+      restore.
+    """
+    component = getattr(diffractometer, name)
+    if isinstance(component, PseudoPositioner):
+        cls = component.__class__
+        return {
+            "name": name,
+            "category": "pseudo_positioner",
+            "pseudos": [p.attr_name for p in component.pseudo_positioners],
+            "reals": [r.attr_name for r in component.real_positioners],
+            "class": cls.__name__,
+            "module": cls.__module__,
+        }
+    return {"name": name, "category": "scalar"}
+
+
+@versionadded(
+    version="0.7.0",
+    reason=(
+        "Build a synthetic structural stand-in for a nested "
+        "``PseudoPositioner`` auxiliary on restore.  See :issue:`388`."
+    ),
+)
+def make_aux_pseudo_positioner_class(
+    name: str,
+    pseudos: Sequence[str],
+    reals: Sequence[str],
+) -> type:
+    """
+    Build a synthetic :class:`~ophyd.pseudopos.PseudoPositioner` subclass
+    with the given sub-axis names.
+
+    The resulting class is **structural only**: ``forward()`` and
+    ``inverse()`` return zeros for every sub-axis.  Its purpose is to
+    let downstream code (printers, plan inspection, etc.) traverse the
+    same component tree the original device exposed.
+    """
+    if not pseudos:
+        raise ValueError(
+            f"pseudo_positioner aux {name!r} must declare at least one pseudo"
+        )
+    if not reals:
+        raise ValueError(
+            f"pseudo_positioner aux {name!r} must declare at least one real"
+        )
+
+    body: dict = {}
+    for p in pseudos:
+        body[p] = Component(PseudoSingle, kind="hinted")
+    for r in reals:
+        body[r] = Component(
+            SoftPositioner,
+            kind="hinted",
+            limits=(-1e9, 1e9),
+            init_pos=0,
+        )
+
+    n_pseudos = len(pseudos)
+    n_reals = len(reals)
+
+    @pseudo_position_argument
+    def forward(self, pp):  # noqa: ARG001
+        return self.RealPosition(*([0.0] * n_reals))
+
+    @real_position_argument
+    def inverse(self, rp):  # noqa: ARG001
+        return self.PseudoPosition(*([0.0] * n_pseudos))
+
+    body["forward"] = forward
+    body["inverse"] = inverse
+
+    cls_name = f"_AuxPseudoPositioner_{name}"
+    return type(cls_name, (PseudoPositioner,), body)

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -133,10 +133,27 @@ class Core:
             # first sample is cubic, no reflections
             self.add_sample(DEFAULT_SAMPLE_NAME, 1)
 
+    @versionchanged(
+        version="0.7.0",
+        reason=(
+            "``axes.auxiliary_axes`` is now a list of "
+            "``{name, category, …}`` records (schema v2) instead of a "
+            "flat list of names; nested ``PseudoPositioner`` auxiliaries "
+            "round-trip with their sub-axis structure preserved.  See "
+            ":issue:`388`."
+        ),
+    )
     def _asdict(self) -> KeyValueMap:
         """Describe the diffractometer as a dictionary."""
         from .__init__ import __version__
         from .blocks.configure import CONFIG_SCHEMA_VERSION
+
+        # ``describe_aux`` lives in :mod:`hklpy2.devices` so the
+        # ophyd-typing introspection (``isinstance(..., PseudoPositioner)``)
+        # stays in the ophyd-construction module, preserving
+        # ``ops.py``'s ophyd-free separation of concerns.  See
+        # :issue:`388`.
+        from .devices import describe_aux
 
         header: ConfigHeaderDict = {
             "datetime": str(datetime.datetime.now()),
@@ -152,7 +169,10 @@ class Core:
                 "real_axes": self.diffractometer.real_axis_names,
                 "axes_xref": self.axes_xref,
                 "extra_axes": self.all_extras,
-                "auxiliary_axes": self.diffractometer.auxiliary_axis_names,
+                "auxiliary_axes": [
+                    describe_aux(self.diffractometer, name)
+                    for name in self.diffractometer.auxiliary_axis_names
+                ],
             },
             "digits": self.diffractometer.digits,
             "sample_name": self.sample.name,

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -15,6 +15,8 @@ and retrieve orientation information from previously recorded runs.
 import logging
 import pathlib
 import sys
+import warnings
+from collections.abc import Callable
 from collections.abc import Iterator
 from typing import Any
 from typing import Mapping
@@ -35,10 +37,113 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "ConfigurationRunWrapper",
+    "register_aux_reconstructor",
     "simulator_from_config",
     "get_run_orientation",
     "list_orientation_runs",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary-axis reconstruction (issue #388)
+# ---------------------------------------------------------------------------
+
+#: Built-in / user-registered callables that turn an aux record (``dict``
+#: with ``name`` / ``category`` / …) into a ``creator()`` ``reals=`` value
+#: (``None`` for a scalar SoftPositioner, or a dict-spec describing a
+#: nested PseudoPositioner stand-in).  Keyed by the record's
+#: ``category``.  Use :func:`register_aux_reconstructor` to register a
+#: custom builder; built-ins live in :data:`_BUILTIN_AUX_RECONSTRUCTORS`.
+_AUX_RECONSTRUCTORS: dict[str, Callable[[Mapping[str, Any]], Any]] = {}
+
+
+@versionadded(
+    version="0.7.0",
+    reason="Public hook for restoring custom auxiliary sub-devices.  See :issue:`388`.",
+)
+def register_aux_reconstructor(
+    category: str,
+    builder: Callable[[Mapping[str, Any]], Any],
+) -> None:
+    """
+    Register a builder for a given aux-record ``category``.
+
+    The ``builder`` receives a normalised record (``dict`` with at least
+    ``name`` and ``category``) and returns whatever
+    :func:`~hklpy2.diffract.creator` accepts as a ``reals=`` value:
+
+    * ``None`` for a scalar :class:`~ophyd.SoftPositioner` (the
+      historic default);
+    * a ``dict`` spec of the form ``{"class": <callable or import path>,
+      ...kwargs}`` for any nested device.
+
+    Built-in categories — ``"scalar"`` and ``"pseudo_positioner"`` —
+    may be overridden by a later registration.
+
+    PARAMETERS
+
+    category : str
+        The ``category`` value the builder handles (e.g. a custom
+        ``"device_group"``).
+    builder : callable
+        ``builder(record) -> creator-reals-spec``.
+    """
+    if not isinstance(category, str) or not category:
+        raise ValueError(f"category must be a non-empty str; got {category!r}")
+    if not callable(builder):
+        raise TypeError(f"builder must be callable; got {type(builder).__name__!r}")
+    _AUX_RECONSTRUCTORS[category] = builder
+
+
+def _normalize_aux_record(entry: Any) -> dict:
+    """Coerce a v1 (str) or v2 (dict) aux entry into the v2 record form."""
+    from .exceptions import ConfigurationError
+
+    if isinstance(entry, str):  # legacy v1 form
+        return {"name": entry, "category": "scalar"}
+    if not isinstance(entry, Mapping):
+        raise ConfigurationError(
+            f"auxiliary_axes entry must be a str (legacy) or dict; got {entry!r}"
+        )
+    rec = dict(entry)
+    if "name" not in rec or not isinstance(rec["name"], str) or not rec["name"]:
+        raise ConfigurationError(
+            f"auxiliary_axes record is missing a non-empty 'name': {entry!r}"
+        )
+    rec.setdefault("category", "scalar")
+    if rec["category"] not in _AUX_RECONSTRUCTORS:
+        warnings.warn(
+            (
+                f"Unknown auxiliary_axes category {rec['category']!r}"
+                f" for {rec['name']!r}; falling back to scalar SoftPositioner."
+            ),
+            UserWarning,
+            stacklevel=3,
+        )
+        rec["category"] = "scalar"
+    return rec
+
+
+def _build_scalar_aux(record: Mapping[str, Any]) -> Any:
+    """Built-in builder for ``category == 'scalar'``: a SoftPositioner."""
+    return None  # creator() interprets None as a default SoftPositioner
+
+
+def _build_pseudo_positioner_aux(record: Mapping[str, Any]) -> dict:
+    """Built-in builder for ``category == 'pseudo_positioner'``."""
+    from .devices import make_aux_pseudo_positioner_class
+
+    cls = make_aux_pseudo_positioner_class(
+        name=record["name"],
+        pseudos=record.get("pseudos") or [],
+        reals=record.get("reals") or [],
+    )
+    return {"class": cls, "kind": "hinted"}
+
+
+# Register built-ins.  Users may override via register_aux_reconstructor().
+_AUX_RECONSTRUCTORS["scalar"] = _build_scalar_aux
+_AUX_RECONSTRUCTORS["pseudo_positioner"] = _build_pseudo_positioner_aux
 
 
 class ConfigurationRunWrapper:
@@ -343,6 +448,15 @@ def list_orientation_runs(
     version="0.6.1",
     reason="Accept a ``DiffractometerBase`` instance directly.",
 )
+@versionchanged(
+    version="0.7.0",
+    reason=(
+        "Restore nested ``PseudoPositioner`` auxiliaries as structural "
+        "stand-ins (forward/inverse return zeros).  ``axes.auxiliary_axes`` "
+        "is now a list of ``{name, category, …}`` records; the legacy flat "
+        "list of names is still accepted on read.  See :issue:`388`."
+    ),
+)
 def simulator_from_config(config):
     """
     Create a simulated diffractometer from a saved configuration.
@@ -462,10 +576,20 @@ def simulator_from_config(config):
 
     reals_dict = {name: None for name in real_axes}
 
-    # Restore auxiliary axes saved in the config (backward-compatible: absent in old files).
-    for name in axes_cfg.get("auxiliary_axes", []):
-        if name not in reals_dict:
-            reals_dict[name] = None
+    # Restore auxiliary axes saved in the config.  Backward-compatible:
+    #   * absent in very old files (handled by .get() default);
+    #   * v1 schema: flat list of names (str) — normalised to scalar records;
+    #   * v2 schema: list of {name, category, ...} records.
+    # See issue #388.
+    for entry in axes_cfg.get("auxiliary_axes", []):
+        record = _normalize_aux_record(entry)
+        aux_name = record["name"]
+        if aux_name in reals_dict:
+            # An aux that overlaps with a real axis is not an auxiliary;
+            # leave the real-axis entry alone.
+            continue
+        builder = _AUX_RECONSTRUCTORS[record["category"]]
+        reals_dict[aux_name] = builder(record)
 
     # Pass _real and _pseudo so creator() maps axes in solver-expected order
     # even when diffractometer names differ from solver canonical names.

--- a/src/hklpy2/tests/configuration_i240.yml
+++ b/src/hklpy2/tests/configuration_i240.yml
@@ -3,7 +3,7 @@
 _header:
   datetime: '2026-04-30 17:31:46.831426'
   hklpy2_version: 0.6.2.dev4+gde2b3abb7.d20260430
-  config_schema_version: 1
+  config_schema_version: 2
   python_class: Hklpy2Diffractometer
   file: /home/beams1/JEMIAN/Documents/projects/Bluesky/hklpy2/src/hklpy2/tests/configuration_i240.yml.reexport.tmp
   comment: 're-exported for issue #390 schema sync (configuration_i240.yml)'

--- a/src/hklpy2/tests/e4cv-silicon-example.yml
+++ b/src/hklpy2/tests/e4cv-silicon-example.yml
@@ -3,7 +3,7 @@
 _header:
   datetime: '2026-04-30 17:31:45.287102'
   hklpy2_version: 0.6.2.dev4+gde2b3abb7.d20260430
-  config_schema_version: 1
+  config_schema_version: 2
   python_class: Hklpy2Diffractometer
   file: /home/beams1/JEMIAN/Documents/projects/Bluesky/hklpy2/src/hklpy2/tests/e4cv-silicon-example.yml.reexport.tmp
   comment: 're-exported for issue #390 schema sync (e4cv-silicon-example.yml)'

--- a/src/hklpy2/tests/e4cv_orient.yml
+++ b/src/hklpy2/tests/e4cv_orient.yml
@@ -3,7 +3,7 @@
 _header:
   datetime: '2026-04-30 17:31:44.495500'
   hklpy2_version: 0.6.2.dev4+gde2b3abb7.d20260430
-  config_schema_version: 1
+  config_schema_version: 2
   python_class: Hklpy2Diffractometer
   file: /home/beams1/JEMIAN/Documents/projects/Bluesky/hklpy2/src/hklpy2/tests/e4cv_orient.yml.reexport.tmp
   comment: 're-exported for issue #390 schema sync (e4cv_orient.yml)'

--- a/src/hklpy2/tests/fourc-configuration.yml
+++ b/src/hklpy2/tests/fourc-configuration.yml
@@ -3,7 +3,7 @@
 _header:
   datetime: '2025-04-07'
   hklpy2_version: 0.0.25.dev88+g6e0f270.d20240926
-  config_schema_version: 1
+  config_schema_version: 2
   python_class: Fourc
   file: fourc-configuration.yml
   comment: 'E4CV with Fourc axes names and vibranium orientation'

--- a/src/hklpy2/tests/fourc-i183.yml
+++ b/src/hklpy2/tests/fourc-i183.yml
@@ -3,7 +3,7 @@
 _header:
   datetime: '2026-04-30 17:31:46.053305'
   hklpy2_version: 0.6.2.dev4+gde2b3abb7.d20260430
-  config_schema_version: 1
+  config_schema_version: 2
   python_class: Hklpy2Diffractometer
   file: /home/beams1/JEMIAN/Documents/projects/Bluesky/hklpy2/src/hklpy2/tests/fourc-i183.yml.reexport.tmp
   comment: 're-exported for issue #390 schema sync (fourc-i183.yml)'

--- a/src/hklpy2/tests/tardis.yml
+++ b/src/hklpy2/tests/tardis.yml
@@ -3,7 +3,7 @@
 _header:
   datetime: '2025-04-09 21:38:25.942848'
   hklpy2_version: 0.0.29.dev43+gdc399a0.d20250410
-  config_schema_version: 1
+  config_schema_version: 2
   python_class: Hklpy2Diffractometer
   file: dev_tardis-cmazzoli.yml
   comment: NSLS-II tardis with oriented sample from @cmazzoli

--- a/src/hklpy2/tests/test_aux_roundtrip.py
+++ b/src/hklpy2/tests/test_aux_roundtrip.py
@@ -1,0 +1,352 @@
+"""
+Tests for issue #388: round-trip of auxiliary sub-devices (scalar +
+nested ``PseudoPositioner``) through the export / restore schema (v2).
+"""
+
+import re
+import warnings
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from ..blocks.configure import CONFIG_SCHEMA_VERSION
+from ..devices import describe_aux
+from ..devices import make_aux_pseudo_positioner_class
+from ..exceptions import ConfigurationError
+from ..run_utils import _AUX_RECONSTRUCTORS
+from ..run_utils import _normalize_aux_record
+from ..run_utils import register_aux_reconstructor
+from ..run_utils import simulator_from_config
+from .test_diffract import _build_gonio_with_nested_pseudo
+
+
+# ---------------------------------------------------------------------------
+# Schema-v2 export: describe_aux() and Core._asdict()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                aux_name="tablex",
+                expected=dict(name="tablex", category="scalar"),
+            ),
+            does_not_raise(),
+            id="scalar-aux-record",
+        ),
+        pytest.param(
+            dict(
+                aux_name="ana",
+                expected=dict(
+                    name="ana",
+                    category="pseudo_positioner",
+                    pseudos=["energy"],
+                    reals=["theta"],
+                    class_name="_MiniAnalyzer",
+                ),
+            ),
+            does_not_raise(),
+            id="pseudo-positioner-aux-record",
+        ),
+    ],
+)
+def test_describe_aux(parms, context):
+    """``describe_aux()`` produces v2 records with the right shape."""
+    with context:
+        gonio = _build_gonio_with_nested_pseudo()
+        record = describe_aux(gonio, parms["aux_name"])
+
+        for key, value in parms["expected"].items():
+            if key == "class_name":
+                assert record["class"] == value
+            else:
+                assert record[key] == value
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(check="schema-version-bumped"),
+            does_not_raise(),
+            id="schema-version-is-2",
+        ),
+        pytest.param(
+            dict(check="aux-axes-is-list-of-records"),
+            does_not_raise(),
+            id="aux-axes-record-form",
+        ),
+    ],
+)
+def test_export_schema_v2(parms, context):
+    """``Core._asdict()`` writes schema v2 with record-form aux axes."""
+    with context:
+        gonio = _build_gonio_with_nested_pseudo()
+        cfg = gonio.configuration
+
+        if parms["check"] == "schema-version-bumped":
+            assert cfg["_header"]["config_schema_version"] == CONFIG_SCHEMA_VERSION
+            assert CONFIG_SCHEMA_VERSION == 2
+
+        elif parms["check"] == "aux-axes-is-list-of-records":
+            aux = cfg["axes"]["auxiliary_axes"]
+            assert all(isinstance(rec, dict) for rec in aux)
+            assert {rec["name"] for rec in aux} == {"tablex", "ana"}
+            ana = next(r for r in aux if r["name"] == "ana")
+            assert ana["category"] == "pseudo_positioner"
+            assert ana["pseudos"] == ["energy"]
+            assert ana["reals"] == ["theta"]
+
+
+# ---------------------------------------------------------------------------
+# Schema-v1 / v2 input normalisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                entry="tablex",
+                expected=dict(name="tablex", category="scalar"),
+            ),
+            does_not_raise(),
+            id="legacy-string-form",
+        ),
+        pytest.param(
+            dict(
+                entry={"name": "tablex"},
+                expected=dict(name="tablex", category="scalar"),
+            ),
+            does_not_raise(),
+            id="record-without-category-defaults-scalar",
+        ),
+        pytest.param(
+            dict(
+                entry={
+                    "name": "ana",
+                    "category": "pseudo_positioner",
+                    "pseudos": ["energy"],
+                    "reals": ["theta"],
+                },
+                expected=dict(name="ana", category="pseudo_positioner"),
+            ),
+            does_not_raise(),
+            id="full-pseudo-positioner-record",
+        ),
+        pytest.param(
+            dict(entry={"category": "scalar"}),
+            pytest.raises(
+                ConfigurationError,
+                match=re.escape("missing a non-empty 'name'"),
+            ),
+            id="missing-name-raises",
+        ),
+        pytest.param(
+            dict(entry=42),
+            pytest.raises(
+                ConfigurationError,
+                match=re.escape("must be a str (legacy) or dict"),
+            ),
+            id="bogus-type-raises",
+        ),
+    ],
+)
+def test_normalize_aux_record(parms, context):
+    """Legacy-vs-record normalisation, plus error paths."""
+    with context:
+        record = _normalize_aux_record(parms["entry"])
+        for key, value in parms["expected"].items():
+            assert record[key] == value
+
+
+def test_normalize_aux_record_unknown_category_warns_and_degrades():
+    """Unknown category emits ``UserWarning`` and degrades to ``scalar``."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        record = _normalize_aux_record(
+            {"name": "weird", "category": "no-such-category"}
+        )
+
+    assert record["category"] == "scalar"
+    matching = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning) and "no-such-category" in str(w.message)
+    ]
+    assert len(matching) == 1, f"expected one UserWarning, got: {matching!r}"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end round-trip via simulator_from_config()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                check="aux-names-preserved",
+                expected_names={"tablex", "ana"},
+            ),
+            does_not_raise(),
+            id="round-trip-aux-names",
+        ),
+        pytest.param(
+            dict(
+                check="ana-substructure-preserved",
+                expected_pseudos=["energy"],
+                expected_reals=["theta"],
+            ),
+            does_not_raise(),
+            id="round-trip-pseudo-positioner-substructure",
+        ),
+        pytest.param(
+            dict(check="wh-full-does-not-raise"),
+            does_not_raise(),
+            id="round-trip-wh-full",
+        ),
+    ],
+)
+def test_simulator_from_config_aux_roundtrip(parms, context):
+    """Nested PseudoPositioner aux survives export -> simulator_from_config."""
+    with context:
+        gonio = _build_gonio_with_nested_pseudo()
+        cfg = gonio.configuration
+        sim = simulator_from_config(cfg)
+
+        if parms["check"] == "aux-names-preserved":
+            assert set(sim.auxiliary_axis_names) == parms["expected_names"]
+
+        elif parms["check"] == "ana-substructure-preserved":
+            from ophyd import PseudoPositioner
+
+            assert isinstance(sim.ana, PseudoPositioner)
+            assert [p.attr_name for p in sim.ana.pseudo_positioners] == parms[
+                "expected_pseudos"
+            ]
+            assert [r.attr_name for r in sim.ana.real_positioners] == parms[
+                "expected_reals"
+            ]
+
+        elif parms["check"] == "wh-full-does-not-raise":
+            sim.wh(full=True)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(legacy_form=["tablex"]),
+            does_not_raise(),
+            id="v1-flat-list-of-strings",
+        ),
+    ],
+)
+def test_simulator_from_config_accepts_v1_aux_form(parms, context):
+    """Legacy v1 flat-list ``auxiliary_axes`` still loads without error."""
+    with context:
+        # Build a minimal v1-shaped config and feed it through
+        # simulator_from_config().  We start from a v2 export and rewrite
+        # only the auxiliary_axes field.
+        from hklpy2 import creator
+
+        donor = creator(name="donor")
+        cfg = donor.configuration
+        cfg["axes"]["auxiliary_axes"] = parms["legacy_form"]
+
+        sim = simulator_from_config(cfg)
+        for legacy_name in parms["legacy_form"]:
+            assert legacy_name in sim.auxiliary_axis_names
+
+
+# ---------------------------------------------------------------------------
+# Public hook: register_aux_reconstructor()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(category="my_cat", builder=lambda rec: None),
+            does_not_raise(),
+            id="register-and-use",
+        ),
+        pytest.param(
+            dict(category="", builder=lambda rec: None),
+            pytest.raises(ValueError, match=re.escape("non-empty str")),
+            id="empty-category-rejected",
+        ),
+        pytest.param(
+            dict(category="x", builder="not-callable"),
+            pytest.raises(TypeError, match=re.escape("builder must be callable")),
+            id="non-callable-builder-rejected",
+        ),
+    ],
+)
+def test_register_aux_reconstructor(parms, context):
+    """Registry rejects bad inputs, accepts good ones, and is consulted on read."""
+    with context:
+        register_aux_reconstructor(parms["category"], parms["builder"])
+        # On success the entry is queryable and the normaliser accepts it.
+        assert _AUX_RECONSTRUCTORS[parms["category"]] is parms["builder"]
+
+        record = _normalize_aux_record({"name": "x", "category": parms["category"]})
+        # No degrade-to-scalar warning path:
+        assert record["category"] == parms["category"]
+
+        # Cleanup so we don't leak state between parametrize cases.
+        _AUX_RECONSTRUCTORS.pop(parms["category"], None)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic PseudoPositioner builder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(name="aux1", pseudos=["e"], reals=["t"]),
+            does_not_raise(),
+            id="single-pseudo-single-real",
+        ),
+        pytest.param(
+            dict(name="aux2", pseudos=["a", "b"], reals=["x", "y", "z"]),
+            does_not_raise(),
+            id="multi-pseudo-multi-real",
+        ),
+        pytest.param(
+            dict(name="bad", pseudos=[], reals=["t"]),
+            pytest.raises(ValueError, match=re.escape("at least one pseudo")),
+            id="empty-pseudos-raises",
+        ),
+        pytest.param(
+            dict(name="bad", pseudos=["e"], reals=[]),
+            pytest.raises(ValueError, match=re.escape("at least one real")),
+            id="empty-reals-raises",
+        ),
+    ],
+)
+def test_make_aux_pseudo_positioner_class(parms, context):
+    """Synthetic class is well-formed and forward/inverse return zeros."""
+    with context:
+        cls = make_aux_pseudo_positioner_class(
+            name=parms["name"],
+            pseudos=parms["pseudos"],
+            reals=parms["reals"],
+        )
+        instance = cls(name=parms["name"])
+        assert [p.attr_name for p in instance.pseudo_positioners] == parms["pseudos"]
+        assert [r.attr_name for r in instance.real_positioners] == parms["reals"]
+        # forward/inverse return zero-valued tuples of the right length.
+        rp = instance.forward(instance.PseudoPosition(*([1.0] * len(parms["pseudos"]))))
+        assert tuple(rp) == tuple([0.0] * len(parms["reals"]))
+        pp = instance.inverse(instance.RealPosition(*([1.0] * len(parms["reals"]))))
+        assert tuple(pp) == tuple([0.0] * len(parms["pseudos"]))

--- a/src/hklpy2/tests/test_aux_roundtrip.py
+++ b/src/hklpy2/tests/test_aux_roundtrip.py
@@ -350,3 +350,94 @@ def test_make_aux_pseudo_positioner_class(parms, context):
         assert tuple(rp) == tuple([0.0] * len(parms["reals"]))
         pp = instance.inverse(instance.RealPosition(*([1.0] * len(parms["reals"]))))
         assert tuple(pp) == tuple([0.0] * len(parms["pseudos"]))
+
+
+# ---------------------------------------------------------------------------
+# define_real_axis() / make_component() callable-class acceptance (#388)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(spec={"class": 42}),
+            pytest.raises(
+                TypeError,
+                match=re.escape("must be a dotted import path (str) or a callable"),
+            ),
+            id="define-real-axis-bogus-class",
+        ),
+        pytest.param(
+            dict(spec={"class": "ophyd.SoftPositioner"}),
+            does_not_raise(),
+            id="define-real-axis-string-class",
+        ),
+    ],
+)
+def test_define_real_axis_class_kind(parms, context):
+    """``define_real_axis`` rejects non-str non-callable ``class`` values."""
+    from ..devices import define_real_axis
+
+    with context:
+        define_real_axis(parms["spec"], dict(labels=[]))
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(call_name=42),
+            pytest.raises(
+                TypeError,
+                match=re.escape("must be a dotted import path"),
+            ),
+            id="make-component-bogus-call-name",
+        ),
+        pytest.param(
+            dict(call_name="ophyd.SoftPositioner"),
+            does_not_raise(),
+            id="make-component-string-call-name",
+        ),
+    ],
+)
+def test_make_component_call_name_kind(parms, context):
+    """``make_component`` rejects non-str non-callable ``call_name`` values."""
+    from ..devices import make_component
+
+    with context:
+        make_component(parms["call_name"])
+
+
+# ---------------------------------------------------------------------------
+# simulator_from_config(): aux name overlapping a real axis is left alone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(overlap_name="omega"),
+            does_not_raise(),
+            id="aux-name-collides-with-real-axis",
+        ),
+    ],
+)
+def test_simulator_from_config_aux_overlapping_real(parms, context):
+    """An aux record whose name matches a real axis is silently skipped."""
+    from hklpy2 import creator
+
+    with context:
+        donor = creator(name="donor")
+        cfg = donor.configuration
+        # Inject an aux record whose name shadows a real axis.
+        cfg["axes"]["auxiliary_axes"] = [
+            {"name": parms["overlap_name"], "category": "scalar"}
+        ]
+
+        sim = simulator_from_config(cfg)
+        # The real-axis omega remains a SoftPositioner (not overwritten),
+        # and is not surfaced as an auxiliary.
+        assert parms["overlap_name"] in sim.real_axis_names
+        assert parms["overlap_name"] not in sim.auxiliary_axis_names

--- a/src/hklpy2/tests/test_i210.py
+++ b/src/hklpy2/tests/test_i210.py
@@ -372,10 +372,13 @@ def test_simulator_from_config_auxiliary_axes_roundtrip(tmp_path):
     sim.core.calc_UB(r1, r2)
 
     # Export — auxiliary_axes must appear in the saved config.
+    # Schema v2 (issue #388): record form, not flat list of names.
     config_file = tmp_path / "e4cv-analyzer.yml"
     sim.export(str(config_file))
     cfg = yaml.safe_load(config_file.read_text())
-    assert cfg["axes"].get("auxiliary_axes") == ["atheta", "attheta"]
+    aux = cfg["axes"].get("auxiliary_axes")
+    assert [rec["name"] for rec in aux] == ["atheta", "attheta"]
+    assert all(rec["category"] == "scalar" for rec in aux)
 
     # Restore without reals= — auxiliary axes come from the config automatically.
     sim2 = simulator_from_config(config_file)


### PR DESCRIPTION
- closes #388

## Summary

* Bumps configuration schema to **v2** so ``axes.auxiliary_axes`` carries
  a list of records (``{name, category, ...}``) instead of a flat list of
  attribute names.  v1 (flat-list) is still accepted on read.
* Nested ``PseudoPositioner`` auxiliaries (e.g. an analyzer with
  ``.energy`` / ``.theta``) now round-trip through ``export()`` ->
  ``simulator_from_config()`` with their sub-axis structure preserved.
  The synthesised stand-in is **structural only**: ``forward()`` /
  ``inverse()`` return zeros (the simulator does not know the device's
  physics).
* Public hook ``register_aux_reconstructor(category, builder)`` lets
  users plug in custom builders for new ``category`` values without
  another schema bump.

## Implementation

* ``devices.describe_aux()`` — categorises an auxiliary into a v2 record.
* ``devices.make_aux_pseudo_positioner_class()`` — builds the synthetic
  structural stand-in.
* Both helpers live in ``devices.py`` (the ophyd-typed module),
  preserving ``ops.py``'s ophyd-free separation of concerns.
* ``run_utils._normalize_aux_record()`` accepts both v1 (str) and v2
  (dict) entries; unknown ``category`` warns and degrades to ``scalar``
  (consistent with the warn-and-proceed policy from #396).
* ``define_real_axis`` / ``make_component`` accept a callable in
  addition to a dotted-path string for ``class``, so the synthesised
  stand-in class can be passed directly without round-tripping through
  ``importlib``.
* Built-in registry entries: ``scalar`` (``None`` -> ``SoftPositioner``)
  and ``pseudo_positioner`` (synthesised stand-in).

## Verification

* ``pre-commit run --all-files``: all hooks pass.
* ``pytest src/hklpy2``: 1258 passed, 7 skipped, 8 deselected (no new
  failures).  21 new tests in ``test_aux_roundtrip.py`` plus an updated
  assertion in ``test_i210.py``.

Agent: OpenCode (claudeopus47)