### PR TITLE
fix: flush dirty solver state before snapshotting configuration

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -30,6 +30,14 @@ describe future plans.
 
     Release expected 2026-Q3.
 
+    0.7.2
+    #####
+
+    Fixes
+    -----
+
+    * Flush pending solver writes before snapshotting ``configuration``. (:issue:`407`)
+
 0.7.1
 #####
 

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -143,10 +143,28 @@ class Core:
             ":issue:`388`."
         ),
     )
+    @versionchanged(
+        version="0.7.2",
+        reason=(
+            "Flush any dirty solver-state domains before reading "
+            "``solver._metadata`` so the snapshot reflects pending writes "
+            "(e.g. a recent ``core.mode = …`` assignment) instead of the "
+            "previous solver state.  See :issue:`407`."
+        ),
+    )
     def _asdict(self) -> KeyValueMap:
         """Describe the diffractometer as a dictionary."""
         from .__init__ import __version__
         from .blocks.configure import CONFIG_SCHEMA_VERSION
+
+        # Ensure the snapshot reflects any pending solver writes.  The
+        # ``solver:`` block is sourced from ``self.solver._metadata``,
+        # which reads live solver state; without this flush a recent
+        # ``core.mode = …`` (or any other deferred push) would be lost
+        # on export.  Gated on the dirty bitfield so the fast path is
+        # unaffected when nothing has changed.  See :issue:`407`.
+        if self._solver_dirty:
+            self.update_solver()
 
         # ``describe_aux`` lives in :mod:`hklpy2.devices` so the
         # ophyd-typing introspection (``isinstance(..., PseudoPositioner)``)

--- a/src/hklpy2/tests/test_i407.py
+++ b/src/hklpy2/tests/test_i407.py
@@ -1,0 +1,201 @@
+"""
+Regression test for issue #407.
+
+``Diffractometer.export()`` / ``core.configuration`` must reflect the
+*current* value of ``core.mode`` after assignment, even if no
+``forward()`` / ``inverse()`` / ``update_solver()`` call has intervened
+to flush the dirty bitfield to the underlying solver.
+
+The fix flushes pending solver writes at the top of
+``Core._asdict()`` (gated on the dirty bitfield) so the snapshot is
+self-consistent.  Covered here:
+
+* The real ``hkl_soleil`` (``HklSolver``) backend, whose ``_metadata``
+  reads ``self.engine.current_mode_get()``.
+* A minimal ``SolverBase``-style stand-in whose ``_metadata`` reads
+  ``self.mode`` (the same pattern out-of-tree solvers use).
+"""
+
+from contextlib import nullcontext as does_not_raise
+from typing import List
+
+import pytest
+
+from hklpy2 import creator
+from hklpy2 import solver_utils
+from hklpy2.backends.no_op import NoOpSolver
+from hklpy2.backends.typing import GeometryDescriptor
+
+
+class _StandInSolver407(NoOpSolver):
+    """
+    Minimal stand-in solver that emits ``mode`` through ``_metadata``.
+
+    Mirrors the pattern used by ``HklSolver`` (and by out-of-tree
+    solvers) where ``_metadata`` surfaces the live solver-side mode.
+    Used to confirm the staleness fix is solver-agnostic.
+    """
+
+    name = "stand_in_407"
+    _geometry_registry: dict = {}
+
+    @property
+    def _metadata(self):
+        meta = dict(super()._metadata)
+        meta["mode"] = self.mode
+        return meta
+
+    @property
+    def real_axis_names(self) -> List[str]:
+        return ["omega"]
+
+    @property
+    def pseudo_axis_names(self) -> List[str]:
+        return ["h"]
+
+    @property
+    def modes(self) -> List[str]:
+        return ["alpha", "beta", "gamma"]
+
+
+_StandInSolver407.register_geometry(
+    GeometryDescriptor(
+        name="STANDIN407",
+        pseudo_axis_names=["h"],
+        real_axis_names=["omega"],
+        modes=["alpha", "beta", "gamma"],
+        extra_axis_names={"alpha": [], "beta": [], "gamma": []},
+    )
+)
+
+
+@pytest.fixture
+def _patched_solvers(monkeypatch):
+    """Make the stand-in solver discoverable via ``get_solver``."""
+    real_get_solver = solver_utils.get_solver
+    real_solvers = solver_utils.solvers
+
+    def fake_get_solver(name):
+        if name == _StandInSolver407.name:
+            return _StandInSolver407
+        return real_get_solver(name)
+
+    def fake_solvers():
+        mapping = dict(real_solvers())
+        mapping[_StandInSolver407.name] = (
+            f"{_StandInSolver407.__module__}:{_StandInSolver407.__name__}"
+        )
+        return mapping
+
+    monkeypatch.setattr(solver_utils, "get_solver", fake_get_solver)
+    monkeypatch.setattr(solver_utils, "solvers", fake_solvers)
+    yield
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(new_mode="constant_omega"),
+            does_not_raise(),
+            id="hkl_soleil E4CV constant_omega flushed on export",
+        ),
+        pytest.param(
+            dict(new_mode="constant_chi"),
+            does_not_raise(),
+            id="hkl_soleil E4CV constant_chi flushed on export",
+        ),
+        pytest.param(
+            dict(new_mode="constant_phi"),
+            does_not_raise(),
+            id="hkl_soleil E4CV constant_phi flushed on export",
+        ),
+    ],
+)
+def test_hkl_soleil_mode_flushed_on_export(parms, context):
+    """A bare ``core.mode = X`` is reflected by ``core.configuration``."""
+    pytest.importorskip("hkl")
+    with context:
+        sim = creator(solver="hkl_soleil", geometry="E4CV", name="e4cv_407")
+        # Sanity: the new mode differs from the default.
+        assert sim.core.mode != parms["new_mode"]
+
+        sim.core.mode = parms["new_mode"]
+        # No forward() / inverse() / update_solver() between the
+        # assignment and the snapshot.
+        cfg = sim.configuration
+
+        assert cfg["solver"]["mode"] == parms["new_mode"]
+        # And the cached Python-side mode also matches.
+        assert sim.core.mode == parms["new_mode"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(new_mode="beta"),
+            does_not_raise(),
+            id="standin solver mode beta flushed on export",
+        ),
+        pytest.param(
+            dict(new_mode="gamma"),
+            does_not_raise(),
+            id="standin solver mode gamma flushed on export",
+        ),
+    ],
+)
+def test_standin_solver_mode_flushed_on_export(parms, context, _patched_solvers):
+    """Solver-agnostic check: any ``_metadata`` that reads ``self.mode``."""
+    with context:
+        sim = creator(
+            name="standin407",
+            solver=_StandInSolver407.name,
+            geometry="STANDIN407",
+        )
+        assert sim.core.mode != parms["new_mode"]
+
+        sim.core.mode = parms["new_mode"]
+        cfg = sim.configuration
+
+        assert cfg["solver"]["mode"] == parms["new_mode"]
+        assert sim.core.solver.mode == parms["new_mode"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="clean bitfield: snapshot does not re-push to solver",
+        ),
+    ],
+)
+def test_clean_bitfield_skips_flush(parms, context, _patched_solvers, monkeypatch):
+    """The fast path must not invoke ``update_solver()`` when clean."""
+    with context:
+        sim = creator(
+            name="standin407_clean",
+            solver=_StandInSolver407.name,
+            geometry="STANDIN407",
+        )
+        # Force a clean state.
+        sim.core.update_solver()
+        assert not sim.core._solver_dirty
+
+        # Spy on update_solver: it must NOT be called by _asdict()
+        # when the bitfield is clean.
+        calls: list = []
+        real_update = sim.core.update_solver
+
+        def spy(*args, **kwargs):
+            calls.append((args, kwargs))
+            return real_update(*args, **kwargs)
+
+        monkeypatch.setattr(sim.core, "update_solver", spy)
+        _ = sim.configuration
+
+        assert calls == [], (
+            f"expected no update_solver() calls on clean snapshot, got {calls}"
+        )


