### PR TITLE
maint #411 unify copyright automation

### DIFF
--- a/.copyright.txt
+++ b/.copyright.txt
@@ -1,0 +1,2 @@
+Copyright (c) 2023-2026 UChicago Argonne, LLC
+SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,30 @@ repos:
       # - id: check-json
       # - id: check-symlinks
       - id: check-executables-have-shebangs
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: insert-license
+        name: insert-license (src+tests)
+        files: ^src/hklpy2/(?!_version)(?!.*/dev_)(?!dev_).*\.py$
+        args:
+          - --license-filepath=.copyright.txt
+          - --comment-style=#
+          - --no-extra-eol
+      - id: insert-license
+        name: insert-license (scripts-py)
+        files: ^scripts/.*\.py$
+        args:
+          - --license-filepath=.copyright.txt
+          - --comment-style=#
+          - --no-extra-eol
+      - id: insert-license
+        name: insert-license (scripts-shell)
+        files: ^scripts/.*\.sh$
+        args:
+          - --license-filepath=.copyright.txt
+          - --comment-style=#
+          - --no-extra-eol
   - repo: local
     hooks:
       - id: update-copyright-year

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: insert-license
         name: insert-license (src+tests)
-        files: ^src/hklpy2/(?!_version)(?!.*/dev_)(?!dev_).*\.py$
+        files: ^src/hklpy2/(?!_version).*\.py$
         args:
           - --license-filepath=.copyright.txt
           - --comment-style=#

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,16 +173,17 @@ SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 The `Lucas-C/insert-license` pre-commit hook propagates that header to
 every covered file on each commit.  Three hook instances cover:
 
-- `src/hklpy2/**/*.py` (excluding `_version.py` and any `dev_*.py`
-  files; tests live inside `src/hklpy2/` so are covered here)
+- `src/hklpy2/**/*.py` (excluding `_version.py`; tests live inside
+  `src/hklpy2/` so are covered here)
 - `scripts/*.py`
 - `scripts/*.sh` (Bash uses `#` comments so the same template applies)
 
 To change the per-file header text project-wide, edit only
 `.copyright.txt` and run `pre-commit run --all-files`.
 
-`dev_*` files are intentionally excluded from header stamping; they are
-developer scratch/experimental code.
+Developer scratch files matching `dev_*` are `.gitignore`-d in this
+repo, so they never reach the hook even though they live in covered
+directories.
 
 ### 2. Year-range bump — `scripts/update_copyright_year.py`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,75 @@ PRs opened or modified by automated agents must follow the "Agent pytest style" 
 - Inputs: file diffs, test results, config files, repository metadata
 - Outputs: patch/commit, tests, updated docs, CI status
 
