### PR TITLE
feat #405 forward non-reserved solver: keys as solver_kwargs

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -30,6 +30,14 @@ describe future plans.
 
     Release expected 2026-Q3.
 
+0.7.1
+#####
+
+Enhancements
+------------
+
+* Forward non-reserved ``solver:`` keys as ``solver_kwargs`` in ``simulator_from_config()``. (:issue:`405`)
+
 0.7.0
 #####
 

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -302,7 +302,31 @@ class SolverBase(ABC):
 
     @property
     def _metadata(self) -> SolverMetadataDict:
-        """Dictionary with this solver's summary metadata."""
+        """
+        Dictionary with this solver's summary metadata.
+
+        .. rubric:: Persistence and round-trip contract
+
+        The dictionary returned here becomes the ``solver:`` block in
+        the YAML configuration produced by
+        :meth:`~hklpy2.diffract.DiffractometerBase.export`.  On restore,
+        :func:`~hklpy2.run_utils.simulator_from_config` forwards every
+        key *except* the reserved set
+        ``{"name", "description", "geometry", "real_axes", "version",
+        "mode"}`` into the solver constructor as a ``solver_kwargs``
+        entry (see :issue:`405`).
+
+        Subclasses that override ``_metadata`` to persist additional
+        solver construction state are responsible for:
+
+        * choosing key names that do not collide with the reserved set
+          listed above, and
+        * accepting the matching keyword argument(s) in their
+          ``__init__`` so the persisted state is actually re-applied.
+
+        Subclasses are encouraged to call ``super()._metadata`` and
+        extend the returned dictionary rather than replacing it.
+        """
         return {
             "name": self.name,
             "description": repr(self),

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -45,6 +45,30 @@ __all__ = [
 
 
 # ---------------------------------------------------------------------------
+# Reserved keys in the persisted ``solver:`` configuration block.
+#
+# Every other key found in ``solver:`` at restore time is forwarded into
+# ``solver_kwargs`` so that solver-specific construction state persisted via
+# a ``_metadata`` override survives the export/restore round-trip
+# (issue #405).  Out-of-tree solver authors should avoid collisions with
+# this set when extending ``_metadata``.
+#
+# Reserved key meanings:
+#   * ``name``         — selects the solver class
+#   * ``geometry``     — selects the solver geometry
+#   * ``real_axes``    — solver-canonical real-axis ordering
+#   * ``description``  — informational only
+#   * ``version``      — informational only
+#   * ``mode``         — re-applied post-construction by
+#                        ``Diffractometer.restore()``; must not also flow
+#                        as a construction kwarg
+# ---------------------------------------------------------------------------
+_RESERVED_SOLVER_KEYS: frozenset[str] = frozenset(
+    {"name", "description", "geometry", "real_axes", "version", "mode"}
+)
+
+
+# ---------------------------------------------------------------------------
 # Auxiliary-axis reconstruction (issue #388)
 # ---------------------------------------------------------------------------
 
@@ -457,6 +481,15 @@ def list_orientation_runs(
         "list of names is still accepted on read.  See :issue:`388`."
     ),
 )
+@versionchanged(
+    version="0.7.1",
+    reason=(
+        "Forward every non-reserved key in the ``solver:`` block as a "
+        "``solver_kwargs`` entry so that solver-specific construction "
+        "state persisted via ``_metadata`` survives the round-trip.  "
+        "See :issue:`405`."
+    ),
+)
 def simulator_from_config(config):
     """
     Create a simulated diffractometer from a saved configuration.
@@ -499,6 +532,17 @@ def simulator_from_config(config):
 
         >>> sim = hklpy2.simulator_from_config(diffractometer)
 
+    .. rubric:: Solver construction kwargs
+
+    Every key in the persisted ``solver:`` block *except* the reserved
+    set ``{"name", "description", "geometry", "real_axes", "version",
+    "mode"}`` is forwarded to the solver's constructor as a
+    ``solver_kwargs`` entry.  This lets a solver persist arbitrary
+    construction state by overriding its ``_metadata`` property and
+    accepting the matching keyword in its ``__init__``.  See
+    :issue:`405`.  Solver authors are responsible for choosing
+    ``_metadata`` key names that do not collide with the reserved set.
+
     SEE ALSO
 
         :func:`~hklpy2.diffract.creator` — create a diffractometer from scratch.
@@ -536,10 +580,18 @@ def simulator_from_config(config):
 
     geometry = solver_cfg.get("geometry") or get_solver(solver_name).default_geometry()
 
-    solver_kwargs: dict = {}
-    engine = solver_cfg.get("engine")
-    if engine is not None:
-        solver_kwargs["engine"] = engine
+    # Generic forwarding (issue #405): every non-reserved key in the
+    # ``solver:`` block flows through to the solver constructor via
+    # ``solver_kwargs``.  This subsumes the previous ``engine`` special
+    # case and lets out-of-tree solvers persist construction state by
+    # overriding ``_metadata`` -- no new abstract API is required.
+    solver_kwargs: dict = {
+        k: v for k, v in solver_cfg.items() if k not in _RESERVED_SOLVER_KEYS
+    }
+    if solver_kwargs:
+        logger.debug(
+            "simulator_from_config: forwarding solver_kwargs=%r", solver_kwargs
+        )
 
     axes_cfg = config.get("axes", {})
     axes_xref = axes_cfg.get("axes_xref", {})

--- a/src/hklpy2/tests/test_i405.py
+++ b/src/hklpy2/tests/test_i405.py
@@ -14,7 +14,7 @@ from typing import List
 
 import pytest
 
-import hklpy2
+from hklpy2 import creator
 from hklpy2 import solver_utils
 from hklpy2.backends.no_op import NoOpSolver
 from hklpy2.backends.typing import GeometryDescriptor
@@ -133,7 +133,7 @@ def _patched_solvers(monkeypatch):
 def test_solver_kwargs_roundtrip(parms, context, _patched_solvers, caplog):
     """Non-reserved ``solver:`` keys flow through ``solver_kwargs``."""
     with context:
-        original = hklpy2.creator(
+        original = creator(
             name="standin",
             solver=_StandInSolver.name,
             geometry="STANDIN",
@@ -181,7 +181,7 @@ def test_multiple_non_reserved_keys_forwarded(parms, context, _patched_solvers):
         # Build a minimal config dict by hand so we exercise the
         # forwarding path on arbitrary extra keys without depending on
         # the stand-in's ``_metadata`` shape.
-        original = hklpy2.creator(
+        original = creator(
             name="standin",
             solver=_StandInSolver.name,
             geometry="STANDIN",
@@ -241,7 +241,7 @@ def test_hkl_soleil_engine_still_forwarded(parms, context):
     """
     pytest.importorskip("hkl")
     with context:
-        original = hklpy2.creator(
+        original = creator(
             name="sixc",
             geometry="E6C",
             solver_kwargs={"engine": "psi"},

--- a/src/hklpy2/tests/test_i405.py
+++ b/src/hklpy2/tests/test_i405.py
@@ -1,0 +1,253 @@
+"""
+Regression test for issue #405.
+
+``simulator_from_config()`` must forward every non-reserved key in the
+persisted ``solver:`` block to the solver constructor via
+``solver_kwargs``.  This lets out-of-tree solvers persist construction
+state by overriding ``_metadata`` and accepting the matching keyword
+in their ``__init__``.
+"""
+
+import logging
+from contextlib import nullcontext as does_not_raise
+from typing import List
+
+import pytest
+
+import hklpy2
+from hklpy2 import solver_utils
+from hklpy2.backends.no_op import NoOpSolver
+from hklpy2.backends.typing import GeometryDescriptor
+from hklpy2.run_utils import _RESERVED_SOLVER_KEYS
+from hklpy2.run_utils import simulator_from_config
+
+# Module-level mutable cell so the stand-in solver's ``__init__`` can
+# report what kwargs it received to the active test function.
+_LAST_INIT_KWARGS: dict = {}
+
+
+class _StandInSolver(NoOpSolver):
+    """
+    Minimal stand-in solver used only by the issue-405 round-trip test.
+
+    Persists an arbitrary ``marker`` field through ``_metadata`` and
+    accepts it back via ``__init__``.  Recording the received kwargs
+    in a module-level cell lets the test verify that the value made
+    it through the full export / restore round-trip.
+    """
+
+    name = "stand_in_405"
+    _geometry_registry: dict = {}
+
+    def __init__(
+        self,
+        geometry: str,
+        *,
+        marker: str = "",
+        another: object = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(geometry, **kwargs)
+        self._marker = marker
+        self._another = another
+        _LAST_INIT_KWARGS.clear()
+        _LAST_INIT_KWARGS.update(
+            {"geometry": geometry, "marker": marker, "another": another}
+        )
+
+    @property
+    def _metadata(self):
+        meta = dict(super()._metadata)
+        meta["marker"] = self._marker
+        return meta
+
+    @property
+    def real_axis_names(self) -> List[str]:
+        return ["omega"]
+
+    @property
+    def pseudo_axis_names(self) -> List[str]:
+        return ["h"]
+
+    @property
+    def modes(self) -> List[str]:
+        return ["default"]
+
+
+# Register a single fake geometry on the stand-in solver.
+_StandInSolver.register_geometry(
+    GeometryDescriptor(
+        name="STANDIN",
+        pseudo_axis_names=["h"],
+        real_axis_names=["omega"],
+        modes=["default"],
+        extra_axis_names={"default": []},
+    )
+)
+
+
+@pytest.fixture
+def _patched_solvers(monkeypatch):
+    """Make the stand-in solver discoverable via ``get_solver``."""
+
+    real_get_solver = solver_utils.get_solver
+    real_solvers = solver_utils.solvers
+
+    def fake_get_solver(name):
+        if name == _StandInSolver.name:
+            return _StandInSolver
+        return real_get_solver(name)
+
+    def fake_solvers():
+        mapping = dict(real_solvers())
+        mapping[_StandInSolver.name] = (
+            f"{_StandInSolver.__module__}:{_StandInSolver.__name__}"
+        )
+        return mapping
+
+    monkeypatch.setattr(solver_utils, "get_solver", fake_get_solver)
+    monkeypatch.setattr(solver_utils, "solvers", fake_solvers)
+    yield
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(marker="hello-405"),
+            does_not_raise(),
+            id="non-reserved marker key survives round-trip",
+        ),
+        pytest.param(
+            dict(marker=""),
+            does_not_raise(),
+            id="empty marker still forwarded",
+        ),
+        pytest.param(
+            dict(marker={"nested": [1, 2, 3]}),
+            does_not_raise(),
+            id="structured marker value survives round-trip",
+        ),
+    ],
+)
+def test_solver_kwargs_roundtrip(parms, context, _patched_solvers, caplog):
+    """Non-reserved ``solver:`` keys flow through ``solver_kwargs``."""
+    with context:
+        original = hklpy2.creator(
+            name="standin",
+            solver=_StandInSolver.name,
+            geometry="STANDIN",
+            solver_kwargs={"marker": parms["marker"]},
+        )
+
+        # The solver received the marker on the first construction.
+        assert _LAST_INIT_KWARGS["marker"] == parms["marker"]
+
+        # Snapshot, then rebuild from the config dict.
+        config = original.configuration
+        assert config["solver"]["marker"] == parms["marker"]
+
+        # Capture the debug-log entry that lists the forwarded kwargs.
+        _LAST_INIT_KWARGS.clear()
+        with caplog.at_level(logging.DEBUG, logger="hklpy2.run_utils"):
+            sim = simulator_from_config(config)
+
+        # Stand-in solver's ``__init__`` was called with the marker.
+        assert _LAST_INIT_KWARGS["marker"] == parms["marker"]
+        # The new simulator carries the same marker.
+        assert sim.core.solver._marker == parms["marker"]
+
+        # Debug logging announces forwarded kwargs (issue #405).
+        forwarded_msgs = [
+            r.message for r in caplog.records if "forwarding solver_kwargs" in r.message
+        ]
+        assert forwarded_msgs, "expected a 'forwarding solver_kwargs' debug line"
+        assert "marker" in forwarded_msgs[0]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(extra_keys={"marker": "m", "another": 42}),
+            does_not_raise(),
+            id="multiple non-reserved keys all forwarded",
+        ),
+    ],
+)
+def test_multiple_non_reserved_keys_forwarded(parms, context, _patched_solvers):
+    """Every non-reserved key in ``solver:`` flows through, not just one."""
+    with context:
+        # Build a minimal config dict by hand so we exercise the
+        # forwarding path on arbitrary extra keys without depending on
+        # the stand-in's ``_metadata`` shape.
+        original = hklpy2.creator(
+            name="standin",
+            solver=_StandInSolver.name,
+            geometry="STANDIN",
+            solver_kwargs={"marker": "m"},
+        )
+        config = original.configuration
+        # Inject additional non-reserved keys after export.
+        config["solver"].update(parms["extra_keys"])
+
+        _LAST_INIT_KWARGS.clear()
+        simulator_from_config(config)
+
+        # Both non-reserved keys reached the stand-in constructor.
+        for key, value in parms["extra_keys"].items():
+            assert _LAST_INIT_KWARGS[key] == value
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                reserved={
+                    "name",
+                    "description",
+                    "geometry",
+                    "real_axes",
+                    "version",
+                    "mode",
+                }
+            ),
+            does_not_raise(),
+            id="reserved key set matches the documented contract",
+        ),
+    ],
+)
+def test_reserved_solver_keys_contract(parms, context):
+    """The reserved-key set is stable and matches its documentation."""
+    with context:
+        assert set(_RESERVED_SOLVER_KEYS) == parms["reserved"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="HklSolver engine field still survives round-trip",
+        ),
+    ],
+)
+def test_hkl_soleil_engine_still_forwarded(parms, context):
+    """
+    The pre-existing ``engine`` special case is subsumed by the generic
+    forwarding; HklSolver configs must continue to round-trip unchanged.
+    """
+    pytest.importorskip("hkl")
+    with context:
+        original = hklpy2.creator(
+            name="sixc",
+            geometry="E6C",
+            solver_kwargs={"engine": "psi"},
+        )
+        config = original.configuration
+        assert config["solver"]["engine"] == "psi"
+
+        sim = simulator_from_config(config)
+        assert sim.core.solver.engine_name == "psi"