### PR DESCRIPTION
- closes #407

## Summary

`Diffractometer.export()` / `core.configuration` saved a *stale* solver-side
mode when `core.mode` had been set but no `forward()` / `inverse()` /
`update_solver()` had run between the assignment and the export.  The
\`solver:\` block is sourced from \`self.solver._metadata\`, which reads live
solver state, and the dirty bitfield from #386 / #390 had not been flushed.

## Fix

\`Core._asdict()\` now calls \`self.update_solver()\` at the top, **gated on
the dirty bitfield** (\`if self._solver_dirty:\`).  The fast path is
unaffected when nothing has changed; when something is pending the
snapshot reflects the current intent before reading \`_metadata\`.

Using the existing bitfield as a conditional (rather than pushing
eagerly in \`Core.mode.setter\`) preserves the batching win from #386 /
#390 — solver pushes still occur exactly once per \`forward()\` /
\`inverse()\` / snapshot, not on every property assignment.

## Tests

\`src/hklpy2/tests/test_i407.py\`:

- \`test_hkl_soleil_mode_flushed_on_export\` — parametrized over three
  \`E4CV\` modes; verifies \`cfg[\"solver\"][\"mode\"]\` reflects the assignment
  without an intervening \`forward()\` / \`update_solver()\`.
- \`test_standin_solver_mode_flushed_on_export\` — solver-agnostic check
  using a \`SolverBase\`-style stand-in whose \`_metadata\` reads
  \`self.mode\` (the pattern out-of-tree solvers use; mirrors how
  \`HklSolver\` surfaces its mode).
- \`test_clean_bitfield_skips_flush\` — fast-path regression confirming
  the snapshot does *not* invoke \`update_solver()\` when the bitfield is
  clean.

All five bug-exposing parameter sets fail on \`main\` (confirmed by
stashing the fix and re-running) and pass after the fix.  Full suite:
\`1275 passed, 7 skipped\` in 213 s.

## Acceptance criteria (from #407)

- [x] Test asserts \`sim.core.mode = X; cfg = sim.configuration\` emits
      \`cfg[\"solver\"][\"mode\"] == X\` without an intervening
      \`update_solver()\` / \`forward()\` / \`inverse()\`.
- [x] Regression coverage for \`HklSolver\` *and* a solver whose
      \`_metadata\` reads \`self.mode\`.
- [x] No regression in \`simulator_from_config()\` round-trips.

## Notes

- \`@versionchanged\` for \`0.7.2\` stacked under the existing
  \`@versionchanged\` on \`Core._asdict()\`.
- \`RELEASE_NOTES.rst\` entry added under a new \`0.7.2\` section inside
  the \`.. comment\` block (per AGENTS.md).

Agent: OpenCode (claudeopus47)