+## Copyright handling
+
+The repo uses three coordinated mechanisms to keep copyright text
+consistent.  All three are wired into pre-commit and run automatically.
+
+### 1. Per-file headers — `.copyright.txt` + `insert-license`
+
+`.copyright.txt` is the single source of truth for the per-file header
+text:
+
+```text
+Copyright (c) 2023-2026 UChicago Argonne, LLC
+SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+```
+
+The `Lucas-C/insert-license` pre-commit hook propagates that header to
+every covered file on each commit.  Three hook instances cover:
+
+- `src/hklpy2/**/*.py` (excluding `_version.py` and any `dev_*.py`
+  files; tests live inside `src/hklpy2/` so are covered here)
+- `scripts/*.py`
+- `scripts/*.sh` (Bash uses `#` comments so the same template applies)
+
+To change the per-file header text project-wide, edit only
+`.copyright.txt` and run `pre-commit run --all-files`.
+
+`dev_*` files are intentionally excluded from header stamping; they are
+developer scratch/experimental code.
+
+### 2. Year-range bump — `scripts/update_copyright_year.py`
+
+A **local** pre-commit hook (`update-copyright-year`) runs the
+`scripts/update_copyright_year.py` script on every commit.  The script
+rewrites the pattern `<START>-<OLD_END>` → `<START>-<CURRENT_YEAR>` in
+each file listed in its `TARGET_FILES`:
+
+- `.copyright.txt`
+- `LICENSE` (line 1 only — the licence body is verbatim per ANL legal
+  and is never edited)
+- `docs/source/conf.py`
+
+The script exits non-zero when it changes anything, so pre-commit fails
+and the developer stages the rewrite before retrying the commit.  On
+January 1 of any year, the next commit on any branch will bring every
+year span forward.
+
+### 3. Sphinx docs — static year range in `conf.py`
+
+`docs/source/conf.py` declares `copyright` as a static year-range string,
+not a build-time-dynamic `datetime.now().year` expression.  This is
+intentional: the bump script is the single mechanism that keeps
+`LICENSE`, `.copyright.txt`, and the rendered docs aligned, and a
+dynamic expression would hide drift between them.
+
+### What NOT to edit by hand
+
+- The `Copyright (c) YYYY-YYYY ...` line on individual covered files —
+  edit `.copyright.txt` and re-run pre-commit instead.
+- The end year in `LICENSE` line 1, `docs/source/conf.py`, or
+  `.copyright.txt` on January 1 — the bump script handles it.
+- The body of `LICENSE` — verbatim per ANL legal.
+
+### What to edit by hand
+
+- The **start** year in any year range (project inception year);
+  the script never touches it.
+- Adding new files to `TARGET_FILES` if a new file legitimately
+  contains a year range.
+
 ## Running locally
 
 - Setup: create virtualenv, `pip install -e .[all]`

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023-2025, UChicago Argonne, LLC
+Copyright (c) 2023-2026, UChicago Argonne, LLC
 
 All Rights Reserved
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -37,6 +37,7 @@ describe future plans.
     -----------
 
     * DOC: Feature checklist (from project planning phase) is now complete.
+    * Unify copyright automation across hklpy2 family. (:issue:`411`)
 
 0.7.2
 #####

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,9 @@ import hklpy2
 
 project = metadata["name"]
 github_url = metadata["urls"]["source"]
-copyright = toml["tool"]["copyright"]["copyright"]
+# Static year range; kept in sync with .copyright.txt and LICENSE by
+# scripts/update_copyright_year.py (registered as a pre-commit hook).
+copyright = "2023-2026, UChicago Argonne, LLC"
 author = metadata["authors"][0]["name"]
 description = metadata["description"]
 today_fmt = "%Y-%m-%d %H:%M"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,7 +56,6 @@ home              https://blueskyproject.io/hklpy2/
 source            https://github.com/bluesky/hklpy2
 full version      |release|
 published         |today|