### PR DESCRIPTION
- closes #405

## Summary

`simulator_from_config()` now forwards every key in the persisted `solver:`
block except a small reserved set (`name`, `description`, `geometry`,
`real_axes`, `version`, `mode`) into `solver_kwargs`.  This lets
out-of-tree solvers persist arbitrary construction state by overriding
`_metadata` and accepting the matching keyword in `__init__` — no new
abstract API is required.  The previous `engine` special case is
subsumed by the generic forwarding.

## Changes

- `src/hklpy2/run_utils.py`
  - Add module-private `_RESERVED_SOLVER_KEYS` constant with key-by-key
    rationale.
  - Replace the hard-coded `engine`-only branch with a dict-comprehension
    that forwards every non-reserved key.
  - Add a `logger.debug(...)` line announcing the forwarded kwargs.
  - Document the new behavior in `simulator_from_config()`'s docstring
    and stack a `@versionchanged(version="0.7.1", ...)`.
- `src/hklpy2/backends/base.py`
  - Expand `SolverBase._metadata` docstring with the persistence /
    round-trip contract, the reserved-key list, and the solver author's
    responsibilities.
- `src/hklpy2/tests/test_i405.py` (new)
  - In-test `_StandInSolver` (subclass of `NoOpSolver`) registered via
    a `monkeypatch`ed `get_solver` / `solvers` pair.
  - 6 parametrized tests: marker round-trip with three value shapes,
    multi-key forwarding, reserved-set contract, and a regression on
    `HklSolver` `engine` to confirm the pre-existing special case is
    preserved.
- `RELEASE_NOTES.rst`
  - New `0.7.1` section with the Enhancements entry.

## Verification

- `pre-commit run` on all touched files: all hooks pass.
- `pytest src/hklpy2`: **1269 passed, 7 skipped** (218 s).

## Design notes

- The reserved-key set is module-private (`_RESERVED_SOLVER_KEYS`) per
  the "no new abstract API" framing in the issue; solver authors learn
  about it from the `SolverBase._metadata` docstring rather than from
  a public import.
- Solver authors are responsible for avoiding name collisions with the
  reserved set and with `creator()`'s own parameter names; this is
  documented in the `_metadata` docstring.

Agent: OpenCode (claudeopus47)