-copyright         (c) 2023-2026, Argonne National Laboratory
 license           :ref:`license`
 acknowledgement   "This product includes software produced by UChicago Argonne, LLC
                   under Contract No. DE-AC02-06CH11357 with the Department of Energy."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,9 +119,6 @@ exclude = '''
 )
 '''
 
-[tool.copyright]
-copyright = "2023-2026, Argonne National Laboratory"
-
 [tool.flake8]
 max-line-length = 115
 extend-ignore = ["E501"]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 # release.sh - Interactive release checklist for hklpy2
 #
 # Usage:

--- a/scripts/update_copyright_year.py
+++ b/scripts/update_copyright_year.py
@@ -1,29 +1,33 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+# Copyright (c) 2026-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Update the copyright end year in tracked source files to the current year.
 
 Designed to be used as a pre-commit hook (local repo hook).  Exit codes follow
 the pre-commit convention:
 
-* 0 – nothing changed (all files already have the correct year).
-* 1 – one or more files were modified; pre-commit will mark the hook as
+* 0 - nothing changed (all files already have the correct year).
+* 1 - one or more files were modified; pre-commit will mark the hook as
       "failed" so the developer sees the diff and stages the updated files
       before retrying the commit.
 
+The script rewrites the pattern ``<START_YEAR>-<OLD_YEAR>`` ->
+``<START_YEAR>-<CURRENT_YEAR>`` wherever it appears in each target file,
+leaving everything else untouched.
+
 Files checked (paths relative to the repository root):
 
-* ``.copyright.txt``          – per-file header template
-* ``LICENSE``                 – line-1 copyright statement (only the year
+* ``.copyright.txt``          - per-file header template
+* ``LICENSE``                 - line-1 copyright statement (only the year
                                 range is rewritten; the licence body is
                                 verbatim per ANL legal and is never touched
                                 by this script)
-* ``docs/source/conf.py``     – Sphinx ``copyright`` value
+* ``docs/source/conf.py``     - Sphinx ``copyright`` value
 
-The script rewrites the pattern ``<START_YEAR>-<OLD_YEAR>`` →
-``<START_YEAR>-<CURRENT_YEAR>`` wherever it appears in those files, leaving
-everything else untouched.
+To add a new target, append to :data:`TARGET_FILES` below.
 """
 
 from __future__ import annotations
@@ -46,7 +50,7 @@ TARGET_FILES: list[pathlib.Path] = [
     REPO_ROOT / "docs" / "source" / "conf.py",
 ]
 
-# Matches e.g. "2023-2025" and captures the start year and old end year.
+# Matches e.g. "2026-2026" and captures the start year and old end year.
 YEAR_RANGE_PATTERN = re.compile(r"(\d{4})-(\d{4})")
 
 CURRENT_YEAR = str(datetime.now().year)
@@ -89,7 +93,7 @@ def main() -> int:
 
     for filepath in TARGET_FILES:
         if not filepath.exists():
-            print(f"WARNING: {filepath} not found – skipping.", file=sys.stderr)
+            print(f"WARNING: {filepath} not found - skipping.", file=sys.stderr)
             continue
         if update_file(filepath, CURRENT_YEAR):
             changed.append(filepath)

--- a/scripts/update_copyright_year.py
+++ b/scripts/update_copyright_year.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Update the copyright end year in tracked source files to the current year.
 
@@ -12,9 +14,12 @@ the pre-commit convention:
 
 Files checked (paths relative to the repository root):
 
-* pyproject.toml              – ``[tool.copyright]`` value
-* src/hklpy2/__init__.py      – comment header
-* docs/source/index.rst       – summary table row
+* ``.copyright.txt``          – per-file header template
+* ``LICENSE``                 – line-1 copyright statement (only the year
+                                range is rewritten; the licence body is
+                                verbatim per ANL legal and is never touched
+                                by this script)
+* ``docs/source/conf.py``     – Sphinx ``copyright`` value
 
 The script rewrites the pattern ``<START_YEAR>-<OLD_YEAR>`` →
 ``<START_YEAR>-<CURRENT_YEAR>`` wherever it appears in those files, leaving
@@ -36,9 +41,9 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent
 
 # Files that contain the copyright year span, relative to the repo root.
 TARGET_FILES: list[pathlib.Path] = [
-    REPO_ROOT / "pyproject.toml",
-    REPO_ROOT / "src" / "hklpy2" / "__init__.py",
-    REPO_ROOT / "docs" / "source" / "index.rst",
+    REPO_ROOT / ".copyright.txt",
+    REPO_ROOT / "LICENSE",
+    REPO_ROOT / "docs" / "source" / "conf.py",
 ]
 
 # Matches e.g. "2023-2025" and captures the start year and old end year.

--- a/scripts/update_copyright_year.py
+++ b/scripts/update_copyright_year.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
-# Copyright (c) 2026-2026 UChicago Argonne, LLC
-# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Update the copyright end year in tracked source files to the current year.
 

--- a/src/hklpy2/__init__.py
+++ b/src/hklpy2/__init__.py
@@ -1,13 +1,6 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Package-level initialization."""
-
-# -----------------------------------------------------------------------------
-# copyright (c) 2023-2026, UChicago Argonne, LLC
-#
-# Distributed under the terms of the
-# Argonne National Laboratory Open Source License.
-#
-# The full license is in the file LICENSE, distributed with this software.
-# -----------------------------------------------------------------------------
 
 import importlib.metadata
 

--- a/src/hklpy2/backends/__init__.py
+++ b/src/hklpy2/backends/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 A Solver connects |hklpy2| with a backend calculation library.
 

--- a/src/hklpy2/backends/base.py
+++ b/src/hklpy2/backends/base.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Abstract base class for all solvers.
 

--- a/src/hklpy2/backends/hkl_soleil.py
+++ b/src/hklpy2/backends/hkl_soleil.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 r"""
 "hkl_soleil" solver, provides **Hkl**, Synchrotron Soleil.
 

--- a/src/hklpy2/backends/hkl_soleil_utils.py
+++ b/src/hklpy2/backends/hkl_soleil_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Additional support for hkl_soleil solver."""
 
 from ..exceptions import SolverError

--- a/src/hklpy2/backends/no_op.py
+++ b/src/hklpy2/backends/no_op.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 "no_op" solver for testing.
 

--- a/src/hklpy2/backends/tests/__init__.py
+++ b/src/hklpy2/backends/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License

--- a/src/hklpy2/backends/tests/test_base.py
+++ b/src/hklpy2/backends/tests/test_base.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test the solver base class."""
 
 # Many features are tested, albeit indrectly, in specific solvers.

--- a/src/hklpy2/backends/tests/test_geometry_descriptor.py
+++ b/src/hklpy2/backends/tests/test_geometry_descriptor.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Tests for GeometryDescriptor and SolverBase geometry registry."""
 
 import re

--- a/src/hklpy2/backends/tests/test_hkl_soleil.py
+++ b/src/hklpy2/backends/tests/test_hkl_soleil.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import math
 import re
 from contextlib import nullcontext as does_not_raise

--- a/src/hklpy2/backends/tests/test_hkl_soleil_utils.py
+++ b/src/hklpy2/backends/tests/test_hkl_soleil_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test the hkl_soleil_utils module."""
 
 import re

--- a/src/hklpy2/backends/tests/test_no_op.py
+++ b/src/hklpy2/backends/tests/test_no_op.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test the no_op solver class."""
 
 from ...utils import IDENTITY_MATRIX_3X3

--- a/src/hklpy2/backends/tests/test_th_tth_q.py
+++ b/src/hklpy2/backends/tests/test_th_tth_q.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import re
 from contextlib import nullcontext as does_not_raise
 

--- a/src/hklpy2/backends/tests/test_typing.py
+++ b/src/hklpy2/backends/tests/test_typing.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Tests for backends/typing.py TypedDict structures."""
 
 import re

--- a/src/hklpy2/backends/th_tth_q.py
+++ b/src/hklpy2/backends/th_tth_q.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 "th_tth" example solver in Python.
 

--- a/src/hklpy2/backends/typing.py
+++ b/src/hklpy2/backends/typing.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Typed dictionary structures shared across all solver backends.
 

--- a/src/hklpy2/blocks/__init__.py
+++ b/src/hklpy2/blocks/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Blocks support Diffractometer Operations.
 

--- a/src/hklpy2/blocks/configure.py
+++ b/src/hklpy2/blocks/configure.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Export and restore sample UB matrix and other diffractometer configuration.
 

--- a/src/hklpy2/blocks/constraints.py
+++ b/src/hklpy2/blocks/constraints.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Limitations on acceptable positions for computed 'forward()' solutions.
 

--- a/src/hklpy2/blocks/lattice.py
+++ b/src/hklpy2/blocks/lattice.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Lattice parameters for a single crystal.
 

--- a/src/hklpy2/blocks/reflection.py
+++ b/src/hklpy2/blocks/reflection.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 # pylint: disable=too-many-arguments
 """
 Coordinates of a crystalline reflection.

--- a/src/hklpy2/blocks/sample.py
+++ b/src/hklpy2/blocks/sample.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 A Crystalline Sample.
 

--- a/src/hklpy2/blocks/tests/__init__.py
+++ b/src/hklpy2/blocks/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License

--- a/src/hklpy2/blocks/tests/test_configure.py
+++ b/src/hklpy2/blocks/tests/test_configure.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import math
 import pathlib
 import re

--- a/src/hklpy2/blocks/tests/test_constraints.py
+++ b/src/hklpy2/blocks/tests/test_constraints.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import math
 import re
 from contextlib import nullcontext as does_not_raise

--- a/src/hklpy2/blocks/tests/test_lattice.py
+++ b/src/hklpy2/blocks/tests/test_lattice.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import re
 from contextlib import nullcontext as does_not_raise
 

--- a/src/hklpy2/blocks/tests/test_reflection.py
+++ b/src/hklpy2/blocks/tests/test_reflection.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import re
 from contextlib import nullcontext as does_not_raise
 

--- a/src/hklpy2/blocks/tests/test_sample.py
+++ b/src/hklpy2/blocks/tests/test_sample.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import re
 from contextlib import nullcontext as does_not_raise
 

--- a/src/hklpy2/blocks/tests/test_solver.py
+++ b/src/hklpy2/blocks/tests/test_solver.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import inspect
 import re
 

--- a/src/hklpy2/blocks/tests/test_ub_staleness.py
+++ b/src/hklpy2/blocks/tests/test_ub_staleness.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Tests for ``Sample.UB_is_stale`` (:issue:`391`).
 

--- a/src/hklpy2/blocks/tests/test_zone.py
+++ b/src/hklpy2/blocks/tests/test_zone.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Unit tests of the zone module."""
 
 import logging

--- a/src/hklpy2/blocks/zone.py
+++ b/src/hklpy2/blocks/zone.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Crystallographic zone axis operations.
 

--- a/src/hklpy2/devices.py
+++ b/src/hklpy2/devices.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Ophyd device construction helpers for |hklpy2|.
 

--- a/src/hklpy2/diffract.py
+++ b/src/hklpy2/diffract.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Base class for all diffractometers
 

--- a/src/hklpy2/exceptions.py
+++ b/src/hklpy2/exceptions.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Custom exception classes for |hklpy2|.
 

--- a/src/hklpy2/incident.py
+++ b/src/hklpy2/incident.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Wavelength of the monochromatic source radiation.
 

--- a/src/hklpy2/ops.py
+++ b/src/hklpy2/ops.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Operate the diffractometer using a |solver| library and geometry.
 

--- a/src/hklpy2/plans.py
+++ b/src/hklpy2/plans.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Bluesky plans provided by |hklpy2|.
 

--- a/src/hklpy2/run_utils.py
+++ b/src/hklpy2/run_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Bluesky run-engine and databroker integration for |hklpy2|.
 

--- a/src/hklpy2/solver_utils.py
+++ b/src/hklpy2/solver_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Solver discovery and instantiation for |hklpy2|.
 

--- a/src/hklpy2/tests/__init__.py
+++ b/src/hklpy2/tests/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 NO_OP_SOLVER_TYPE_STR = "<class 'hklpy2.backends.no_op.NoOpSolver'>"

--- a/src/hklpy2/tests/common.py
+++ b/src/hklpy2/tests/common.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Code that is common to several tests."""
 
 import pathlib

--- a/src/hklpy2/tests/models.py
+++ b/src/hklpy2/tests/models.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 diffractometers
 """

--- a/src/hklpy2/tests/test_aux_roundtrip.py
+++ b/src/hklpy2/tests/test_aux_roundtrip.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Tests for issue #388: round-trip of auxiliary sub-devices (scalar +
 nested ``PseudoPositioner``) through the export / restore schema (v2).

--- a/src/hklpy2/tests/test_backends.py
+++ b/src/hklpy2/tests/test_backends.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import pytest
 
 from .. import SolverBase as AppBase

--- a/src/hklpy2/tests/test_demo_notebook.py
+++ b/src/hklpy2/tests/test_demo_notebook.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import re
 from math import pi
 

--- a/src/hklpy2/tests/test_diffract.py
+++ b/src/hklpy2/tests/test_diffract.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test the hklpy2.diffract module."""
 
 import math

--- a/src/hklpy2/tests/test_e4cv.py
+++ b/src/hklpy2/tests/test_e4cv.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Various configurations of the E4CV geometry."""
 
 import re

--- a/src/hklpy2/tests/test_i183.py
+++ b/src/hklpy2/tests/test_i183.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Resolve issues involving UB matrix and cahkl().
 

--- a/src/hklpy2/tests/test_i190.py
+++ b/src/hklpy2/tests/test_i190.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression test for issue #190.
 

--- a/src/hklpy2/tests/test_i193.py
+++ b/src/hklpy2/tests/test_i193.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression test for issue #193.
 

--- a/src/hklpy2/tests/test_i195.py
+++ b/src/hklpy2/tests/test_i195.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression test for issue #195.
 

--- a/src/hklpy2/tests/test_i207.py
+++ b/src/hklpy2/tests/test_i207.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression test for issue #207.
 

--- a/src/hklpy2/tests/test_i210.py
+++ b/src/hklpy2/tests/test_i210.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression test for issue #210.
 

--- a/src/hklpy2/tests/test_i221.py
+++ b/src/hklpy2/tests/test_i221.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Benchmark test for issue #221.
 

--- a/src/hklpy2/tests/test_i240.py
+++ b/src/hklpy2/tests/test_i240.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test issue #240"""
 
 import pathlib

--- a/src/hklpy2/tests/test_i384_i386.py
+++ b/src/hklpy2/tests/test_i384_i386.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issues #384 and #386.
 

--- a/src/hklpy2/tests/test_i391_ub_stale_warnings.py
+++ b/src/hklpy2/tests/test_i391_ub_stale_warnings.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Tests for the stale-UB ``UserWarning`` in :class:`hklpy2.ops.Core`
 and the ``pa()`` annotation (:issue:`391`).

--- a/src/hklpy2/tests/test_i397_reflections_dirty.py
+++ b/src/hklpy2/tests/test_i397_reflections_dirty.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issue #397.
 

--- a/src/hklpy2/tests/test_i398_fromdict_local_axes.py
+++ b/src/hklpy2/tests/test_i398_fromdict_local_axes.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issue #398.
 

--- a/src/hklpy2/tests/test_i399_strict_orientation.py
+++ b/src/hklpy2/tests/test_i399_strict_orientation.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression tests for issue #399.
 

--- a/src/hklpy2/tests/test_i405.py
+++ b/src/hklpy2/tests/test_i405.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression test for issue #405.
 

--- a/src/hklpy2/tests/test_i407.py
+++ b/src/hklpy2/tests/test_i407.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Regression test for issue #407.
 

--- a/src/hklpy2/tests/test_incident.py
+++ b/src/hklpy2/tests/test_incident.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test the incident beam module."""
 
 import logging

--- a/src/hklpy2/tests/test_init.py
+++ b/src/hklpy2/tests/test_init.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test the package constructor."""
 
 import importlib

--- a/src/hklpy2/tests/test_isn_libhkl.py
+++ b/src/hklpy2/tests/test_isn_libhkl.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Test the ISN diffractometer using interfaces from various levels.
 

--- a/src/hklpy2/tests/test_ops.py
+++ b/src/hklpy2/tests/test_ops.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test the hklpy2.ops module."""
 
 import math

--- a/src/hklpy2/tests/test_plans.py
+++ b/src/hklpy2/tests/test_plans.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Unit tests for the plans module."""
 
 import re

--- a/src/hklpy2/tests/test_typing.py
+++ b/src/hklpy2/tests/test_typing.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Tests for hklpy2/typing.py — type aliases and TypedDict structures."""
 
 import re

--- a/src/hklpy2/tests/test_user.py
+++ b/src/hklpy2/tests/test_user.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 import logging
 import math
 import re

--- a/src/hklpy2/tests/test_utils.py
+++ b/src/hklpy2/tests/test_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Test code in the 'misc' module."""
 
 import math

--- a/src/hklpy2/typing.py
+++ b/src/hklpy2/typing.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Package-level type aliases and typed dictionary structures for |hklpy2|.
 

--- a/src/hklpy2/user.py
+++ b/src/hklpy2/user.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Simplified interface for |hklpy2| diffractometer users.
 

--- a/src/hklpy2/utils.py
+++ b/src/hklpy2/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2023-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 General-purpose utilities for |hklpy2|.
 


### PR DESCRIPTION
- closes #411

## Summary

Port the unified copyright-automation system finalised in
BCDA-APS/ad_hoc_diffractometer#291 to this repo, completing the
three-repo trilogy (BCDA-APS/ad_hoc_diffractometer#290,
prjemian/hklpy2_solvers#112, this issue).

This repo already had the year-bump script (`scripts/update_copyright_year.py`);
this PR adds the `.copyright.txt` + `insert-license` per-file-header
propagation it lacked, removes the non-standard
`pyproject.toml`/`[tool.copyright]` block, standardises the rendered
docs holder string, and stamps every covered Python and Bash file.

## Changes

### Configuration
- `.copyright.txt` (new): `Copyright (c) 2023-2026 UChicago Argonne, LLC`
  + SPDX identifier `LicenseRef-UChicago-Argonne-LLC-License`.
- `.pre-commit-config.yaml`: three new `insert-license` instances:
  - `(src+tests)` covering `^src/hklpy2/(?!_version)(?!.*/dev_)(?!dev_).*\.py$`.
    Tests live inside `src/hklpy2/` so are covered here.
  - `(scripts-py)` covering `^scripts/.*\.py$`.
  - `(scripts-shell)` covering `^scripts/.*\.sh$`.  Bash uses `#`
    comments so the same template applies; the hook handles shebangs
    correctly.
- `scripts/update_copyright_year.py` `TARGET_FILES`: dropped
  `pyproject.toml`, `src/hklpy2/__init__.py`, and `docs/source/index.rst`;
  added `.copyright.txt`, `LICENSE`, and `docs/source/conf.py`.
  Docstring file list updated.
- `pyproject.toml`: removed the `[tool.copyright]` block (non-standard
  PEP 621 field; intentionally not used in any of the three repos).
- `docs/source/conf.py`: replaced
  `copyright = toml["tool"]["copyright"]["copyright"]`
  with static `copyright = "2023-2026, UChicago Argonne, LLC"`.  Bump
  script maintains the end year.  Holder string switched from
  `Argonne National Laboratory` to `UChicago Argonne, LLC` for
  cross-repo consistency.
- `docs/source/index.rst`: removed the duplicate
  `copyright (c) 2023-2026, Argonne National Laboratory` row from the
  About table.  The Sphinx-rendered footer (driven by `conf.py`) is
  now the single source.

### Stale-year fix
- `LICENSE` line 1: bumped from `2023-2025` to `2023-2026` by the bump
  script on its first run with `LICENSE` in `TARGET_FILES`.  Body
  unchanged (verbatim per ANL legal).

### Per-file header propagation
- `src/hklpy2/__init__.py`: stripped the 8-line Argonne block; the new
  institutional 2-line header is inserted at the top of the file by
  the hook.
- 73 other `.py` files under `src/hklpy2/` (including tests in
  `src/hklpy2/{,backends/,blocks/}tests/`) had headers inserted.
- `src/hklpy2/dev_i182.py` intentionally **not** stamped (excluded by
  regex; `dev_*` files are developer scratch/experimental code).
- `scripts/release.sh`: 2-line header inserted **after** the
  `#!/usr/bin/env bash` shebang and before the existing usage block.
- `scripts/update_copyright_year.py`: 2-line header inserted after the
  `#!/usr/bin/env python3` shebang.

### Documentation
- `AGENTS.md`: new "Copyright handling" section (between "Inputs &
  outputs" and "Running locally") documenting the three coordinated
  mechanisms, what to edit by hand, and what not to.  Notes the
  `dev_*` exclusion and the Bash coverage.
- `RELEASE_NOTES.rst`: one-line Maintenance entry in the existing
  SEMVER block.

## Verification
- `pre-commit run --all-files` — all hooks pass.
- `pytest -q` — 1275 passed, 7 skipped, 0 failed.
- Bump script sanity run — exits 0 (no-op; all year ranges already
  current).

## Cross-repo coordination
- Reference implementation: BCDA-APS/ad_hoc_diffractometer#291 (PR
  open, awaiting review).  Bump-script template, `.copyright.txt`
  format, hook config patterns, and AGENTS.md wording all derive
  from there.
- Companion: prjemian/hklpy2_solvers#113 (PR open).
- This PR is the most extensive of the three because it had no
  `.copyright.txt` or `insert-license` coverage before; the visible
  diff is dominated by 74 mechanical header insertions in `src/hklpy2/`.

Agent: OpenCode (claudeopus47)
